### PR TITLE
Workaround for window maximize issue

### DIFF
--- a/CollapseLauncher/Classes/Properties/InnerLauncherConfig.cs
+++ b/CollapseLauncher/Classes/Properties/InnerLauncherConfig.cs
@@ -50,6 +50,8 @@ namespace CollapseLauncher
         public static Microsoft.UI.WindowId m_windowID;
         public static Rect                  m_windowPosSize;
         public static IntPtr                m_windowHandle;
+        public static IntPtr                m_oldWndProc;
+        public static Delegate              m_newWndProcDelegate;
         public static AppWindow             m_appWindow;
         public static OverlappedPresenter   m_presenter;
         public static MainPage              m_mainPage;

--- a/Hi3Helper.Core/Classes/Data/InvokeProp.cs
+++ b/Hi3Helper.Core/Classes/Data/InvokeProp.cs
@@ -204,10 +204,16 @@ namespace Hi3Helper
         public extern static uint SetWindowLong(IntPtr hwnd, int index, uint value);
 
         [DllImport("user32.dll")]
+        public extern static IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr value);
+
+        [DllImport("user32.dll")]
         public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
         [DllImport("user32.dll")]
         public static extern bool DestroyWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hwnd, uint msg, UIntPtr wParam, IntPtr lParam);
 
         public static IntPtr GetProcessWindowHandle(string ProcName) => Process.GetProcessesByName(Path.GetFileNameWithoutExtension(ProcName), ".")[0].MainWindowHandle;
 


### PR DESCRIPTION
Windows App SDK 1.4 introduces a new issue. Double-clicking on the title bar will maximize the window, ignoring `IsMaximizable = false`.
Temporary workaround: register the WndProc hook to filter out the WM_SYSCOMMAND SC_MAXIMIZE message.

https://github.com/microsoft/microsoft-ui-xaml/issues/8666