### PR TITLE
Update Inno Setup Log file after update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "Hi3Helper.SharpHDiffPatch"]
 	path = Hi3Helper.SharpHDiffPatch
 	url = https://github.com/neon-nyan/Hi3Helper.SharpHDiffPatch
+[submodule "InnoSetupHelper/InnoSetupLogParser"]
+	path = InnoSetupHelper/InnoSetupLogParser
+	url = https://github.com/CollapseLauncher/InnoSetupLogParser

--- a/ClearCache.bat
+++ b/ClearCache.bat
@@ -17,5 +17,7 @@ echo 	Clearing HDiff cache
 rmdir /S /Q Hi3Helper.SharpHDiffPatch\Hi3Helper.SharpHDiffPatch\bin && rmdir /S /Q Hi3Helper.SharpHDiffPatch\Hi3Helper.SharpHDiffPatch\obj
 echo 	Clearing 2nd HDiff cache
 rmdir /S /Q Hi3Helper.SharpHDiffPatch\SharpHDiffPatch\bin && rmdir /S /Q Hi3Helper.SharpHDiffPatch\SharpHDiffPatch\obj
+echo 	Clearing InnoSetupHelper cache
+rmdir /S /Q InnoSetupHelper\bin && rmdir /S /Q InnoSetupHelper\obj
 echo 	Clearing 7z cache
 rmdir /S /Q Hi3Helper.Core\Classes\Data\Tools\SevenZipTool\SevenZipExtractor\SevenZipExtractor\bin && rmdir /S /Q Hi3Helper.Core\Classes\Data\Tools\SevenZipTool\SevenZipExtractor\SevenZipExtractor\obj

--- a/CollapseLauncher.sln
+++ b/CollapseLauncher.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SevenZipExtractor", "Hi3Hel
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hi3Helper.SharpHDiffPatch", "Hi3Helper.SharpHDiffPatch\Hi3Helper.SharpHDiffPatch\Hi3Helper.SharpHDiffPatch.csproj", "{3AD82793-E1E0-46C6-B239-703373CD11CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InnoSetupHelper", "InnoSetupHelper\InnoSetupHelper.csproj", "{21691306-8D30-4993-98A2-A5AE0712D81A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -72,6 +74,12 @@ Global
 		{3AD82793-E1E0-46C6-B239-703373CD11CF}.Publish|x64.Build.0 = Release|x64
 		{3AD82793-E1E0-46C6-B239-703373CD11CF}.Release|x64.ActiveCfg = Release|x64
 		{3AD82793-E1E0-46C6-B239-703373CD11CF}.Release|x64.Build.0 = Release|x64
+		{21691306-8D30-4993-98A2-A5AE0712D81A}.Debug|x64.ActiveCfg = Debug|x64
+		{21691306-8D30-4993-98A2-A5AE0712D81A}.Debug|x64.Build.0 = Debug|x64
+		{21691306-8D30-4993-98A2-A5AE0712D81A}.Publish|x64.ActiveCfg = Release|x64
+		{21691306-8D30-4993-98A2-A5AE0712D81A}.Publish|x64.Build.0 = Release|x64
+		{21691306-8D30-4993-98A2-A5AE0712D81A}.Release|x64.ActiveCfg = Release|x64
+		{21691306-8D30-4993-98A2-A5AE0712D81A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -111,6 +111,7 @@
 		<ProjectReference Include="..\Hi3Helper.Core\Hi3Helper.Core.csproj" />
 		<ProjectReference Include="..\Hi3Helper.Http\Hi3Helper.Http.csproj" />
 		<ProjectReference Include="..\Hi3Helper.SharpHDiffPatch\Hi3Helper.SharpHDiffPatch\Hi3Helper.SharpHDiffPatch.csproj" />
+		<ProjectReference Include="..\InnoSetupHelper\InnoSetupHelper.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -141,6 +142,7 @@
 			<TrimmableAssembly Include="Hi3Helper.EncTool" />
 			<TrimmableAssembly Include="Hi3Helper.Http" />
 			<TrimmableAssembly Include="Hi3Helper.SharpHDiffPatch" />
+			<TrimmableAssembly Include="InnoSetupHelper" />
 			<TrimmableAssembly Include="SevenZipExtractor" />
       
 			<!-- Additional assemblies -->

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -5,6 +5,8 @@ using Hi3Helper;
 using Hi3Helper.Http;
 using Hi3Helper.Preset;
 using Hi3Helper.Shared.ClassStruct;
+using Hi3Helper.Shared.Region;
+using InnoSetupHelper;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -641,10 +643,23 @@ namespace CollapseLauncher
             try
             {
                 string UpdateNotifFile = Path.Combine(AppDataFolder, "_NewVer");
+                string NeedInnoUpdateFile = Path.Combine(AppDataFolder, "_NeedInnoLogUpdate");
                 TypedEventHandler<InfoBar, object> ClickClose = new TypedEventHandler<InfoBar, object>((sender, args) =>
                 {
                     File.Delete(UpdateNotifFile);
                 });
+
+                // If the update was handled by squirrel and it needs Inno Setup Log file to get updated, then do the routine
+                if (File.Exists(NeedInnoUpdateFile))
+                {
+                    try
+                    {
+                        string InnoLogPath = Path.Combine(Path.GetDirectoryName(AppFolder), "unins000.dat");
+                        if (File.Exists(InnoLogPath)) InnoSetupLogUpdate.UpdateInnoSetupLog(InnoLogPath);
+                        File.Delete(NeedInnoUpdateFile);
+                    }
+                    catch { }
+                }
 
                 if (File.Exists(UpdateNotifFile))
                 {

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -658,7 +658,10 @@ namespace CollapseLauncher
                         if (File.Exists(InnoLogPath)) InnoSetupLogUpdate.UpdateInnoSetupLog(InnoLogPath);
                         File.Delete(NeedInnoUpdateFile);
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        LogWriteLine($"Something wrong while opening the \"unins000.dat\" or deleting the \"_NeedInnoLogUpdate\" file\r\n{ex}", LogType.Error, true);
+                    }
                 }
 
                 if (File.Exists(UpdateNotifFile))

--- a/CollapseLauncher/XAMLs/Updater/Classes/Updater.cs
+++ b/CollapseLauncher/XAMLs/Updater/Classes/Updater.cs
@@ -158,6 +158,7 @@ namespace CollapseLauncher
         public async Task FinishUpdate(bool NoSuicide = false)
         {
             string newVerTagPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "LocalLow", "CollapseLauncher", "_NewVer");
+            string needInnoLogUpdatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "LocalLow", "CollapseLauncher", "_NeedInnoLogUpdate");
 
             Status.status = string.Format(Lang._UpdatePage.UpdateStatus5 + $" {Lang._UpdatePage.UpdateMessage5}", NewVersionTag.VersionString);
             UpdateStatus();
@@ -166,6 +167,7 @@ namespace CollapseLauncher
             UpdateProgress();
 
             File.WriteAllText(newVerTagPath, NewVersionTag.VersionString);
+            File.WriteAllText(needInnoLogUpdatePath, NewVersionTag.VersionString);
 
             if (IsUseLegacyDownload)
             {

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -1297,6 +1297,12 @@
       "hi3helper.sharphdiffpatch": {
         "type": "Project"
       },
+      "innosetuphelper": {
+        "type": "Project",
+        "dependencies": {
+          "Hi3Helper.Core": "[1.0.0, )"
+        }
+      },
       "sevenzipextractor": {
         "type": "Project"
       }

--- a/InnoSetupHelper/InnoSetupHelper.csproj
+++ b/InnoSetupHelper/InnoSetupHelper.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<Platforms>x64</Platforms>
+		<DebugType>portable</DebugType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Hi3Helper.Core\Hi3Helper.Core.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/InnoSetupHelper/InnoSetupLogUpdate.cs
+++ b/InnoSetupHelper/InnoSetupLogUpdate.cs
@@ -29,7 +29,7 @@ namespace InnoSetupHelper
             "Hi3SEA", "Hi3Global", "Hi3TW", "Hi3KR", "Hi3CN", "Hi3JP", "BH3",
             "GIGlb", "GICN", "GenshinImpact", "YuanShen", "GIBilibili",
             "SRGlb", "SRCN", "StarRail", "HSRBilibili",
-            "ZZZGlb", "ZZZCN", "ZZZ"
+            "ZZZGlb", "ZZZCN", "ZZZBilibili" // Adding ZZZ for Bilibili (if that even exist lol)
 #if DEBUG
             // Hi3Helper.Http DLLs
             , "Hi3Helper.Http"

--- a/InnoSetupHelper/InnoSetupLogUpdate.cs
+++ b/InnoSetupHelper/InnoSetupLogUpdate.cs
@@ -1,0 +1,130 @@
+﻿using Hi3Helper;
+using Hi3Helper.EncTool.Parser.InnoUninstallerLog;
+using LibISULR;
+using LibISULR.Flags;
+using LibISULR.Records;
+using System;
+using System.IO;
+using System.Linq;
+using static Hi3Helper.Logger;
+
+namespace InnoSetupHelper
+{
+    public class InnoSetupLogUpdate
+    {
+        private static readonly string[] excludeDeleteFile = new string[]
+        {
+            // Generic Files
+#if DEBUG
+            "ApplyUpdate.",
+#else
+            "ApplyUpdate.exe",
+#endif
+            "config.ini",
+            "_Temp",
+            "unins00",
+            "unins000",
+
+            // Game Files (we added this in-case the user uses the same directory as the executable)
+            "Hi3SEA", "Hi3Global", "Hi3TW", "Hi3KR", "Hi3CN", "Hi3JP", "BH3",
+            "GIGlb", "GICN", "GenshinImpact", "YuanShen", "GIBilibili",
+            "SRGlb", "SRCN", "StarRail", "HSRBilibili",
+            "ZZZGlb", "ZZZCN", "ZZZ"
+#if DEBUG
+            // Hi3Helper.Http DLLs
+            , "Hi3Helper.Http"
+#endif
+        };
+
+        public static void UpdateInnoSetupLog(string path)
+        {
+            string directoryPath = Path.GetDirectoryName(path)!;
+            string searchValue = GetPathWithoutDriveLetter(directoryPath);
+
+            LogWriteLine($"[InnoSetupLogUpdate::UpdateInnoSetupLog()] Updating Inno Setup file located at: {path}", LogType.Default, true);
+            try
+            {
+                using (InnoUninstLog innoLog = InnoUninstLog.Load(path, true))
+                {
+                    // Always set the log to x64 mode
+                    innoLog.Header.IsLog64bit = true;
+
+                    // Clean up the existing file and directory records
+                    CleanUpInnoDirOrFilesRecord(innoLog, searchValue);
+
+                    // Try register the parent path
+                    RegisterDirOrFilesRecord(innoLog, directoryPath);
+
+                    // Save the Inno Setup log
+                    innoLog.Save(path);
+                    LogWriteLine($"[InnoSetupLogUpdate::UpdateInnoSetupLog()] Inno Setup file: {path} has been successfully updated!", LogType.Default, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"[InnoSetupLogUpdate::UpdateInnoSetupLog()] Inno Setup file: {path} was failed due to an error: {ex}", LogType.Warning, true);
+            }
+        }
+
+        private static string GetPathWithoutDriveLetter(string path)
+        {
+            int firstIndexOf = path.IndexOf('\\');
+            return firstIndexOf > -1 ? path.Substring(firstIndexOf + 1) : path;
+        }
+
+        private static void RegisterDirOrFilesRecord(InnoUninstLog innoLog, string pathToRegister)
+        {
+            DirectoryInfo currentDirectory = new DirectoryInfo(pathToRegister);
+            foreach (FileInfo fileInfo in currentDirectory.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
+            {
+                if (excludeDeleteFile.Any(x => x.IndexOf(fileInfo.FullName, StringComparison.OrdinalIgnoreCase) > -1)) continue;
+                fileInfo.IsReadOnly = false;
+                LogWriteLine($"[InnoSetupLogUpdate::RegisterDirOrFilesRecord()] Registering Inno Setup record: (DeleteFileRecord){fileInfo.FullName}", LogType.Default, true);
+                innoLog.Records.Add(DeleteFileRecord.Create(fileInfo.FullName));
+            }
+
+            foreach (DirectoryInfo subdirectories in currentDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly))
+            {
+                RegisterDirOrFilesRecord(innoLog, subdirectories.FullName);
+            }
+            LogWriteLine($"[InnoSetupLogUpdate::RegisterDirOrFilesRecord()] Registering Inno Setup record: (DeleteDirOrFilesRecord){pathToRegister}", LogType.Default, true);
+            innoLog.Records.Add(DeleteDirOrFilesRecord.Create(pathToRegister));
+        }
+
+        private static void CleanUpInnoDirOrFilesRecord(InnoUninstLog innoLog, string searchValue)
+        {
+            int index = 0;
+            do
+            {
+                BaseRecord baseRecord = innoLog.Records[index];
+                bool isRecordValid = false;
+                switch (baseRecord.Type)
+                {
+                    case RecordType.DeleteDirOrFiles:
+                        isRecordValid = IsInnoRecordContainsPath<DeleteDirOrFilesFlags>(baseRecord, searchValue)
+                                     && IsDeleteDirOrFilesFlagsValid((DeleteDirOrFilesRecord)baseRecord);
+                        LogWriteLine($"[InnoSetupLogUpdate::CleanUpInnoDirOrFilesRecord()] Removing outdated Inno Setup record: (DeleteDirOrFilesRecord){((DeleteDirOrFilesRecord)baseRecord).Paths[0]}", LogType.Default, true);
+                        break;
+                    case RecordType.DeleteFile:
+                        isRecordValid = IsInnoRecordContainsPath<DeleteFileFlags>(baseRecord, searchValue)
+                                     && IsDeleteFileFlagsValid((DeleteFileRecord)baseRecord);
+                        LogWriteLine($"[InnoSetupLogUpdate::CleanUpInnoDirOrFilesRecord()] Removing outdated Inno Setup record: (DeleteFileRecord){((DeleteFileRecord)baseRecord).Paths[0]}", LogType.Default, true);
+                        break;
+                }
+                if (isRecordValid)
+                {
+                    innoLog.Records.RemoveAt(index);
+                    continue;
+                }
+                ++index;
+            } while (index < innoLog.Records.Count);
+        }
+
+        private static bool IsDeleteDirOrFilesFlagsValid(DeleteDirOrFilesRecord record) => (record.Flags ^ (DeleteDirOrFilesFlags.IsDir | DeleteDirOrFilesFlags.DisableFsRedir)) == 0;
+        private static bool IsDeleteFileFlagsValid(DeleteFileRecord record) => (record.Flags & DeleteFileFlags.DisableFsRedir) != 0;
+        private static bool IsInnoRecordContainsPath<TFlags>(BaseRecord record, string searchValue)
+            where TFlags : Enum => ((BasePathListRecord<TFlags>)record)
+            .Paths[0]
+            .IndexOf(searchValue, StringComparison.OrdinalIgnoreCase) > -1;
+    }
+}


### PR DESCRIPTION
# What's changed?
This PR includes a change for updating the "Inno Setup Log"'s ``unins000.dat`` file, which is a manifest to list all the files to be removed on uninstalling the app.

Currently due to the nature of Collapse using Squirrel as its Update module and Inno Setup as its Installer for both Stable and Preview builds, all the updated files related with Collapse doesn't get registered in the ``unins000.dat`` file and making the uninstallation incomplete.

This PR also adding another submodule [**InnoSetupLogParser**](https://github.com/CollapseLauncher/InnoSetupLogParser/tree/main), which is a parser and modification tool for ``unins000.dat`` file. This submodule was initially created by [**preseverence**](https://github.com/preseverence/isulr) and has been modified to work on both Collapse and [**ApplyUpdate**](https://github.com/CollapseLauncher/ApplyUpdate).

This PR is to solve the issue mentioned in #345.