### PR TITLE
Allow minimizing main window from taskbar

### DIFF
--- a/CollapseLauncher/App.xaml
+++ b/CollapseLauncher/App.xaml
@@ -666,6 +666,11 @@
                             </Setter.Value>
                         </Setter>
                     </Style>
+
+                    <!-- WindowChrome min max close styles -->
+                    <x:Double x:Key="WindowCaptionButtonStrokeWidth">1</x:Double>
+                    <SolidColorBrush x:Key="WindowCaptionBackground" Color="#00000000"/>
+                    <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled" Color="#00000000"/>
                 </ResourceDictionary>
                 <!-- Custom controls styles -->
                 <ResourceDictionary Source="ms-appx:///XAMLs/Theme/DataGrid.xaml"/>

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
@@ -27,11 +27,37 @@
             </Frame.ContentTransitions>
         </Frame>
         <customcontrol:ContentDialogCollapse x:Name="ContentDialog" x:FieldModifier="internal"/>
-        <Button x:Name="MinimizeButton" Width="48" Height="48"
-                Margin="0,0,48,0" HorizontalAlignment="Right"
+        <Grid x:Name="AppTitleBar">
+            <Button x:Name="MinimizeButton" Width="48" Height="48"
+                    Margin="0,0,48,0" HorizontalAlignment="Right"
+                    Style="{StaticResource WindowCaptionButton}"
+                    Click="MinimizeButton_Click"
+                    Content="M 0 0 H 10"/>
+            <Button x:Name="CloseButton" Width="48" Height="48"
+                Margin="0,0,0,0" HorizontalAlignment="Right"
                 Style="{StaticResource WindowCaptionButton}"
-                Click="MinimizeButton_Click"
-                Content="M 0 0 H 10"/>
+                Click="CloseButton_Click"
+                Content="M 0 0 L 10 10 M 10 0 L 0 10">
+                <Button.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Light">
+                                <StaticResource x:Key="WindowCaptionButtonBackgroundPointerOver" ResourceKey="CloseButtonBackgroundPointerOver" />
+                                <StaticResource x:Key="WindowCaptionButtonBackgroundPressed" ResourceKey="CloseButtonBackgroundPressed" />
+                                <StaticResource x:Key="WindowCaptionButtonStrokePointerOver" ResourceKey="CloseButtonStrokePointerOver" />
+                                <StaticResource x:Key="WindowCaptionButtonStrokePressed" ResourceKey="CloseButtonStrokePressed" />
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Default">
+                                <StaticResource x:Key="WindowCaptionButtonBackgroundPointerOver" ResourceKey="CloseButtonBackgroundPointerOver" />
+                                <StaticResource x:Key="WindowCaptionButtonBackgroundPressed" ResourceKey="CloseButtonBackgroundPressed" />
+                                <StaticResource x:Key="WindowCaptionButtonStrokePointerOver" ResourceKey="CloseButtonStrokePointerOver" />
+                                <StaticResource x:Key="WindowCaptionButtonStrokePressed" ResourceKey="CloseButtonStrokePressed" />
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </Button.Resources>
+            </Button>
+        </Grid>
         <local:TrayIcon x:Name="TrayIcon"/>
     </Grid>
 </Window>

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI;
+using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -133,34 +134,33 @@ namespace CollapseLauncher
                 m_presenter.IsResizable = false;
                 m_presenter.IsMaximizable = false;
 
-                if (IsAppThemeLight)
-                {
-                    m_appWindow.TitleBar.ButtonForegroundColor = new Windows.UI.Color { A = 255, B = 0, G = 0, R = 0 };
-                    m_appWindow.TitleBar.ButtonInactiveForegroundColor = new Windows.UI.Color { A = 0, B = 160, G = 160, R = 160 };
-                    m_appWindow.TitleBar.ButtonHoverBackgroundColor = new Windows.UI.Color { A = 64, B = 0, G = 0, R = 0 };
-                }
-                else
-                {
-                    m_appWindow.TitleBar.ButtonForegroundColor = new Windows.UI.Color { A = 255, B = 255, G = 255, R = 255 };
-                    m_appWindow.TitleBar.ButtonHoverBackgroundColor = new Windows.UI.Color { A = 64, B = 0, G = 0, R = 0 };
-                }
-
                 m_appWindow.TitleBar.ButtonBackgroundColor = new Windows.UI.Color { A = 0, B = 0, G = 0, R = 0 };
                 m_appWindow.TitleBar.ButtonInactiveBackgroundColor = new Windows.UI.Color { A = 0, B = 0, G = 0, R = 0 };
+
+                // Hide system menu
+                var controlsHwnd = FindWindowEx(m_windowHandle, 0, "ReunionWindowingCaptionControls", "ReunionCaptionControlsWindow");
+                if (controlsHwnd != IntPtr.Zero)
+                {
+                    DestroyWindow(controlsHwnd);
+                }
+
+                // Fix mouse event
+                var incps = InputNonClientPointerSource.GetForWindowId(m_windowID);
+                incps.SetRegionRects(NonClientRegionKind.Close, null);
+                incps.SetRegionRects(NonClientRegionKind.Minimize, null);
+                var safeArea = new RectInt32[] { new(m_appWindow.Size.Width - (int)((144 + 12) * m_appDPIScale), 0, (int)((144 + 12) * m_appDPIScale), (int)(48 * m_appDPIScale)) };
+                incps.SetRegionRects(NonClientRegionKind.Passthrough, safeArea);
             }
             else
             {
+                // Shouldn't happen
+                // https://learn.microsoft.com/en-us/windows/apps/develop/title-bar#colors
+
                 m_presenter.IsResizable = false;
                 m_presenter.IsMaximizable = false;
                 ExtendsContentIntoTitleBar = false;
+                AppTitleBar.Visibility = Visibility.Collapsed;
             }
-
-            // Hide minimize and maximize button
-            int gwl_style = -16;
-            uint minimizeBtn = 0x00020000;
-            uint maximizeBtn = 0x00010000;
-            var currentStyle = GetWindowLong(m_windowHandle, gwl_style);
-            SetWindowLong(m_windowHandle, gwl_style, currentStyle & ~minimizeBtn & ~maximizeBtn);
 
             MainFrameChangerInvoker.WindowFrameEvent += MainFrameChangerInvoker_WindowFrameEvent;
             LauncherUpdateInvoker.UpdateEvent += LauncherUpdateInvoker_UpdateEvent;
@@ -318,6 +318,11 @@ namespace CollapseLauncher
                 TrayIcon.ToggleAllVisibility();
             }
             else m_presenter.Minimize();
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.Close();
         }
     }
 }

--- a/Hi3Helper.Core/Classes/Data/InvokeProp.cs
+++ b/Hi3Helper.Core/Classes/Data/InvokeProp.cs
@@ -20,7 +20,7 @@ namespace Hi3Helper
         public enum SetWindowPosFlags : uint
         {
             SWP_NOMOVE = 2,
-            SWP_SHOWWINDOW = 40,
+            SWP_SHOWWINDOW = 0x40,
         }
 
         public enum SpecialWindowHandles
@@ -202,6 +202,12 @@ namespace Hi3Helper
 
         [DllImport("user32.dll")]
         public extern static uint SetWindowLong(IntPtr hwnd, int index, uint value);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
+
+        [DllImport("user32.dll")]
+        public static extern bool DestroyWindow(IntPtr hwnd);
 
         public static IntPtr GetProcessWindowHandle(string ProcName) => Process.GetProcessesByName(Path.GetFileNameWithoutExtension(ProcName), ".")[0].MainWindowHandle;
 


### PR DESCRIPTION
Remove the "ReunionCaptionControlsWindow" window to hide the control buttons.

Fix #311