### PR TITLE
Auto stop carousel when main window is hidden

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -179,13 +179,13 @@ namespace CollapseLauncher
         {
             const uint WM_SYSCOMMAND = 0x0112;
             const uint WM_SHOWWINDOW = 0x0018;
-            const uint SC_MAXIMIZE = 0xF030;
-            const uint SC_MINIMIZE = 0xF020;
-            const uint SC_RESTORE = 0xF120;
+            const uint WM_SIZE = 0x0005;
             switch (msg)
             {
                 case WM_SYSCOMMAND:
                 {
+                    const uint SC_MAXIMIZE = 0xF030;
+                    const uint SC_MINIMIZE = 0xF020;
                     switch (wParam)
                     {
                         case SC_MAXIMIZE:
@@ -196,19 +196,12 @@ namespace CollapseLauncher
                         }
                         case SC_MINIMIZE:
                         {
-                            m_homePage?.CarouselStopScroll();
-
                             if (GetAppConfigValue("MinimizeToTray").ToBool())
                             {
+                                // Carousel is handled inside WM_SHOWWINDOW message for minimize to tray
                                 TrayIcon.ToggleAllVisibility();
                                 return 0;
                             }
-
-                            break;
-                        }
-                        case SC_RESTORE:
-                        {
-                            m_homePage?.CarouselRestartScroll();
                             break;
                         }
                     }
@@ -220,6 +213,25 @@ namespace CollapseLauncher
                         m_homePage?.CarouselStopScroll();
                     else
                         m_homePage?.CarouselRestartScroll();
+                    break;
+                }
+                case WM_SIZE:
+                {
+                    const uint SIZE_MINIMIZED = 1;
+                    const uint SIZE_RESTORED = 0;
+                    switch (wParam)
+                    {
+                        case SIZE_MINIMIZED:
+                        {
+                            m_homePage?.CarouselStopScroll();
+                            break;
+                        }
+                        case SIZE_RESTORED:
+                        {
+                            m_homePage?.CarouselRestartScroll();
+                            break;
+                        }
+                    }
                     break;
                 }
             }
@@ -373,10 +385,7 @@ namespace CollapseLauncher
 
         private void MinimizeButton_Click(object sender, RoutedEventArgs e)
         {
-            // m_presenter.Minimize() does not send SC_MINIMIZE message
-            const uint WM_SYSCOMMAND = 0x0112;
-            const uint SC_MINIMIZE = 0xF020;
-            SendMessage(m_windowHandle, WM_SYSCOMMAND, SC_MINIMIZE, 0);
+            m_presenter.Minimize();
         }
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -1219,7 +1219,7 @@ namespace CollapseLauncher.Pages
                 switch (GetAppConfigValue("GameLaunchedBehavior").ToString())
                 {
                     case "Minimize":
-                        m_presenter.Minimize();
+                        (m_window as MainWindow).Minimize();
                         break;
                     case "ToTray":
                         H.NotifyIcon.WindowExtensions.Hide(m_window);
@@ -1228,7 +1228,7 @@ namespace CollapseLauncher.Pages
                     case "Nothing":
                         break;
                     default:
-                        m_presenter.Minimize();
+                        (m_window as MainWindow).Minimize();
                         break;
                 }
 
@@ -1281,16 +1281,16 @@ namespace CollapseLauncher.Pages
             switch (GetAppConfigValue("GameLaunchedBehavior").ToString())
             {
                 case "Minimize":
-                    m_presenter.Restore();
+                    (m_window as MainWindow).Restore();
                     break;
                 case "ToTray":
                     H.NotifyIcon.WindowExtensions.Show(m_window);
-                    m_presenter.Restore();
+                    (m_window as MainWindow).Restore();
                     break;
                 case "Nothing":
                     break;
                 default:
-                    m_presenter.Restore();
+                    (m_window as MainWindow).Restore();
                     break;
             }
         }
@@ -1535,7 +1535,7 @@ namespace CollapseLauncher.Pages
             catch (OperationCanceledException)
             {
                 LogWriteLine($"{new string('=', barwidth)} GAME STOPPED {new string('=', barwidth)}", LogType.Warning, true);
-                m_presenter.Restore();
+                (m_window as MainWindow).Restore();
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -272,9 +272,9 @@ namespace CollapseLauncher.Pages
             catch (Exception) { }
         }
 
-        private void CarouselStopScroll(object sender, PointerRoutedEventArgs e) => CarouselToken.Cancel();
+        public void CarouselStopScroll(object sender = null, PointerRoutedEventArgs e = null) => CarouselToken.Cancel();
 
-        private void CarouselRestartScroll(object sender, PointerRoutedEventArgs e)
+        public void CarouselRestartScroll(object sender = null, PointerRoutedEventArgs e = null)
         {
             // Don't restart carousel if game is running and LoPrio is on
             if (!CurrentGameProperty.IsGameRunning || !GetAppConfigValue("LowerCollapsePrioOnGameLaunch").ToBool())
@@ -1934,7 +1934,7 @@ namespace CollapseLauncher.Pages
                     LogWriteLine($"Collapse process [PID {collapseProcess.Id}] priority is set to Below Normal, PriorityBoost is off, carousel is temporarily stopped", LogType.Default, true);
                 }
 
-                CarouselStopScroll(null, null);
+                CarouselStopScroll();
                 await proc.WaitForExitAsync();
 
                 using (Process collapseProcess = Process.GetCurrentProcess())
@@ -1943,7 +1943,7 @@ namespace CollapseLauncher.Pages
                     collapseProcess.PriorityClass = ProcessPriorityClass.Normal;
                     LogWriteLine($"Collapse process [PID {collapseProcess.Id}] priority is set to Normal, PriorityBoost is on, carousel is started", LogType.Default, true);
                 }
-                CarouselRestartScroll(null, null);
+                CarouselRestartScroll();
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/XAMLs/MainApp/TrayIcon.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/TrayIcon.xaml.cs
@@ -31,11 +31,11 @@ namespace CollapseLauncher
         private readonly string _popupHelp1 = Lang._Misc.Taskbar_PopupHelp1;
         private readonly string _popupHelp2 = Lang._Misc.Taskbar_PopupHelp2;
 
-        private readonly string _showApp = Lang._Misc.Taskbar_ShowApp;
-        private readonly string _hideApp = Lang._Misc.Taskbar_HideApp;
+        private readonly string _showApp     = Lang._Misc.Taskbar_ShowApp;
+        private readonly string _hideApp     = Lang._Misc.Taskbar_HideApp;
         private readonly string _showConsole = Lang._Misc.Taskbar_ShowConsole;
         private readonly string _hideConsole = Lang._Misc.Taskbar_HideConsole;
-        private readonly string _exitApp = Lang._Misc.Taskbar_ExitApp;
+        private readonly string _exitApp     = Lang._Misc.Taskbar_ExitApp;
 
         private readonly string _preview = Lang._Misc.BuildChannelPreview;
         private readonly string _stable = Lang._Misc.BuildChannelStable;
@@ -109,13 +109,13 @@ namespace CollapseLauncher
         /// <summary>
         /// Toggle console window visibility
         /// </summary>
-        public void ToggleConsoleVisibility()
+        public void ToggleConsoleVisibility(bool forceShow = false)
         {
             if (LauncherConfig.GetAppConfigValue("EnableConsole").ToBool())
             {
                 IntPtr consoleWindowHandle = InvokeProp.GetConsoleWindow();
                 if (InvokeProp.m_consoleHandle == IntPtr.Zero) return;
-                if (IsWindowVisible(consoleWindowHandle))
+                if (IsWindowVisible(consoleWindowHandle) && !forceShow)
                 {
                     LoggerConsole.DisposeConsole();
                     ConsoleTaskbarToggle.Text = _showConsole;
@@ -134,12 +134,12 @@ namespace CollapseLauncher
         /// <summary>
         /// Toggle main window visibility
         /// </summary>
-        public void ToggleMainVisibility()
+        public void ToggleMainVisibility(bool forceShow = false)
         {
             IntPtr mainWindowHandle = m_windowHandle;
             var    isVisible        = IsWindowVisible(mainWindowHandle);
 
-            if (isVisible)
+            if (isVisible && !forceShow)
             {
                 WindowExtensions.Hide(m_window);
                 MainTaskbarToggle.Text     = _showApp;
@@ -198,7 +198,7 @@ namespace CollapseLauncher
             {
                 if (!IsWindowVisible(consoleWindowHandle))
                 {
-                    LoggerConsole.AllocateConsole();
+                    ToggleConsoleVisibility(true);
                 }
                 //Stupid workaround for console window not showing up using SetForegroundWindow
                 //Basically do minimize then maximize action using ShowWindow 6->9 (nice)
@@ -208,7 +208,7 @@ namespace CollapseLauncher
             }
 
             if (!isMainWindowVisible)
-                ToggleMainVisibility();
+                ToggleMainVisibility(true);
             ShowWindow(mainWindowHandle, 9);
             SetForegroundWindow(mainWindowHandle);
         }
@@ -228,6 +228,19 @@ namespace CollapseLauncher
                 ConsoleTaskbarToggle.IsEnabled = false;
                 ConsoleTaskbarToggle.Text = _hideConsole;
             }
+            
+            // Force refresh all text based on their respective window state
+            IntPtr consoleWindowHandle = InvokeProp.GetConsoleWindow();
+            IntPtr mainWindowHandle    = m_windowHandle;
+            
+            bool isMainWindowVisible = IsWindowVisible(mainWindowHandle);
+            bool isConsoleVisible    = LauncherConfig.GetAppConfigValue("EnableConsole").ToBool() && IsWindowVisible(consoleWindowHandle);
+
+            if (isConsoleVisible) ConsoleTaskbarToggle.Text = _hideConsole;
+            else ConsoleTaskbarToggle.Text                  = _showConsole;
+
+            if (isMainWindowVisible) MainTaskbarToggle.Text = _hideApp;
+            else MainTaskbarToggle.Text                     = _showApp;
         }
         #endregion
     }

--- a/Hi3Helper.Core/Classes/Data/InvokeProp.cs
+++ b/Hi3Helper.Core/Classes/Data/InvokeProp.cs
@@ -155,7 +155,7 @@ namespace Hi3Helper
         public static extern bool SHGetPathFromIDList(IntPtr pidl, IntPtr pszPath);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, string lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, UIntPtr wParam, IntPtr lParam);
 
         [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetOpenFileName([In, Out] OpenFileName ofn);


### PR DESCRIPTION
Converge operations to `WM_SYSCOMMAND` and `WM_SHOWWINDOW` to prevent missing some events.
~Edit: `WM_SIZE` and `WM_SHOWWINDOW` now~
Edit: reverted

Move the "MinimizeToTray" function to WndProc to fix the issue that minimizing a window from the taskbar does not minimize to the tray.