### PR TITLE
Preview 1.72.14 Pre-release Hotfix 

### DIFF
--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -96,6 +96,12 @@
           "Microsoft.WindowsAppSDK": "1.4.231115000"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "B3etT5XQ2nlWkZGO2m/ytDYrOmSsQG1XNBaM6ZYlX5Ch/tDrMFadr0/mK6gjZwaQc55g+5+WZMw4Cz3m8VEF7g=="
+      },
       "Microsoft.NETCore.Platforms": {
         "type": "Direct",
         "requested": "[8.0.0-preview.7.23375.6, )",

--- a/Hi3Helper.Core/packages.lock.json
+++ b/Hi3Helper.Core/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "B3etT5XQ2nlWkZGO2m/ytDYrOmSsQG1XNBaM6ZYlX5Ch/tDrMFadr0/mK6gjZwaQc55g+5+WZMw4Cz3m8VEF7g=="
+      },
       "Google.Protobuf": {
         "type": "Transitive",
         "resolved": "3.25.1",
@@ -23,6 +29,7 @@
       "hi3helper.http": {
         "type": "Project"
       }
-    }
+    },
+    "net8.0/win-x64": {}
   }
 }


### PR DESCRIPTION
# What's New? - 1.72.14
- **[Fix]** Fixed Double Empty issue on SevenZipExtractor that caused full crash
- **[Fix]** Fixed missing `subChanneID` and `channeID` required on `config.ini` file
  - This fix HSR `Distribution Error` when launching the game #350
- **[Fix]** Fixed Collapse not uninstalled correctly due to missing entries on `InnoSetup log files`
- **[Fix]** Fixed HI3 7.2 `CGMetadata` repair stating `NotFound` error
- **[Fix]** Fixed `PropVariant` issue with `SevenZipExtractor` submodule
- **[Imp]** Use the new `CollapseMetadata V2` on HI3 for smaller fetch and faster repair
- **[Imp]** Update SharpHDiffPatch submodule
- **[Imp]** Implement `plugin` API to fetch games hotfixes automatically (thanks @shatyuka !)
- **[Imp]** Add warning for HSR GameSettings for those who got the new Settings mechanics
  - The new settings save all game related settings into one registry key, similar to Genshin. While this is doable for us to implement, the early investigation revealed that the value of said registry is always nulled and something is indeed wrong with it. So we put a warning for those who got it that the behavior for Collapse' GSP for HSR might be unpredictable.
  - To get rid of the A/B testing that they do, you can try to reset the entire HSR registry key by deleting them in `HKCU/Software/Cognosphere`, find the one related to your game region and (backup first, then) delete the entire key (folder).
- **[Loc]** Sync translation from transifex