### PR TITLE
Add metered network for update

### DIFF
--- a/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
+++ b/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
@@ -30,6 +30,8 @@ namespace CollapseLauncher
 
         public static async void StartCheckUpdate(bool forceUpdate)
         {
+
+            bool notMetered = Windows.Networking.Connectivity.NetworkInformation.GetInternetConnectionProfile().GetConnectionCost().NetworkCostType == Windows.Networking.Connectivity.NetworkCostType.Unrestricted;
             UpdateChannelName = IsPreview ? "preview" : "stable";
             while (true)
             {
@@ -46,16 +48,19 @@ namespace CollapseLauncher
                             isUpdateCooldownActive = true;
                             using (Updater updater = new Updater(UpdateChannelName))
                             {
+
                                 UpdateInfo info = await updater.StartCheck();
                                 GameVersion RemoteVersion = new GameVersion(info.FutureReleaseEntry.Version.Version);
 
                                 AppUpdateVersionProp miscMetadata = await GetUpdateMetadata();
                                 UpdateProperty = new AppUpdateVersionProp { ver = RemoteVersion.VersionString, time = miscMetadata.time };
-
-                                if (CompareVersion(AppCurrentVersion, RemoteVersion))
-                                    GetStatus(new LauncherUpdateProperty { IsUpdateAvailable = true, NewVersionName = RemoteVersion });
-                                else
-                                    GetStatus(new LauncherUpdateProperty { IsUpdateAvailable = false, NewVersionName = RemoteVersion });
+                                if (notMetered || forceUpdate)
+                                {
+                                    if (CompareVersion(AppCurrentVersion, RemoteVersion))
+                                        GetStatus(new LauncherUpdateProperty { IsUpdateAvailable = true, NewVersionName = RemoteVersion });
+                                    else
+                                        GetStatus(new LauncherUpdateProperty { IsUpdateAvailable = false, NewVersionName = RemoteVersion });
+                                }
                             }
                             ForceInvokeUpdate = false;
                         }

--- a/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
+++ b/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Squirrel;
+using Windows.Networking.Connectivity;
 using static CollapseLauncher.InnerLauncherConfig;
 using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
@@ -27,11 +28,14 @@ namespace CollapseLauncher
         private static LauncherUpdateInvoker invoker = new LauncherUpdateInvoker();
         public static void GetStatus(LauncherUpdateProperty e) => invoker.GetStatus(e);
         public static bool isUpdateCooldownActive;
+        public static bool notMetered;
 
         public static async void StartCheckUpdate(bool forceUpdate)
         {
+            NetworkCostType currentNetCostType = NetworkInformation.GetInternetConnectionProfile()?.GetConnectionCost().NetworkCostType ?? NetworkCostType.Fixed;
+            if (currentNetCostType == NetworkCostType.Unrestricted || currentNetCostType == NetworkCostType.Unknown)
+                notMetered = true;
 
-            bool notMetered = Windows.Networking.Connectivity.NetworkInformation.GetInternetConnectionProfile().GetConnectionCost().NetworkCostType == Windows.Networking.Connectivity.NetworkCostType.Unrestricted;
             UpdateChannelName = IsPreview ? "preview" : "stable";
             while (true)
             {
@@ -45,24 +49,29 @@ namespace CollapseLauncher
                         // Stopping auto update when it was recently called. Workaround for update being called twice on metadata update.
                         if (!isUpdateCooldownActive)
                         {
-                            isUpdateCooldownActive = true;
-                            using (Updater updater = new Updater(UpdateChannelName))
+                            if (notMetered || forceUpdate)
                             {
-
-                                UpdateInfo info = await updater.StartCheck();
-                                GameVersion RemoteVersion = new GameVersion(info.FutureReleaseEntry.Version.Version);
-
-                                AppUpdateVersionProp miscMetadata = await GetUpdateMetadata();
-                                UpdateProperty = new AppUpdateVersionProp { ver = RemoteVersion.VersionString, time = miscMetadata.time };
-                                if (notMetered || forceUpdate)
+                                isUpdateCooldownActive = true;
+                                using (Updater updater = new Updater(UpdateChannelName))
                                 {
+                                    UpdateInfo info = await updater.StartCheck();
+                                    GameVersion RemoteVersion = new GameVersion(info.FutureReleaseEntry.Version.Version);
+
+                                    AppUpdateVersionProp miscMetadata = await GetUpdateMetadata();
+                                    UpdateProperty = new AppUpdateVersionProp { ver = RemoteVersion.VersionString, time = miscMetadata.time };
+
                                     if (CompareVersion(AppCurrentVersion, RemoteVersion))
                                         GetStatus(new LauncherUpdateProperty { IsUpdateAvailable = true, NewVersionName = RemoteVersion });
                                     else
                                         GetStatus(new LauncherUpdateProperty { IsUpdateAvailable = false, NewVersionName = RemoteVersion });
                                 }
+                                ForceInvokeUpdate = false;
                             }
-                            ForceInvokeUpdate = false;
+                            else
+                            {
+                                LogWriteLine($"Current network state is metered or disconnected! Auto update is skipped.\r\n\tPlease check your connection or use `Check for Update` button in Settings menu to update.", LogType.Warning, true);
+                            }
+                            isUpdateCooldownActive = true;
                         }
                         else LogWriteLine("Update was recently invoked! Stopping auto update until it resets in 15 minutes", LogType.Error, true);
                     }

--- a/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
+++ b/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
@@ -28,13 +28,12 @@ namespace CollapseLauncher
         private static LauncherUpdateInvoker invoker = new LauncherUpdateInvoker();
         public static void GetStatus(LauncherUpdateProperty e) => invoker.GetStatus(e);
         public static bool isUpdateCooldownActive;
-        public static bool isMetered;
+        public static bool isMetered = true;
 
         public static async void StartCheckUpdate(bool forceUpdate)
         {
             NetworkCostType currentNetCostType = NetworkInformation.GetInternetConnectionProfile()?.GetConnectionCost().NetworkCostType ?? NetworkCostType.Fixed;
-            if (currentNetCostType == NetworkCostType.Unrestricted || currentNetCostType == NetworkCostType.Unknown)
-                isMetered = false;
+            isMetered = !(currentNetCostType == NetworkCostType.Unrestricted || currentNetCostType == NetworkCostType.Unknown);
 
             UpdateChannelName = IsPreview ? "preview" : "stable";
             while (true)

--- a/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
+++ b/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
@@ -28,13 +28,13 @@ namespace CollapseLauncher
         private static LauncherUpdateInvoker invoker = new LauncherUpdateInvoker();
         public static void GetStatus(LauncherUpdateProperty e) => invoker.GetStatus(e);
         public static bool isUpdateCooldownActive;
-        public static bool notMetered;
+        public static bool isMetered;
 
         public static async void StartCheckUpdate(bool forceUpdate)
         {
             NetworkCostType currentNetCostType = NetworkInformation.GetInternetConnectionProfile()?.GetConnectionCost().NetworkCostType ?? NetworkCostType.Fixed;
             if (currentNetCostType == NetworkCostType.Unrestricted || currentNetCostType == NetworkCostType.Unknown)
-                notMetered = true;
+                isMetered = false;
 
             UpdateChannelName = IsPreview ? "preview" : "stable";
             while (true)
@@ -49,7 +49,7 @@ namespace CollapseLauncher
                         // Stopping auto update when it was recently called. Workaround for update being called twice on metadata update.
                         if (!isUpdateCooldownActive)
                         {
-                            if (notMetered || forceUpdate)
+                            if (!isMetered || forceUpdate)
                             {
                                 isUpdateCooldownActive = true;
                                 using (Updater updater = new Updater(UpdateChannelName))

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -491,6 +491,23 @@ namespace CollapseLauncher.Dialogs
             );
         }
 
+        public static async Task<ContentDialogResult> Dialog_MeteredConnectionWarning(UIElement Content)
+        {
+            TextBlock texts = new TextBlock { TextWrapping = TextWrapping.Wrap };
+            texts.Inlines.Add(new Run { Text = Lang._Dialogs.MeteredConnectionWarningSubtitle });
+
+            return await SpawnDialog(
+                        Lang._Dialogs.MeteredConnectionWarningTitle,
+                        texts,
+                        Content,
+                        Lang._Misc.NoCancel,
+                        Lang._Misc.Yes,
+                        null,
+                        ContentDialogButton.Primary,
+                        ContentDialogTheme.Warning
+                );   
+        }
+
         public static async Task<ContentDialogResult> SpawnDialog(
             string title, object content, UIElement Content,
             string closeText = null, string primaryText = null,

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -23,7 +23,6 @@ using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 using static CollapseLauncher.Dialogs.SimpleDialogs;
-using System.Data;
 
 namespace CollapseLauncher.Pages
 {

--- a/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
@@ -94,6 +94,8 @@
                 public string LocateExePathSubtitle { get; set; } = LangFallback?._Dialogs.LocateExePathSubtitle;
                 public string StopGameTitle { get; set; } = LangFallback?._Dialogs.StopGameTitle;
                 public string StopGameSubtitle { get; set; } = LangFallback?._Dialogs.StopGameSubtitle;
+                public string MeteredConnectionWarningTitle { get; set; } = LangFallback?._Dialogs.MeteredConnectionWarningTitle;
+                public string MeteredConnectionWarningSubtitle { get; set; } = LangFallback?._Dialogs.MeteredConnectionWarningSubtitle;
             }
         }
         #endregion

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -589,7 +589,7 @@
     "StopGameTitle": "Force Stop Game",
     "StopGameSubtitle": "Are you sure you want to force stop current running game?\r\nYou may lose some in-game progress.",
     "MeteredConnectionWarningTitle": "Metered Connection Detected!",
-    "MeteredConnectionWarningSubtitle": "Your current internet connection is stated as Metered! Continuing the action may result in additional charges. Are you sure?"
+    "MeteredConnectionWarningSubtitle": "Your current internet connection was detected as being 'Metered'! Continuing the update process may incur additional charges from your internet provider. Do you wish to proceed?"
   },
 
   "_InstallMgmt": {

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -587,7 +587,9 @@
     "CannotUseAppLocationForGameDirTitle": "Folder is invalid!",
     "CannotUseAppLocationForGameDirSubtitle": "You can't use this folder as it is being used as a system folder or being used for main executable of the app. Please choose another folder!",
     "StopGameTitle": "Force Stop Game",
-    "StopGameSubtitle": "Are you sure you want to force stop current running game?\r\nYou may lose some in-game progress."
+    "StopGameSubtitle": "Are you sure you want to force stop current running game?\r\nYou may lose some in-game progress.",
+    "MeteredConnectionWarningTitle": "Metered Connection Detected!",
+    "MeteredConnectionWarningSubtitle": "Your current internet connection is stated as Metered! Continuing the action may result in additional charges. Are you sure?"
   },
 
   "_InstallMgmt": {

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -588,6 +588,8 @@
     "CannotUseAppLocationForGameDirSubtitle": "您无法使用此文件夹，因为它已被用作系统文件夹或被用于存放应用程序的主执行文件。请选择其他文件夹！",
     "StopGameTitle": "强制停止游戏",
     "StopGameSubtitle": "您确定要强制中止当前正在运行的游戏吗？\n您的游戏进度可能会丢失。"
+    "MeteredConnectionWarningTitle": "检测到按流量计费的连接！",
+    "MeteredConnectionWarningSubtitle": "您当前的互联网连接按流量计费！继续该操作可能会产生额外费用。您确定吗？"
   },
 
   "_InstallMgmt": {


### PR DESCRIPTION
[![Build-Canary](https://github.com/CollapseLauncher/Collapse/actions/workflows/build.yml/badge.svg?branch=metered-network)](https://github.com/CollapseLauncher/Collapse/actions/workflows/build.yml)
#286 

Behavior:
- On automated update check (every 15 minutes), skip the check if network is unavailable or set as metered.
- On forced update check (pressing Check for Update button in Settings page), shows warning dialog when metered connection is detected.

