### PR TITLE
Dispose the stream before deleting install package

### DIFF
--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -539,6 +539,9 @@ namespace CollapseLauncher.InstallManager.Base
                             deleteList.MoveTo(Path.Combine(_gamePath, $"deletefiles_{Path.GetFileNameWithoutExtension(asset.PathOutput)}.txt"), true);
                         }
 
+                        // Make sure that the Stream is getting disposed first
+                        stream?.Dispose();
+
                         // If the _canDeleteZip flag is true, then delete the zip
                         if (_canDeleteZip)
                         {


### PR DESCRIPTION
```
[Warn]  Failed while deleting file: D:\Games\CollapseLauncher\GICN\Genshin Impact Game\4ac3bc6fa573a0c57f5c096cc883aa5b_6304194074839243264.zip. Skipping!
System.IO.IOException: The process cannot access the file 'D:\Games\CollapseLauncher\GICN\Genshin Impact Game\4ac3bc6fa573a0c57f5c096cc883aa5b_6304194074839243264.zip' because it is being used by another process.
   at System.IO.FileSystem.DeleteFile(String fullPath)
   at System.IO.FileInfo.Delete()
   at CollapseLauncher.InstallManager.GameInstallPackage.DeleteFile(Int32 count)
```