### PR TITLE
Carousel adjustments

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
@@ -326,14 +326,12 @@
                         </Grid>
                         <StackPanel x:Name="ImageCarouselAndPostPanel" Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Grid.RowSpan="2"
                                 Margin="{x:Bind localWindowSize:WindowSize.CurrentWindowSize.PostPanelBottomMargin}" Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom">
-                            <StackPanel HorizontalAlignment="Left">
+                            <StackPanel HorizontalAlignment="Left" PointerEntered="CarouselStopScroll" PointerExited="CarouselRestartScroll">
                                 <FlipView x:Name="ImageCarousel" Shadow="{ThemeResource SharedShadow}" Visibility="Collapsed"
                                   MaxWidth="{x:Bind localWindowSize:WindowSize.CurrentWindowSize.EventPostCarouselBounds.Width}" Height="{x:Bind localWindowSize:WindowSize.CurrentWindowSize.EventPostCarouselBounds.Height}" 
                                   CornerRadius="8" ItemsSource="{x:Bind MenuPanels.imageCarouselPanel}"
                                   Style="{ThemeResource CollapseFlipViewStyle}"
-                                  HorizontalAlignment="Center"
-                                  PointerEntered="CarouselStopScroll"
-                                  PointerExited="CarouselRestartScroll">
+                                  HorizontalAlignment="Center">
                                     <FlipView.ItemTemplate>
                                         <DataTemplate>
                                             <imageex:ImageEx IsCacheEnabled="True" EnableLazyLoading="True" PlaceholderSource="ms-appx:///Assets/Images/default.png" Source="{Binding Icon}" Tag="{Binding URL}" ToolTipService.ToolTip="{Binding Description}" PointerPressed="OpenImageLinkFromTag"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -409,6 +409,7 @@ namespace CollapseLauncher.Pages
         #region Open Link from Tag
         private void OpenImageLinkFromTag(object sender, PointerRoutedEventArgs e)
         {
+            if (!e.GetCurrentPoint((UIElement) sender).Properties.IsLeftButtonPressed) return;
             SpawnWebView2.SpawnWebView2Window(((ImageEx.ImageEx)sender).Tag.ToString());
         }
 
@@ -465,6 +466,7 @@ namespace CollapseLauncher.Pages
 
         private void ClickImageEventSpriteLink(object sender, PointerRoutedEventArgs e)
         {
+            if (!e.GetCurrentPoint((UIElement)sender).Properties.IsLeftButtonPressed) return;
             object ImageTag = ((Image)sender).Tag;
             if (ImageTag == null) return;
             SpawnWebView2.SpawnWebView2Window((string)ImageTag);


### PR DESCRIPTION
- Regard pips pager as a part of carousel
- Open image links only if left mouse button is pressed

Also found a tiny memory leak caused by `CancellationTokenSource`. It probably doesn't need fixing at this point.