### PR TITLE
Load Genshin graphics settings from ``globalPerfData``

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/Enums/Enums.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/Enums/Enums.cs
@@ -7,132 +7,139 @@ namespace CollapseLauncher.GameSettings.Genshin.Enums
         // HoYoooooooo :wogreeee:
         internal static Dictionary<double, int> RenderResolutionOption = new Dictionary<double, int>
         {
-            { 0.6d, 1 },
-            { 0.8d, 2 },
-            { 0.9d, 9 },
-            { 1.0d, 3 },
-            { 1.1d, 4 },
-            { 1.2d, 5 },
-            { 1.3d, 6 },
-            { 1.4d, 7 },
-            { 1.5d, 8 }
+            { 0.6d, 0 },
+            { 0.8d, 1 },
+            { 0.9d, 8 },
+            { 1.0d, 2 },
+            { 1.1d, 3 },
+            { 1.2d, 4 },
+            { 1.3d, 5 },
+            { 1.4d, 6 },
+            { 1.5d, 7 }
         };
     }
 
     enum FPSOption : int
     {
-        f30 = 1,
-        f60 = 2,
-        f45 = 3
+        f30,
+        f60,
+        f45
     }
 
     enum ShadowQualityOption
     {
-        Lowest = 1,
-        Low = 2,
-        Medium = 3,
-        High = 4
+        Lowest,
+        Low,
+        Medium,
+        High
     }
 
     enum VisualEffectsOption
     {
-        Lowest = 1,
-        Low = 2,
-        Medium = 3,
-        High = 4
+        Lowest,
+        Low,
+        Medium,
+        High
     }
 
     enum SFXQualityOption
     {
-        Lowest = 1,
-        Low = 2,
-        Medium = 3,
-        High = 4
+        Lowest,
+        Low,
+        Medium,
+        High
     }
 
     enum EnvironmentDetailOption
     {
-        Lowest = 1,
-        Low = 2,
-        Medium = 3,
-        High = 4,
-        Highest = 5
+        Lowest,
+        Low,
+        Medium,
+        High,
+        Highest
     }
 
     enum VerticalSyncOption
     {
-        Off = 1,
-        On = 2
+        Off,
+        On
     }
 
     enum AntialiasingOption
     {
-        Off = 1,
-        FSR2 = 2,
-        SMAA = 3
+        Off,
+        FSR2,
+        SMAA
     }
 
     enum VolumetricFogOption
     {
-        Off = 1,
-        On = 2
+        Off,
+        On
     }
 
     enum ReflectionsOption
     {
-        Off = 1,
-        On = 2
+        Off,
+        On
     }
 
     enum MotionBlurOption
     {
-        Off = 1,
-        Low = 2,
-        High = 3,
-        Extreme = 4
+        Off,
+        Low,
+        High,
+        Extreme
     }
 
     enum BloomOption
     {
-        Off = 1,
-        On = 2
+        Off,
+        On
     }
 
     enum CrowdDensityOption
     {
-        Low = 1,
-        High = 2
+        Low,
+        High
     }
 
     enum SubsurfaceScatteringOption
     {
-        Off = 1,
-        Medium = 2,
-        High = 3
+        Off,
+        Medium,
+        High
     }
 
     enum CoOpTeammateEffectsOption
     {
-        Off = 1,
-        PartiallyOff = 2,
-        On = 3
+        Off,
+        PartiallyOff,
+        On
     }
 
     enum AnisotropicFilteringOption
     {
-        x1 = 1,
-        x2 = 2,
-        x4 = 3,
-        x8 = 4,
-        x16 = 5
+        x1,
+        x2,
+        x4,
+        x8,
+        x16
+    }
+
+    enum GraphicsQualityOption
+    {
+        Lowest,
+        Low,
+        Medium,
+        High
     }
 
     enum GlobalIlluminationOption
     {
-        Off = 1,
-        Medium = 2,
-        High = 3,
-        Extreme = 4
+        Off,
+        Medium,
+        High,
+        Extreme
     }
 }
-

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -320,36 +320,29 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                object value = RegistryRoot.GetValue(_ValueName) ?? throw new ArgumentNullException($"Cannot find registry key {_ValueName}");
 
-                if (value != null)
-                {
-                    ReadOnlySpan<byte> byteStr = (byte[])value;
+                ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DUMPGIJSON
-                    // Dump GeneralData as raw string
-                    LogWriteLine($"RAW Genshin Settings: {_ValueName}\r\n" +
-                        $"{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
+                // Dump GeneralData as raw string
+                LogWriteLine($"RAW Genshin Settings: {_ValueName}\r\n" +
+                             $"{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
 
-                    // Dump GeneralData as indented JSON output using GeneralData properties
-                    LogWriteLine($"Deserialized Genshin Settings: {_ValueName}\r\n{byteStr
-                        .Deserialize<GeneralData>(GenshinSettingsJSONContext.Default)
-                        .Serialize(GenshinSettingsJSONContext.Default, false, true)}", LogType.Debug, true);
+                // Dump GeneralData as indented JSON output using GeneralData properties
+                LogWriteLine($"Deserialized Genshin Settings: {_ValueName}\r\n{byteStr
+                    .Deserialize<GeneralData>(GenshinSettingsJSONContext.Default)
+                    .Serialize(GenshinSettingsJSONContext.Default, false, true)}", LogType.Debug, true);
 #endif
 #if DEBUG
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
+                LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
 #else
-                    LogWriteLine($"Loaded Genshin Settings", LogType.Default, true);
+                LogWriteLine($"Loaded Genshin Settings", LogType.Default, true);
 #endif
-                    GeneralData data = byteStr.Deserialize<GeneralData>(GenshinSettingsJSONContext.Default) ?? new GeneralData();
-                    data.graphicsData = GraphicsData.Load(data._graphicsData);
-                    data.globalPerfData = GlobalPerfData.Load(data._globalPerfData, data.graphicsData);
-                    return data;
-                }
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-                GlobalPerfData.Load(null, null);
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-                return new GeneralData();
+                GeneralData data = byteStr.Deserialize<GeneralData>(GenshinSettingsJSONContext.Default) ?? new GeneralData();
+                data.graphicsData = GraphicsData.Load(data._graphicsData);
+                data.globalPerfData = GlobalPerfData.Load(data._globalPerfData, data.graphicsData);
+                return data;
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -343,11 +343,11 @@ namespace CollapseLauncher.GameSettings.Genshin
 #endif
                     GeneralData data = byteStr.Deserialize<GeneralData>(GenshinSettingsJSONContext.Default) ?? new GeneralData();
                     data.graphicsData = GraphicsData.Load(data._graphicsData);
-                    data.globalPerfData = new();
+                    data.globalPerfData = GlobalPerfData.Load(data._globalPerfData, data.graphicsData);
                     return data;
                 }
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-                GraphicsData.Load(null);
+                GlobalPerfData.Load(null, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
                 return new GeneralData();
             }
@@ -372,8 +372,8 @@ namespace CollapseLauncher.GameSettings.Genshin
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
 
-                _graphicsData = graphicsData.Save();
-                _globalPerfData = globalPerfData.Create(graphicsData, graphicsData.volatileVersion);
+                _graphicsData = graphicsData.Create(globalPerfData);
+                _globalPerfData = globalPerfData.Save();
 
                 string data = this.Serialize(GenshinSettingsJSONContext.Default);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
@@ -1,5 +1,9 @@
 using CollapseLauncher.GameSettings.Genshin.Context;
+using CollapseLauncher.GameSettings.Genshin.Enums;
+using Hi3Helper;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using static Hi3Helper.Logger;
 
 namespace CollapseLauncher.GameSettings.Genshin
@@ -40,39 +44,435 @@ namespace CollapseLauncher.GameSettings.Genshin
 
     internal class GlobalPerfData
     {
+        #region Fields
+        private static GlobalPerfData _LowestPreset = new()
+        {
+            FPS = FPSOption.f30,
+            RenderResolution = 1,
+            ShadowQuality = ShadowQualityOption.Lowest,
+            VisualEffects = VisualEffectsOption.Lowest,
+            SFXQuality = SFXQualityOption.Lowest,
+            EnvironmentDetail = EnvironmentDetailOption.Lowest,
+            VerticalSync = VerticalSyncOption.On,
+            Antialiasing = AntialiasingOption.Off,
+            VolumetricFog = VolumetricFogOption.Off,
+            Reflections = ReflectionsOption.Off,
+            MotionBlur = MotionBlurOption.Off,
+            Bloom = BloomOption.On,
+            CrowdDensity = CrowdDensityOption.High,
+            SubsurfaceScattering = SubsurfaceScatteringOption.Off,
+            CoOpTeammateEffects = CoOpTeammateEffectsOption.On,
+            AnisotropicFiltering = AnisotropicFilteringOption.x1,
+            GraphicsQuality = GraphicsQualityOption.Lowest,
+            GlobalIllumination = GlobalIlluminationOption.Off,
+        };
+
+        private static GlobalPerfData _LowPreset = new()
+        {
+            FPS = FPSOption.f30,
+            RenderResolution = 8,
+            ShadowQuality = ShadowQualityOption.Low,
+            VisualEffects = VisualEffectsOption.Low,
+            SFXQuality = SFXQualityOption.Low,
+            EnvironmentDetail = EnvironmentDetailOption.Low,
+            VerticalSync = VerticalSyncOption.On,
+            Antialiasing = AntialiasingOption.FSR2,
+            VolumetricFog = VolumetricFogOption.Off,
+            Reflections = ReflectionsOption.Off,
+            MotionBlur = MotionBlurOption.Off,
+            Bloom = BloomOption.On,
+            CrowdDensity = CrowdDensityOption.High,
+            SubsurfaceScattering = SubsurfaceScatteringOption.Medium,
+            CoOpTeammateEffects = CoOpTeammateEffectsOption.On,
+            AnisotropicFiltering = AnisotropicFilteringOption.x2,
+            GraphicsQuality = GraphicsQualityOption.Low,
+            GlobalIllumination = GlobalIlluminationOption.Off,
+        };
+
+        private static GlobalPerfData _MediumPreset = new()
+        {
+            FPS = FPSOption.f60,
+            RenderResolution = 8,
+            ShadowQuality = ShadowQualityOption.Medium,
+            VisualEffects = VisualEffectsOption.Medium,
+            SFXQuality = SFXQualityOption.Medium,
+            EnvironmentDetail = EnvironmentDetailOption.Medium,
+            VerticalSync = VerticalSyncOption.On,
+            Antialiasing = AntialiasingOption.FSR2,
+            VolumetricFog = VolumetricFogOption.Off,
+            Reflections = ReflectionsOption.Off,
+            MotionBlur = MotionBlurOption.High,
+            Bloom = BloomOption.On,
+            CrowdDensity = CrowdDensityOption.High,
+            SubsurfaceScattering = SubsurfaceScatteringOption.Medium,
+            CoOpTeammateEffects = CoOpTeammateEffectsOption.On,
+            AnisotropicFiltering = AnisotropicFilteringOption.x4,
+            GraphicsQuality = GraphicsQualityOption.Medium,
+            GlobalIllumination = GlobalIlluminationOption.Medium,
+        };
+        #endregion
+
         #region Properties
+        // Generate the list of the FPSOption value and order by ascending it.
+        public static readonly FPSOption[] FPSOptionsList = Enum.GetValues<FPSOption>().OrderBy(GetFPSOptionNumber).ToArray();
+        // Generate the list of the FPS number to be displayed on FPS Combobox
+        public static readonly int[] FPSIndex = FPSOptionsList.Select(GetFPSOptionNumber).ToArray();
+
+        private static int GetFPSOptionNumber(FPSOption value)
+        {
+            // Get the string of the number by trimming the 'f' letter at the beginning
+            string fpsStrNum = value.ToString().TrimStart('f');
+            // Try parse the fpsStrNum as a number
+            _ = int.TryParse(fpsStrNum, out int number);
+            // Return the number
+            return number;
+        }
+
+        public static readonly string[] RenderScaleValuesStr = DictionaryCategory.RenderResolutionOption.Keys.Select(x => x.ToString("0.0")).ToArray();
+        public static readonly List<double> RenderScaleValues = DictionaryCategory.RenderResolutionOption.Keys.ToList();
+        public static readonly List<int> RenderScaleIndex = DictionaryCategory.RenderResolutionOption.Values.ToList();
+
         public List<PerfDataItem> saveItems { get; set; } = new();
         public bool truePortedFromGraphicData { get; set; } = true;
-        public string portedVersion { get; set; } = "OSRELWin3.8.0";
+        public string portedVersion { get; set; } = "OSRELWin4.1.0";
         public bool portedFromGraphicsData { get; set; } = false;
         #endregion
 
+        #region Settings
+        /// <summary>
+        /// This defines "<c>FPS</c>" combobox In-game settings. <br/>
+        /// Options: 30, 60, 45 <br/>
+        /// Default: 60 [0]
+        /// </summary>
+        public FPSOption FPS = FPSOption.f60;
+
+        /// <summary>
+        /// This defines "<c>Render Resolution</c>" combobox In-game settings. <br/>
+        /// Options: 0.6 [0], 0.8 [1], 0.9 [8], 1.0 [2], 1.1 [3], 1.2 [4], 1.3 [5], 1.4 [6], 1.5 [7]<br/>
+        /// Default: 1.0 [2]
+        /// </summary>
+        public int RenderResolution = 2;
+
+        /// <summary>
+        /// This defines "<c>Shadow Quality</c>" combobox In-game settings. <br/>
+        /// Options: Lowest, Low, Medium, High <br/>
+        /// Default: High [3]
+        /// </summary>
+        public ShadowQualityOption ShadowQuality = ShadowQualityOption.High;
+
+        /// <summary>
+        /// This defines "<c>Visual Effects</c>" combobox In-game settings. <br/>
+        /// Options: Lowest, Low, Medium, High <br/>
+        /// Default: High [3]
+        /// </summary>
+        public VisualEffectsOption VisualEffects = VisualEffectsOption.High;
+
+        /// <summary>
+        /// This defines "<c>SFX Quality</c>" combobox In-game settings. <br/>
+        /// Options: Lowest, Low, Medium, High <br/>
+        /// Default: High [3]
+        /// </summary>
+        public SFXQualityOption SFXQuality = SFXQualityOption.High;
+
+        /// <summary>
+        /// This defines "<c>Environment Detail</c>" combobox In-game settings. <br/>
+        /// Options: Lowest, Low, Medium, High, Highest <br/>
+        /// Default: High [3]
+        /// </summary>
+        public EnvironmentDetailOption EnvironmentDetail = EnvironmentDetailOption.High;
+
+        /// <summary>
+        /// This defines "<c>Vertical Sync</c>" combobox In-game settings. <br/>
+        /// Options: Off, On <br/>
+        /// Default: On [1]
+        /// </summary>
+        public VerticalSyncOption VerticalSync = VerticalSyncOption.On;
+
+        /// <summary>
+        /// This defines "<c>Antialiasing</c>" combobox In-game settings. <br/>
+        /// Options: Off, FSR 2, SMAA <br/>
+        /// Default: FSR 2 [1]
+        /// </summary>
+        public AntialiasingOption Antialiasing = AntialiasingOption.FSR2;
+
+        /// <summary>
+        /// This defines "<c>Volumetric Fog</c>" combobox In-game settings. <br/>
+        /// Options: Off, On <br/>
+        /// Default: On [1]
+        /// Game prohibits enabling this if "<c>Shadow Quality</c>" on Low or Lowest
+        /// </summary>
+        public VolumetricFogOption VolumetricFog = VolumetricFogOption.On;
+
+        /// <summary>
+        /// This defines "<c>Reflections</c>" combobox In-game settings. <br/>
+        /// Options: Off, On <br/>
+        /// Default: On [1]
+        /// </summary>
+        public ReflectionsOption Reflections = ReflectionsOption.On;
+
+        /// <summary>
+        /// This defines "<c>Motion Blur</c>" combobox In-game settings. <br/>
+        /// Options: Off, Low, High, Extreme <br/>
+        /// Default: Extreme [3]
+        /// </summary>
+        public MotionBlurOption MotionBlur = MotionBlurOption.Extreme;
+
+        /// <summary>
+        /// This defines "<c>Bloom</c>" combobox In-game settings. <br/>
+        /// Options: Off, On <br/>
+        /// Default: On [1]
+        /// </summary>
+        public BloomOption Bloom = BloomOption.On;
+
+        /// <summary>
+        /// This defines "<c>Crowd Density</c>" combobox In-game settings. <br/>
+        /// Options: Low, High <br/>
+        /// Default: High [1]
+        /// </summary>
+        public CrowdDensityOption CrowdDensity = CrowdDensityOption.High;
+
+        /// <summary>
+        /// This defines "<c>Subsurface Scattering</c>" combobox In-game settings. <br/>
+        /// Options: Off, Medium, High <br/>
+        /// Default: High [2]
+        /// </summary>
+        public SubsurfaceScatteringOption SubsurfaceScattering = SubsurfaceScatteringOption.High;
+
+        /// <summary>
+        /// This defines "<c>Co-Op Teammate Effects</c>" combobox In-game settings. <br/>
+        /// Options: Off, Partially Off, On <br/>
+        /// Default: On [2]
+        /// </summary>
+        public CoOpTeammateEffectsOption CoOpTeammateEffects = CoOpTeammateEffectsOption.On;
+
+        /// <summary>
+        /// This defines "<c>Anisotropic Filtering</c>" combobox In-game settings. <br/>
+        /// Options: 1x, 2x, 4x, 8x, 16x <br/>
+        /// Default: 8x [3]
+        /// </summary>
+        public AnisotropicFilteringOption AnisotropicFiltering = AnisotropicFilteringOption.x8;
+
+        /// <summary>
+        /// This defines "<c>Graphics Quality</c>" combobox In-game settings. <br/>
+        /// Options: Lowest, Low, Medium, High <br/>
+        /// Default: High [3]
+        /// </summary>
+        public GraphicsQualityOption GraphicsQuality = GraphicsQualityOption.High;
+
+        /// <summary>
+        /// This defines "<c>Global Illumination</c>" combobox In-game settings. <br/>
+        /// Options: Off, Medium, High, Extreme
+        /// Default: High [2]  <br/>
+        /// Notes: Only work for PC who meet the specs for Global Illumination, specified by HYV  <br/>
+        /// Further information: https://genshin.hoyoverse.com/en/news/detail/112690#:~:text=Minimum%20Specifications%20for%20Global%20Illumination
+        /// </summary>
+        public GlobalIlluminationOption GlobalIllumination = GlobalIlluminationOption.High;
+        #endregion
+
         #region Methods
-        public string Create(GraphicsData graphics, string version)
+        public static GlobalPerfData Load(string globalPerfJson, GraphicsData graphics)
+        {
+            GlobalPerfData tempData;
+            // No GlobalPerfData object, import from GraphicsData
+            // currentVolatielGrade => saveItems entryType 18
+            // customVolatileGrades => saveItems
+            // volatileVersion => portedVersion
+            if (globalPerfJson == null && graphics != null)
+            {
+                tempData = new GlobalPerfData();
+                var version = graphics.volatileVersion;
+                tempData.portedVersion = version;
+                tempData.saveItems.Add(new(18, graphics.currentVolatielGrade - 1, version));
+                if (graphics.currentVolatielGrade == -1)
+                {
+                    foreach (var setting in graphics.customVolatileGrades)
+                    { 
+                        tempData.saveItems.Add(new(setting.key, setting.value - 1, version));
+                    }
+                }
+            }
+            else
+            {
+                tempData = globalPerfJson.Deserialize<GlobalPerfData>(GenshinSettingsJSONContext.Default) ?? new GlobalPerfData();
+            }
+
+            // Initialize globalPerf with a preset
+            var graphicsQuality = (GraphicsQualityOption)(from setting in tempData.saveItems where setting.entryType == 18 select setting.index).FirstOrDefault(3);
+            var globalPerf = graphicsQuality switch
+            {
+                GraphicsQualityOption.Lowest => _LowestPreset,
+                GraphicsQualityOption.Low => _LowPreset,
+                GraphicsQualityOption.Medium => _MediumPreset,
+                _ => tempData
+            };
+
+            // Apply custom changes
+            globalPerf.truePortedFromGraphicData = tempData.truePortedFromGraphicData;
+            globalPerf.portedVersion = tempData.portedVersion;
+            globalPerf.portedFromGraphicsData = tempData.portedFromGraphicsData;
+            foreach (var setting in tempData.saveItems)
+            {
+                switch (setting.entryType)
+                {
+                    case 1:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - FPS: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.FPS = (FPSOption)setting.index;
+                        break;
+
+                    case 2:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Render Resolution: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.RenderResolution = setting.index;
+                        break;
+
+                    case 3:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Shadow Quality: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.ShadowQuality = (ShadowQualityOption)setting.index;
+                        break;
+
+                    case 4:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Visual Effects: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.VisualEffects = (VisualEffectsOption)setting.index;
+                        break;
+
+                    case 5:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - SFX Quality: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.SFXQuality = (SFXQualityOption)setting.index;
+                        break;
+
+                    case 6:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Environment Detail: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.EnvironmentDetail = (EnvironmentDetailOption)setting.index;
+                        break;
+
+                    case 7:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Vertical Sync: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.VerticalSync = (VerticalSyncOption)setting.index;
+                        break;
+
+                    case 8:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Antialiasing: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.Antialiasing = (AntialiasingOption)setting.index;
+                        break;
+
+                    case 9:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Volumetric Fog: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.VolumetricFog = (VolumetricFogOption)setting.index;
+                        break;
+
+                    case 10:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Reflections: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.Reflections = (ReflectionsOption)setting.index;
+                        break;
+
+                    case 11:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Motion Blur: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.MotionBlur = (MotionBlurOption)setting.index;
+                        break;
+
+                    case 12:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Bloom: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.Bloom = (BloomOption)setting.index;
+                        break;
+
+                    case 13:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Crowd Density: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.CrowdDensity = (CrowdDensityOption)setting.index;
+                        break;
+
+                    // 14 is missing from settings
+                    // And yes, do not reorder this unless the game order finally changes
+                    // It is meant to be like this because miyoyo
+                    case 16:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Co-Op Teammate Effects: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.CoOpTeammateEffects = (CoOpTeammateEffectsOption)setting.index;
+                        break;
+
+                    case 15:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Subsurface Scattering: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.SubsurfaceScattering = (SubsurfaceScatteringOption)setting.index;
+                        break;
+
+                    case 17:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Anisotropic Filtering: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.AnisotropicFiltering = (AnisotropicFilteringOption)setting.index;
+                        break;
+
+                    case 18:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Graphics Quality: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.GraphicsQuality = (GraphicsQualityOption)setting.index;
+                        break;
+
+                    case 19:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Global Illumination: {setting.index}", LogType.Debug, true);
+#endif
+                        globalPerf.GlobalIllumination = (GlobalIlluminationOption)setting.index;
+                        break;
+                }
+            }
+            return globalPerf;
+        }
+
+        public string Save()
         {
             saveItems = new()
             {
-                new PerfDataItem (1, (int)graphics.FPS - 1, version),
-                new PerfDataItem (2, graphics.RenderResolution - 1, version),
-                new PerfDataItem (3,(int) graphics.ShadowQuality - 1, version),
-                new PerfDataItem (4,(int) graphics.VisualEffects - 1, version),
-                new PerfDataItem (5,(int) graphics.SFXQuality - 1, version),
-                new PerfDataItem (6,(int) graphics.EnvironmentDetail - 1, version),
-                new PerfDataItem (7,(int) graphics.VerticalSync - 1, version),
-                new PerfDataItem (8,(int) graphics.Antialiasing - 1, version),
-                new PerfDataItem (9,(int) graphics.VolumetricFog - 1, version),
-                new PerfDataItem (10,(int) graphics.Reflections - 1, version),
-                new PerfDataItem (11,(int) graphics.MotionBlur - 1, version),
-                new PerfDataItem (12,(int) graphics.Bloom - 1, version),
-                new PerfDataItem (13,(int) graphics.CrowdDensity - 1, version),
-                new PerfDataItem (16,(int) graphics.CoOpTeammateEffects - 1, version),
-                new PerfDataItem (15,(int) graphics.SubsurfaceScattering - 1, version),
-                new PerfDataItem (17,(int) graphics.AnisotropicFiltering - 1, version),
-                new PerfDataItem (19,(int) graphics.GlobalIllumination - 1, version)
+                new PerfDataItem(1, (int)FPS, portedVersion),
+                new PerfDataItem(2, RenderResolution, portedVersion),
+                new PerfDataItem(3, (int)ShadowQuality, portedVersion),
+                new PerfDataItem(4, (int)VisualEffects, portedVersion),
+                new PerfDataItem(5, (int)SFXQuality, portedVersion),
+                new PerfDataItem(6, (int)EnvironmentDetail, portedVersion),
+                new PerfDataItem(7, (int)VerticalSync, portedVersion),
+                new PerfDataItem(8, (int)Antialiasing, portedVersion),
+                new PerfDataItem(9, (int)VolumetricFog, portedVersion),
+                new PerfDataItem(10, (int)Reflections, portedVersion),
+                new PerfDataItem(11, (int)MotionBlur, portedVersion),
+                new PerfDataItem(12, (int)Bloom, portedVersion),
+                new PerfDataItem(13, (int)CrowdDensity, portedVersion),
+                new PerfDataItem(16, (int)CoOpTeammateEffects, portedVersion),
+                new PerfDataItem(15, (int)SubsurfaceScattering, portedVersion),
+                new PerfDataItem(17, (int)AnisotropicFiltering, portedVersion),
+                new PerfDataItem(18, (int)GraphicsQuality, portedVersion),
+                new PerfDataItem(19, (int)GlobalIllumination, portedVersion)
             };
             string data = this.Serialize(GenshinSettingsJSONContext.Default, false);
 #if DEBUG
-            LogWriteLine($"Saved Genshin GlobalPerfData\r\n{data}", Hi3Helper.LogType.Debug, true);
+            LogWriteLine($"Saved Genshin GlobalPerfData\r\n{data}", LogType.Debug, true);
 #endif
             return data;
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
@@ -1,9 +1,6 @@
 using CollapseLauncher.GameSettings.Genshin.Context;
-using CollapseLauncher.GameSettings.Genshin.Enums;
 using Hi3Helper;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using static Hi3Helper.Logger;
 
 namespace CollapseLauncher.GameSettings.Genshin
@@ -11,310 +8,41 @@ namespace CollapseLauncher.GameSettings.Genshin
     internal class GraphicsData
     {
         #region Properties
-        // Generate the list of the FPSOption value and order by ascending it.
-        public static readonly FPSOption[] FPSOptionsList = Enum.GetValues<FPSOption>().OrderBy(GetFPSOptionNumber).ToArray();
-        // Generate the list of the FPS number to be displayed on FPS Combobox
-        public static readonly int[] FPSIndex = FPSOptionsList.Select(GetFPSOptionNumber).ToArray();
-
-        private static int GetFPSOptionNumber(FPSOption value)
-        {
-            // Get the string of the number by trimming the 'f' letter at the beginning
-            string fpsStrNum = value.ToString().TrimStart('f');
-            // Try parse the fpsStrNum as a number
-            _ = int.TryParse(fpsStrNum, out int number);
-            // Return the number
-            return number;
-        }
-
-        public static readonly string[] RenderScaleValuesStr = DictionaryCategory.RenderResolutionOption.Keys.Select(x => x.ToString("0.0")).ToArray();
-        public static readonly List<double> RenderScaleValues = DictionaryCategory.RenderResolutionOption.Keys.ToList();
-        public static readonly List<int> RenderScaleIndex = DictionaryCategory.RenderResolutionOption.Values.ToList();
         public int currentVolatielGrade { get; set; } = -1;
         public List<GenshinKeyValuePair> customVolatileGrades { get; set; } = new();
         public string volatileVersion { get; set; } = "";
-        #endregion
-
-        #region Settings
-        /// <summary>
-        /// This defines "<c>FPS</c>" combobox In-game settings. <br/>
-        /// Options: 30, 60, 45 <br/>
-        /// Default: 60 [1]
-        /// </summary>
-        public FPSOption FPS = FPSOption.f60;
-
-        /// <summary>
-        /// This defines "<c>Render Resolution</c>" combobox In-game settings. <br/>
-        /// Options: 0.6 [0], 0.8 [1], 0.9 [9], 1.0 [3], 1.1 [4], 1.2 [5], 1.3 [6], 1.4 [7], 1.5 [8]<br/>
-        /// Default: 1.0 [3]
-        /// </summary>
-        public int RenderResolution = 3;
-
-        /// <summary>
-        /// This defines "<c>Shadow Quality</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High <br/>
-        /// Default: High [4]
-        /// </summary>
-        public ShadowQualityOption ShadowQuality = ShadowQualityOption.High;
-
-        /// <summary>
-        /// This defines "<c>Visual Effects</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High <br/>
-        /// Default: High [4]
-        /// </summary>
-        public VisualEffectsOption VisualEffects = VisualEffectsOption.High;
-
-        /// <summary>
-        /// This defines "<c>SFX Quality</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High <br/>
-        /// Default: High [4]
-        /// </summary>
-        public SFXQualityOption SFXQuality = SFXQualityOption.High;
-
-        /// <summary>
-        /// This defines "<c>Environment Detail</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High, Highest <br/>
-        /// Default: High [4]
-        /// </summary>
-        public EnvironmentDetailOption EnvironmentDetail = EnvironmentDetailOption.High;
-
-        /// <summary>
-        /// This defines "<c>Vertical Sync</c>" combobox In-game settings. <br/>
-        /// Options: Off, On <br/>
-        /// Default: On [2]
-        /// </summary>
-        public VerticalSyncOption VerticalSync = VerticalSyncOption.On;
-
-        /// <summary>
-        /// This defines "<c>Antialiasing</c>" combobox In-game settings. <br/>
-        /// Options: Off, FSR 2, SMAA <br/>
-        /// Default: FSR 2 [2]
-        /// </summary>
-        public AntialiasingOption Antialiasing = AntialiasingOption.FSR2;
-
-        /// <summary>
-        /// This defines "<c>Volumetric Fog</c>" combobox In-game settings. <br/>
-        /// Options: Off, On <br/>
-        /// Default: On [2]
-        /// Game prohibits enabling this if "<c>Shadow Quality</c>" on Low or Lowest
-        /// </summary>
-        public VolumetricFogOption VolumetricFog = VolumetricFogOption.On;
-
-        /// <summary>
-        /// This defines "<c>Reflections</c>" combobox In-game settings. <br/>
-        /// Options: Off, On <br/>
-        /// Default: On [2]
-        /// </summary>
-        public ReflectionsOption Reflections = ReflectionsOption.On;
-
-        /// <summary>
-        /// This defines "<c>Motion Blur</c>" combobox In-game settings. <br/>
-        /// Options: Off, Low, High, Extreme <br/>
-        /// Default: Extreme [4]
-        /// </summary>
-        public MotionBlurOption MotionBlur = MotionBlurOption.Extreme;
-
-        /// <summary>
-        /// This defines "<c>Bloom</c>" combobox In-game settings. <br/>
-        /// Options: Off, On <br/>
-        /// Default: On [2]
-        /// </summary>
-        public BloomOption Bloom = BloomOption.On;
-
-        /// <summary>
-        /// This defines "<c>Crowd Density</c>" combobox In-game settings. <br/>
-        /// Options: Low, High <br/>
-        /// Default: High [2]
-        /// </summary>
-        public CrowdDensityOption CrowdDensity = CrowdDensityOption.High;
-
-        /// <summary>
-        /// This defines "<c>Subsurface Scattering</c>" combobox In-game settings. <br/>
-        /// Options: Off, Medium, High <br/>
-        /// Default: High [3]
-        /// </summary>
-        public SubsurfaceScatteringOption SubsurfaceScattering = SubsurfaceScatteringOption.High;
-
-        /// <summary>
-        /// This defines "<c>Co-Op Teammate Effects</c>" combobox In-game settings. <br/>
-        /// Options: Off, Partially Off, On <br/>
-        /// Default: On [3]
-        /// </summary>
-        public CoOpTeammateEffectsOption CoOpTeammateEffects = CoOpTeammateEffectsOption.On;
-
-        /// <summary>
-        /// This defines "<c>Anisotropic Filtering</c>" combobox In-game settings. <br/>
-        /// Options: 1x, 2x, 4x, 8x, 16x <br/>
-        /// Default: 8x [4]
-        /// </summary>
-        public AnisotropicFilteringOption AnisotropicFiltering = AnisotropicFilteringOption.x8;
-
-        /// <summary>
-        /// This defines "<c>Global Illumination</c>" combobox In-game settings. <br/>
-        /// Options: Off, Medium, High, Extreme
-        /// Default: Off [1]  <br/>
-        /// Notes: Only work for PC who meet the specs for Global Illumination, specified by HYV  <br/>
-        /// Further information: https://genshin.hoyoverse.com/en/news/detail/112690#:~:text=Minimum%20Specifications%20for%20Global%20Illumination
-        /// </summary>
-        public GlobalIlluminationOption GlobalIllumination = GlobalIlluminationOption.Off;
         #endregion
 
         #region Methods
 #nullable enable
         public static GraphicsData Load(string graphicsJson)
         {
-            GraphicsData graphics = graphicsJson.Deserialize<GraphicsData>(GenshinSettingsJSONContext.Default) ?? new GraphicsData();
-            foreach (GenshinKeyValuePair setting in graphics.customVolatileGrades)
-            {
-                switch (setting.key)
-                {
-                    case 1:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - FPS: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.FPS = (FPSOption)setting.value;
-                        break;
-
-                    case 2:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Render Resolution: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.RenderResolution = setting.value;
-                        break;
-
-                    case 3:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Shadow Quality: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.ShadowQuality = (ShadowQualityOption)setting.value;
-                        break;
-
-                    case 4:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Visual Effects: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.VisualEffects = (VisualEffectsOption)setting.value;
-                        break;
-
-                    case 5:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - SFX Quality: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.SFXQuality = (SFXQualityOption)setting.value;
-                        break;
-
-                    case 6:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Environment Detail: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.EnvironmentDetail = (EnvironmentDetailOption)setting.value;
-                        break;
-
-                    case 7:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Vertical Sync: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.VerticalSync = (VerticalSyncOption)setting.value;
-                        break;
-
-                    case 8:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Antialiasing: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.Antialiasing = (AntialiasingOption)setting.value;
-                        break;
-
-                    case 9:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Volumetric Fog: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.VolumetricFog = (VolumetricFogOption)setting.value;
-                        break;
-
-                    case 10:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Reflections: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.Reflections = (ReflectionsOption)setting.value;
-                        break;
-
-                    case 11:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Motion Blur: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.MotionBlur = (MotionBlurOption)setting.value;
-                        break;
-
-                    case 12:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Bloom: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.Bloom = (BloomOption)setting.value;
-                        break;
-
-                    case 13:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Crowd Density: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.CrowdDensity = (CrowdDensityOption)setting.value;
-                        break;
-
-                    // 14 is missing from settings
-                    // And yes, do not reorder this unless the game order finally changes
-                    // It is meant to be like this because miyoyo
-                    case 16:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Co-Op Teammate Effects: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.CoOpTeammateEffects = (CoOpTeammateEffectsOption)setting.value;
-                        break;
-
-                    case 15:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Subsurface Scattering: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.SubsurfaceScattering = (SubsurfaceScatteringOption)setting.value;
-                        break;
-
-                    case 17:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Anisotropic Filtering: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.AnisotropicFiltering = (AnisotropicFilteringOption)setting.value;
-                        break;
-
-                    case 19:
-#if DEBUG
-                        LogWriteLine($"Loaded Genshin Settings: Graphics - Global Illumination: {setting.value}", LogType.Debug, true);
-#endif
-                        graphics.GlobalIllumination = (GlobalIlluminationOption)setting.value;
-                        break;
-                }
-            }
-            return graphics;
+            return graphicsJson.Deserialize<GraphicsData>(GenshinSettingsJSONContext.Default) ?? new GraphicsData();
         }
 
-        public string Save()
+        public string Create(GlobalPerfData globalPerf)
         {
+            volatileVersion = globalPerf.portedVersion;
             customVolatileGrades = new()
             {
-                new GenshinKeyValuePair(1, (int)FPS),
-                new GenshinKeyValuePair(2, (int)RenderResolution),
-                new GenshinKeyValuePair(3, (int)ShadowQuality),
-                new GenshinKeyValuePair(4, (int)VisualEffects),
-                new GenshinKeyValuePair(5, (int)SFXQuality),
-                new GenshinKeyValuePair(6, (int)EnvironmentDetail),
-                new GenshinKeyValuePair(7, (int)VerticalSync),
-                new GenshinKeyValuePair(8, (int)Antialiasing),
-                new GenshinKeyValuePair(9, (int)VolumetricFog),
-                new GenshinKeyValuePair(10, (int)Reflections),
-                new GenshinKeyValuePair(11, (int)MotionBlur),
-                new GenshinKeyValuePair(12, (int)Bloom),
-                new GenshinKeyValuePair(13, (int)CrowdDensity),
-                new GenshinKeyValuePair(16, (int)CoOpTeammateEffects),
-                new GenshinKeyValuePair(15, (int)SubsurfaceScattering),
-                new GenshinKeyValuePair(17, (int)AnisotropicFiltering),
-                new GenshinKeyValuePair(19, (int)GlobalIllumination)
-                };
+                new GenshinKeyValuePair(1, (int)globalPerf.FPS + 1),
+                new GenshinKeyValuePair(2, globalPerf.RenderResolution + 1),
+                new GenshinKeyValuePair(3, (int)globalPerf.ShadowQuality + 1),
+                new GenshinKeyValuePair(4, (int)globalPerf.VisualEffects + 1),
+                new GenshinKeyValuePair(5, (int)globalPerf.SFXQuality + 1),
+                new GenshinKeyValuePair(6, (int)globalPerf.EnvironmentDetail + 1),
+                new GenshinKeyValuePair(7, (int)globalPerf.VerticalSync + 1),
+                new GenshinKeyValuePair(8, (int)globalPerf.Antialiasing + 1),
+                new GenshinKeyValuePair(9, (int)globalPerf.VolumetricFog + 1),
+                new GenshinKeyValuePair(10, (int)globalPerf.Reflections + 1),
+                new GenshinKeyValuePair(11, (int)globalPerf.MotionBlur + 1),
+                new GenshinKeyValuePair(12, (int)globalPerf.Bloom + 1),
+                new GenshinKeyValuePair(13, (int)globalPerf.CrowdDensity + 1),
+                new GenshinKeyValuePair(16, (int)globalPerf.CoOpTeammateEffects + 1),
+                new GenshinKeyValuePair(15, (int)globalPerf.SubsurfaceScattering + 1),
+                new GenshinKeyValuePair(17, (int)globalPerf.AnisotropicFiltering + 1),
+                new GenshinKeyValuePair(19, (int)globalPerf.GlobalIllumination + 1),
+            };
 
             string data = this.Serialize(GenshinSettingsJSONContext.Default, false);
 #if DEBUG

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -148,26 +148,26 @@ namespace CollapseLauncher.Pages
 
         public bool VerticalSync
         {
-            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.graphicsData.VerticalSync - 1);
-            set => Settings.SettingsGeneralData.graphicsData.VerticalSync = (VerticalSyncOption)(Convert.ToInt32(value) + 1);
+            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.globalPerfData.VerticalSync);
+            set => Settings.SettingsGeneralData.globalPerfData.VerticalSync = (VerticalSyncOption)(Convert.ToInt32(value));
         }
 
         public bool VolumetricFog
         {
-            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.graphicsData.VolumetricFog - 1);
-            set => Settings.SettingsGeneralData.graphicsData.VolumetricFog = (VolumetricFogOption)(Convert.ToInt32(value) + 1);
+            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.globalPerfData.VolumetricFog);
+            set => Settings.SettingsGeneralData.globalPerfData.VolumetricFog = (VolumetricFogOption)(Convert.ToInt32(value));
         }
 
         public bool Reflections
         {
-            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.graphicsData.Reflections - 1);
-            set => Settings.SettingsGeneralData.graphicsData.Reflections = (ReflectionsOption)(Convert.ToInt32(value) + 1);
+            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.globalPerfData.Reflections);
+            set => Settings.SettingsGeneralData.globalPerfData.Reflections = (ReflectionsOption)(Convert.ToInt32(value));
         }
 
         public bool Bloom
         {
-            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.graphicsData.Bloom - 1);
-            set => Settings.SettingsGeneralData.graphicsData.Bloom = (BloomOption)(Convert.ToInt32(value) + 1);
+            get => Convert.ToBoolean((int)Settings.SettingsGeneralData.globalPerfData.Bloom);
+            set => Settings.SettingsGeneralData.globalPerfData.Bloom = (BloomOption)(Convert.ToInt32(value));
         }
 
         public int FPS
@@ -175,9 +175,9 @@ namespace CollapseLauncher.Pages
             get
             {
                 // Get the current value
-                FPSOption curValue = Settings.SettingsGeneralData.graphicsData.FPS;
+                FPSOption curValue = Settings.SettingsGeneralData.globalPerfData.FPS;
                 // Get the index of the current value in FPSOptionsList array
-                int indexOfValue = Array.IndexOf(GraphicsData.FPSOptionsList, curValue);
+                int indexOfValue = Array.IndexOf(GlobalPerfData.FPSOptionsList, curValue);
                 // Return the index of the value
                 return indexOfValue;
             }
@@ -187,9 +187,9 @@ namespace CollapseLauncher.Pages
                 if (value < 0) return;
 
                 // Get the FPSOption based on the selected index by the "value"
-                FPSOption valueFromIndex = GraphicsData.FPSOptionsList[value];
+                FPSOption valueFromIndex = GlobalPerfData.FPSOptionsList[value];
                 // Set the actual value to its property
-                Settings.SettingsGeneralData.graphicsData.FPS = valueFromIndex;
+                Settings.SettingsGeneralData.globalPerfData.FPS = valueFromIndex;
             }
         }
 
@@ -197,16 +197,16 @@ namespace CollapseLauncher.Pages
         {
             get
             {
-                int enumIndex = Settings.SettingsGeneralData.graphicsData.RenderResolution;
-                int valueIndex = GraphicsData.RenderScaleIndex.IndexOf(enumIndex);
-                double enumValue = GraphicsData.RenderScaleValues[valueIndex];
-                return GraphicsData.RenderScaleValues.IndexOf(enumValue);
+                int enumIndex = Settings.SettingsGeneralData.globalPerfData.RenderResolution;
+                int valueIndex = GlobalPerfData.RenderScaleIndex.IndexOf(enumIndex);
+                double enumValue = GlobalPerfData.RenderScaleValues[valueIndex];
+                return GlobalPerfData.RenderScaleValues.IndexOf(enumValue);
             }
             set
             {
-                double enumValue = GraphicsData.RenderScaleValues[value];
+                double enumValue = GlobalPerfData.RenderScaleValues[value];
                 int enumIndex = DictionaryCategory.RenderResolutionOption[enumValue];
-                Settings.SettingsGeneralData.graphicsData.RenderResolution = enumIndex;
+                Settings.SettingsGeneralData.globalPerfData.RenderResolution = enumIndex;
             }
         }
 
@@ -214,7 +214,7 @@ namespace CollapseLauncher.Pages
         {
             get
             {
-                int curValue = (int)Settings.SettingsGeneralData.graphicsData.ShadowQuality - 1;
+                int curValue = (int)Settings.SettingsGeneralData.globalPerfData.ShadowQuality;
 
                 // Disable Volumetric Fog when ShadowQuality is not Medium or higher
                 if (curValue < 2)
@@ -241,62 +241,62 @@ namespace CollapseLauncher.Pages
                     VolumetricFogToggle.IsEnabled = true;
                 }
 
-                Settings.SettingsGeneralData.graphicsData.ShadowQuality = (ShadowQualityOption)(value + 1);
+                Settings.SettingsGeneralData.globalPerfData.ShadowQuality = (ShadowQualityOption)(value);
             }
         }
 
         public int VisualEffects
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.VisualEffects - 1;
-            set => Settings.SettingsGeneralData.graphicsData.VisualEffects = (VisualEffectsOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.VisualEffects;
+            set => Settings.SettingsGeneralData.globalPerfData.VisualEffects = (VisualEffectsOption)(value);
         }
 
         public int SFXQuality
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.SFXQuality - 1;
-            set => Settings.SettingsGeneralData.graphicsData.SFXQuality = (SFXQualityOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.SFXQuality;
+            set => Settings.SettingsGeneralData.globalPerfData.SFXQuality = (SFXQualityOption)(value);
         }
 
         public int EnvironmentDetail
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.EnvironmentDetail - 1;
-            set => Settings.SettingsGeneralData.graphicsData.EnvironmentDetail = (EnvironmentDetailOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.EnvironmentDetail;
+            set => Settings.SettingsGeneralData.globalPerfData.EnvironmentDetail = (EnvironmentDetailOption)(value);
         }
 
         public int MotionBlur
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.MotionBlur - 1;
-            set => Settings.SettingsGeneralData.graphicsData.MotionBlur = (MotionBlurOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.MotionBlur;
+            set => Settings.SettingsGeneralData.globalPerfData.MotionBlur = (MotionBlurOption)(value);
         }
 
         public int CrowdDensity
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.CrowdDensity - 1;
-            set => Settings.SettingsGeneralData.graphicsData.CrowdDensity = (CrowdDensityOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.CrowdDensity;
+            set => Settings.SettingsGeneralData.globalPerfData.CrowdDensity = (CrowdDensityOption)(value);
         }
 
         public int SubsurfaceScattering
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.SubsurfaceScattering - 1;
-            set => Settings.SettingsGeneralData.graphicsData.SubsurfaceScattering = (SubsurfaceScatteringOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.SubsurfaceScattering;
+            set => Settings.SettingsGeneralData.globalPerfData.SubsurfaceScattering = (SubsurfaceScatteringOption)(value);
         }
 
         public int CoOpTeammateEffects
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.CoOpTeammateEffects - 1;
-            set => Settings.SettingsGeneralData.graphicsData.CoOpTeammateEffects = (CoOpTeammateEffectsOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.CoOpTeammateEffects;
+            set => Settings.SettingsGeneralData.globalPerfData.CoOpTeammateEffects = (CoOpTeammateEffectsOption)(value);
         }
 
         public int AnisotropicFiltering
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.AnisotropicFiltering - 1;
-            set => Settings.SettingsGeneralData.graphicsData.AnisotropicFiltering = (AnisotropicFilteringOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.AnisotropicFiltering;
+            set => Settings.SettingsGeneralData.globalPerfData.AnisotropicFiltering = (AnisotropicFilteringOption)(value);
         }
 
         public int Antialiasing
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.Antialiasing - 1;
-            set => Settings.SettingsGeneralData.graphicsData.Antialiasing = (AntialiasingOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.Antialiasing;
+            set => Settings.SettingsGeneralData.globalPerfData.Antialiasing = (AntialiasingOption)(value);
         }
 
         public bool TeamPageBackground
@@ -307,8 +307,8 @@ namespace CollapseLauncher.Pages
 
         public int GlobalIllumination
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.GlobalIllumination - 1;
-            set => Settings.SettingsGeneralData.graphicsData.GlobalIllumination = (GlobalIlluminationOption)(value + 1);
+            get => (int)Settings.SettingsGeneralData.globalPerfData.GlobalIllumination;
+            set => Settings.SettingsGeneralData.globalPerfData.GlobalIllumination = (GlobalIlluminationOption)(value);
         }
         #endregion
 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -77,7 +77,7 @@
                                                    HorizontalAlignment="Left" Width="100"/>
                                 </StackPanel>
                                 <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_FPS}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,8,0"/>
-                                <ComboBox x:Name="FPSSelector" SelectedIndex="{x:Bind FPS, Mode=TwoWay}" ItemsSource="{x:Bind static:GraphicsData.FPSIndex}" Margin="0,8,0,8" Width="128" CornerRadius="14"/>
+                                <ComboBox x:Name="FPSSelector" SelectedIndex="{x:Bind FPS, Mode=TwoWay}" ItemsSource="{x:Bind static:GlobalPerfData.FPSIndex}" Margin="0,8,0,8" Width="128" CornerRadius="14"/>
                             </StackPanel>
                             <StackPanel x:Name="GameBoostPanel" Orientation="Horizontal">
                                 <ToggleSwitch Header="{x:Bind helper:Locale.Lang._GameSettingsPage.GameBoost}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" IsOn="{x:Bind IsGameBoost, Mode=TwoWay}" Margin="4,8,0,0"/>
@@ -188,7 +188,7 @@
                                         </Grid.ColumnDefinitions>
                                         <StackPanel Grid.Column="0">
                                             <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_RenderScale}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
-                                            <ComboBox x:Name="RenderScaleSelector" Margin="0,0,0,8" Width="128" CornerRadius="14" SelectedIndex="{x:Bind RenderScale, Mode=TwoWay}" ItemsSource="{x:Bind static:GraphicsData.RenderScaleValuesStr}"/>
+                                            <ComboBox x:Name="RenderScaleSelector" Margin="0,0,0,8" Width="128" CornerRadius="14" SelectedIndex="{x:Bind RenderScale, Mode=TwoWay}" ItemsSource="{x:Bind static:GlobalPerfData.RenderScaleValuesStr}"/>
                                         </StackPanel>
                                         <StackPanel Grid.Column="1">
                                             <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_AAMode}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
@@ -268,7 +268,7 @@
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecDisabled}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecLow}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecHigh}"/>
-                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecVeryHigh}"/>
+                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecExtreme}"/>
                                         </ComboBox>
                                     </StackPanel>
                                     <StackPanel Grid.Column="2">


### PR DESCRIPTION
Fix inconsistency with in-game settings.

Loading mechanism:
First try to load `globalPerfData`, and the current graphics quality option is saved in `saveItems` entryType 18. Then patch the selected graphics quality preset using entries in `saveItems`.
If `globalPerfData` does not exist (older versions), try to import it from `graphicsData`. May not be needed, but it's done anyway.
|  graphicsData   | globalPerfData  |
|  ----  | ----  |
| currentVolatielGrade  | saveItems entryType 18 |
| customVolatileGrades  | saveItems (-1 to zero-based) |
| volatileVersion  | portedVersion |

GlobalPerfData will now be used as the data source for the UI.
Also change the relevant enums to zero-based.

globalPerfData, High graphics quality, Antialiasing changed to SMAA
```json
{
    "saveItems":[
        {
            "entryType":18,
            "index":3,
            "itemVersion":"CNRELWin4.1.0"
        },
        {
            "entryType":8,
            "index":2,
            "itemVersion":"CNRELWin4.1.0"
        }
    ],
    "truePortedFromGraphicData":true,
    "portedVersion":"CNRELWin4.1.0",
    "portedFromGraphicData":false
}
```



Maintainer Edits:
Related to #295 