### PR TITLE
Preview 1.73.1 Release

### DIFF
--- a/Hi3Helper.Core/Lang/de_DE.json
+++ b/Hi3Helper.Core/Lang/de_DE.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "Nicht mehr anzeigen",
     "NotifNoNewNotifs": "Keine neuen Benachrichtigungen",
     "NavigationMenu": "Menü",
-    "NavigationUtilities":  "Werkzeuge"
+    "NavigationUtilities": "Werkzeuge"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "Acryl-Weichzeichner-Effekt verwenden",
     "EnableDownloadChunksMerging": "Heruntergeladene Paketstücke zusammenführen",
+    "UseExternalBrowser": "Always Use External Browser",
 
     "LowerCollapsePrioOnGameLaunch": "Lower Collapse process resource usage when a game is launched",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "Disables Carousel in main page and lower Collapse's priority to Below Normal",
@@ -444,6 +445,7 @@
     "Close": "Schließen",
     "UseCurrentDir": "Aktuelles Verzeichnis verwenden",
     "UseDefaultDir": "Standardverzeichnis verwenden",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "Verzeichnis auswählen",
     "Okay": "Okay",
     "OkaySad": "Okay ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "Ja, fortsetzen",
     "YesMigrateIt": "Ja, migriere es",
     "YesConvertIt": "Ja, konvertiere es",
+    "YesImReallySure": "Yes, I'm really sure!",
     "YesIHaveBeefyPC": "Ja, ich habe einen Starken Computer! ᕦ(ò_ó)ᕤ",
     "YesChangeLocation": "Ja, Ort ändern",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "Ignoriere es",
     "NoOtherLocation": "Weiter installieren",
     "NotSelected": "Nicht ausgewählt",
+    "ExtractAnyway": "Extract Anyway!",
 
     "LangNameENUS": "Englisch (US)",
     "LangNameJP": "Japanisch",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "Hide Collapse window to taskbar",
     "Taskbar_ShowConsole": "Show Collapse console window",
     "Taskbar_HideConsole": "Hide Collapse console window to taskbar",
-    "Taskbar_ExitApp": "Exit Collapse Launcher"
+    "Taskbar_ExitApp": "Exit Collapse Launcher",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "Keine fehlerhaften Dateien gefunden.",
     "ExtremeGraphicsSettingsWarnTitle": "Sehr hohe Voreinstellung gewählt!",
     "ExtremeGraphicsSettingsWarnSubtitle": "Du bist dabei, die Voreinstellung auf \"Sehr Hoch\" zu setzen!\nDie Voreinstellung \"Sehr hoch\" ist im Wesentlichen ein 2-fache Render-Skalierung mit MSAA aktiviert und ist SEHR UNOPTIMIERT!\n\nBist du sicher, dass du diese Einstellung verwenden willst?",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "Vorhandene Installation erkannt!",
     "ExistingInstallSubtitle": "Das Spiel wurde bereits installiert unter:\n\n{0}\n\nEs wird empfohlen das Spiel für bessere Unterstützung und Integration zum Collapse Launcher zu migrieren.\nDu kannst nach wie vor den offiziellen Launcher nutzen, um das Spiel zu starten.\n\nMöchtest du fortfahren?",
     "ExistingInstallBHI3LTitle": "Bestehende Installation über BetterHI3Launcher erkannt!",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "Der Umwandlungsprozess ist fehlgeschlagen :(\nBitte versuche, den Konvertierungsprozess erneut zu starten.",
     "InstallDataCorruptTitle": "Spielinstallation beschädigt",
     "InstallDataCorruptSubtitle": "Eine der heruntergeladenen Dateien ist beschädigt.\n\nServer Hash: {0}\nHeruntergeladener Hash: {1}\n\nMöchtest du versuchen, die Datei erneut herunterzuladen?",
+    "InstallCorruptDataAnywayTitle": "Extract Corrupted Data",
+    "InstallCorruptDataAnywaySubtitle1": "You're about to extract this corrupted data: ",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} bytes)",
+    "InstallCorruptDataAnywaySubtitle3": ". Keep in-mind that the extraction for this data might fail or renders the game fail to run.\r\n\r\nAre you sure to extract this data anyway?",
     "InstallDataDownloadResumeTitle": "Download fortsetzen?",
     "InstallDataDownloadResumeSubtitle": "Du hast bereits {0}/{1} des Spiels heruntergeladen.\n\nWillst du den Download fortsetzen?",
     "InsufficientDiskTitle": "Unzureichender Speicherplatz",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "Your current internet connection was detected as being 'Metered'! Continuing the update process may incur additional charges from your internet provider. Do you wish to proceed?",
 
     "ResetKbShortcutsTitle": "Are you sure you want to reset all shortcuts?",
-    "ResetKbShortcutsSubtitle": "This means every shortcut will be changed to their default key combination. \n\nDo you wish to proceed?\n\nNote: This has no impact on how Collapse operates and you can still change the combination of shortcuts by accessing the Keyboard Shortcuts menu."
+    "ResetKbShortcutsSubtitle": "This means every shortcut will be changed to their default key combination. \n\nDo you wish to proceed?\n\nNote: This has no impact on how Collapse operates and you can still change the combination of shortcuts by accessing the Keyboard Shortcuts menu.",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ Modifier - Shift, Control or Alt/Menu",
     "ChangeShortcut_Help3": "・ Key - Alphabetical (A to Z) or Tab",
     "ChangeShortcut_Help4": "You can choose any combination consisting of one value from each category, unless it is reserved by the system or is already being used."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Southeast Asia",
+    "Global": "Global",
+    "Mainland China": "Mainland China",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Korea",
+    "Japan": "Japan",
+    "Bilibili": "Bilibili"
   }
 }

--- a/Hi3Helper.Core/Lang/es_419.json
+++ b/Hi3Helper.Core/Lang/es_419.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "No mostrar de nuevo",
     "NotifNoNewNotifs": "No hay nuevas notificaciones",
     "NavigationMenu": "Menú",
-    "NavigationUtilities":  "Utilidades"
+    "NavigationUtilities": "Utilidades"
   },
 
   "_HomePage": {
@@ -445,6 +445,7 @@
     "Close": "Cerrar",
     "UseCurrentDir": "Usar directorio actual",
     "UseDefaultDir": "Usar directorio predeterminado",
+    "MoveToDifferentDir": "Mover a otra ubicación ",
     "LocateDir": "Ubicar Directorio",
     "Okay": "Okay",
     "OkaySad": "Okay ;-;)",
@@ -528,7 +529,12 @@
     "Taskbar_HideApp": "Ocultar ventana de Collapse en la barra de tareas",
     "Taskbar_ShowConsole": "Mostrar ventana de consola de Collapse",
     "Taskbar_HideConsole": "Ocultar ventana de consola de Collapse en la barra de tareas",
-    "Taskbar_ExitApp": "Salir de Collapse Launcher"
+    "Taskbar_ExitApp": "Salir de Collapse Launcher",
+
+    "LauncherNameOfficial": "Launcher Oficial ",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Nombre desconocido de Launcher)"
   },
 
   "_BackgroundNotification": {
@@ -568,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "No se encontraron archivos rotos.",
     "ExtremeGraphicsSettingsWarnTitle": "¡Preajuste Muy Alto Seleccionado!",
     "ExtremeGraphicsSettingsWarnSubtitle": "Estas por seleccionar la opción grafica \"Muy Alto\" \nEsta configuración prestablecida es básicamente 2x Escalado de renderizado con MSAA activado y NO ESTA OPTIMIZADO!\n\n¿Estas seguro que quieres usar esta configuración?",
+    "MigrateExistingMoveDirectoryTitle": "Moviendo la instalación existente para: {0}",
+    "MigrateExistingInstallChoiceTitle": "¡Se a detectado una instalación existente de {0} !",
+    "MigrateExistingInstallChoiceSubtitle1": "Tienes una instalación del juego usando {0} en esta ubicación:",
+    "MigrateExistingInstallChoiceSubtitle2": "Tienes la opción de mover los datos del juego a otra carpeta o seguir usando la misma. Es recomendado que uses la ubicación actual para asegurar que puedas seguir iniciando el juego con {0}.",
     "ExistingInstallTitle": "¡Instalación Existente Detectada!",
     "ExistingInstallSubtitle": "El juego ya ha sido instalado en:\n\n{0}\n\nSe recomienda migrar el juego a Collapse Launcher para un mejor soporte e integración.\nNo te preocupes, aún podrás usar el launcher oficial para iniciar el juego.\n\n¿Quieres continuar?",
     "ExistingInstallBHI3LTitle": "¡Instalación existente de BetterHI3Launcher detectada!",
@@ -638,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "¡Se detectó que tu conexión a internet actual es 'Medida'! Continuar con el proceso de actualización puede generar cargos adicionales por parte de tu proveedor de internet. ¿Deseas continuar?",
 
     "ResetKbShortcutsTitle": "¿Seguro de que quieres resetear todos los atajos?",
-    "ResetKbShortcutsSubtitle": "Esto significa que cada acceso directo se cambiará a su combinación de teclas predeterminada. \n\n¿Desea continuar?\n\nNota: Esto no afecta cómo funciona Collapse y aún puede cambiar la combinación de accesos directos accediendo al menú de Accesos directos del teclado."
+    "ResetKbShortcutsSubtitle": "Esto significa que cada acceso directo se cambiará a su combinación de teclas predeterminada. \n\n¿Desea continuar?\n\nNota: Esto no afecta cómo funciona Collapse y aún puede cambiar la combinación de accesos directos accediendo al menú de Accesos directos del teclado.",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "¡El Espacio Disponible en Disco: {0} es insuficiente!",
+    "OperationErrorDiskSpaceInsufficientMsg": "¡No tienes suficiente espacio libre para hacer el proceso en tu Disco {2}!\r\n\r\nEspacio Disponible: {0}\r\nEspacio Requerido: {1}\r\n\r\nPor favor, asegúrate que tienes suficiente espacio libre antes de seguir.",
+
+    "OperationWarningNotCancellableTitle": "¡Precaución: Esta operación NO SE PUEDE CANCELAR!",
+    "OperationWarningNotCancellableMsg1": "Deberías verificar que no tienes tareas pesadas corriendo en tu PC para evitar posibles problemas mientras el proceso se esté ejecutando. Recuerda que ",
+    "OperationWarningNotCancellableMsg2": "NO PUEDES CANCELAR EL PROCESO",
+    "OperationWarningNotCancellableMsg3": " mientras se está ejecutando!\r\n\r\nHace clic en \"",
+    "OperationWarningNotCancellableMsg4": "\" para iniciar el proceso, o \"",
+    "OperationWarningNotCancellableMsg5": "\" para cancelarlo."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moviendo: ",
+    "SpeedIndicatorTitle": "Velocidad: ",
+    "FileCountIndicatorTitle": "Archivos procesados:",
+    "LocateFolderSubtitle": "Selecciona la ubicación deseada para mover el archivo/carpeta.",
+    "ChoosePathTextBoxPlaceholder": "Elija la carpeta de destino...",
+    "ChoosePathButton": "Seleccionar Carpeta",
+    "ChoosePathErrorPathUnselected": "¡Por favor, Selecciona una carpeta antes de continuar!",
+    "ChoosePathErrorPathNotExist": "¡Esta ubicación no existe!",
+    "ChoosePathErrorPathNoPermission": "¡No tienes los permisos para acceder a esta carpeta! Por favor, selecciona otra ubicación."
   },
 
   "_InstallMgmt": {

--- a/Hi3Helper.Core/Lang/ja_JP.json
+++ b/Hi3Helper.Core/Lang/ja_JP.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "次回から表示しない",
     "NotifNoNewNotifs": "通知はありません",
     "NavigationMenu": "メニュー",
-    "NavigationUtilities":  "機能"
+    "NavigationUtilities": "機能"
   },
 
   "_HomePage": {
@@ -445,6 +445,7 @@
     "Close": "閉じる",
     "UseCurrentDir": "現在のディレクトリを使用",
     "UseDefaultDir": "既定のディレクトリを使用",
+    "MoveToDifferentDir": "別のディレクトリへ移動",
     "LocateDir": "ディレクトリ検索",
     "Okay": "オッケー",
     "OkaySad": "オッケー ;-;)",
@@ -528,7 +529,12 @@
     "Taskbar_HideApp": "Collapseメインウィンドウを最小化",
     "Taskbar_ShowConsole": "コンソールを表示",
     "Taskbar_HideConsole": "コンソールを最小化",
-    "Taskbar_ExitApp": "Collapseを終了"
+    "Taskbar_ExitApp": "Collapseを終了",
+
+    "LauncherNameOfficial": "公式ランチャー",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "（ランチャー不明）"
   },
 
   "_BackgroundNotification": {
@@ -568,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "壊れたファイルは見つかりませんでした。",
     "ExtremeGraphicsSettingsWarnTitle": "超すごい設定のプリセットが選択されました！",
     "ExtremeGraphicsSettingsWarnSubtitle": "超すごい設定プリセットを使用しようとしています！\n超すごい設定プリセットはデフォルトでMSAA有効・レンダリングスケール2倍で全く最適化されていません！\n\n本当にこの設定を使用しますか？",
+    "MigrateExistingMoveDirectoryTitle": "既存のインストールを移動させています：{0}",
+    "MigrateExistingInstallChoiceTitle": "{0}の既存のインストールを検出しました！",
+    "MigrateExistingInstallChoiceSubtitle1": "ゲームは既に{0}と紐づけされた状態で以下のディレクトリにインストールされています：",
+    "MigrateExistingInstallChoiceSubtitle2": "ゲームデータを別のディレクトリに移動するか、現在のディレクトリを既定のディレクトリとして使用するかを選択できます。{0}を使用してゲームを確実に起動できるように、現在のディレクトリを既定のディレクトリとして使用することをお勧めします。",
     "ExistingInstallTitle": "既存のインストールが検出されました！",
     "ExistingInstallSubtitle": "ゲームは次の場所に既にインストールされています:\r\n\r\n{0}\r\n\r\nゲームをCollapse Launcherに紐づけすることをお勧めします。\r\nゲームを紐づけしても公式ランチャーを使ってゲームを始めることができます。\r\n\r\n続行しますか？",
     "ExistingInstallBHI3LTitle": "BetterHi3Launcherの既存のインストールが検出されました！",
@@ -607,7 +617,7 @@
     "GameConfigBrokenTitle1": "ゲーム設定が破損しています",
     "GameConfigBrokenSubtitle1": "ランチャーのスコープ設定が壊れています。以前のゲームパスを手動で選択してください。",
     "GameConfigBrokenSubtitle2": "\r\nゲームの場所がランチャーの config.ini ファイルのパスと同じでないことを確認してください:\r\n\r\n{0}\r\n\r\n",
-    "GameConfigBrokenSubtitle3": "パスが同じ場合は、すべてのゲームファイルを別の場所に移動し、\"ディレクトリを指定\"をクリックしてパスを選択してください。",
+    "GameConfigBrokenSubtitle3": "パスが同じ場合は、すべてのゲームファイルを別の場所に移動し、\"ディレクトリ検索\"をクリックしてパスを選択してください。",
     "CookbookLocateTitle": "Cookbookファイルの指定",
     "CookbookLocateSubtitle1": "作業を始める前にダウンロードしたCookbookを指定してください。\r\nまだダウンロードしていない場合は、",
     "CookbookLocateSubtitle2": "ここをクリック",
@@ -638,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "現在のインターネット接続は「従量制」として検出されました。更新を続行すると、インターネットプロバイダーから追加料金が発生する場合があります。続行しますか?",
 
     "ResetKbShortcutsTitle": "本当にすべてのショートカットをリセットしますか？",
-    "ResetKbShortcutsSubtitle": "リセットすると、ショートカットのキー割り当てがデフォルトに戻ります。\n\n本当にリセットしますか？\n\n注：リセットしてもCollapseの動作には影響しません。ショートカット一覧から、またいつでもキー割り当てを変更できます。"
+    "ResetKbShortcutsSubtitle": "リセットすると、ショートカットのキー割り当てがデフォルトに戻ります。\n\n本当にリセットしますか？\n\n注：リセットしてもCollapseの動作には影響しません。ショートカット一覧から、またいつでもキー割り当てを変更できます。",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "ドライブの空き容量：{0}が不足しています！",
+    "OperationErrorDiskSpaceInsufficientMsg": " {2} ドライブに操作を実行するために必要な空き容量がありません！\r\n\r\n現在の空き容量：{0}\r\n必要な空き容量：{1}\r\n\r\n必要なディスク容量を確保したことを確認してから続行してください。",
+
+    "OperationWarningNotCancellableTitle": "警告：この操作は中断できないよ！",
+    "OperationWarningNotCancellableMsg1": "プロセスの実行中に発生する可能性のある問題を回避するために、コンピューター上で動作の重いタスクが実行されていないことを確認してください。この操作は",
+    "OperationWarningNotCancellableMsg2": "絶っっ対に中断できない",
+    "OperationWarningNotCancellableMsg3": "ことをご了承ください！\r\n\r\n\"",
+    "OperationWarningNotCancellableMsg4": "\"を押してプロセスを開始、\"",
+    "OperationWarningNotCancellableMsg5": "\"を押して操作をキャンセルします。"
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "移動中：",
+    "SpeedIndicatorTitle": "速度：",
+    "FileCountIndicatorTitle": "移動完了したファイル：",
+    "LocateFolderSubtitle": "ファイル/フォルダーの移動先を選択してください。",
+    "ChoosePathTextBoxPlaceholder": "移動先を選択してください…",
+    "ChoosePathButton": "移動先を選ぶ",
+    "ChoosePathErrorPathUnselected": "パスを選択してから続行してください！",
+    "ChoosePathErrorPathNotExist": "存在しないパスです！",
+    "ChoosePathErrorPathNoPermission": "その場所にアクセスする権限がありません！別の場所を選択してください！"
   },
 
   "_InstallMgmt": {

--- a/Hi3Helper.Core/Lang/ko_KR.json
+++ b/Hi3Helper.Core/Lang/ko_KR.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "다시 표시하지 않기",
     "NotifNoNewNotifs": "새로운 알림 없음",
     "NavigationMenu": "Menu",
-    "NavigationUtilities":  "Utilities"
+    "NavigationUtilities": "Utilities"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "아크릴 흐림 효과 사용",
     "EnableDownloadChunksMerging": "다운로드한 패키지 청크 병합",
+    "UseExternalBrowser": "Always Use External Browser",
 
     "LowerCollapsePrioOnGameLaunch": "게임이 실행됐을 때 Collapse 프로세스 리소스 사용량 감소",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "메인 페이지의 이미지 슬라이더 비활성화 및 Collapse의 우선순위를 보통 이하로 낮추기",
@@ -444,6 +445,7 @@
     "Close": "닫기",
     "UseCurrentDir": "현재 디렉터리 사용",
     "UseDefaultDir": "기본 디렉터리 사용",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "디렉터리 지정",
     "Okay": "알겠어요",
     "OkaySad": "알겠어요 ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "네, 다시 설정할게요",
     "YesMigrateIt": "네, 이동할게요",
     "YesConvertIt": "네, 변환할게요",
+    "YesImReallySure": "Yes, I'm really sure!",
     "YesIHaveBeefyPC": "네, 저는 강력한 컴퓨터를 가지고 있어요!",
     "YesChangeLocation": "네, 위치를 변경할게요",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "아니요, 무시할게요",
     "NoOtherLocation": "아니요, 계속 설치할게요",
     "NotSelected": "선택되지 않음",
+    "ExtractAnyway": "Extract Anyway!",
 
     "LangNameENUS": "영어 (미국)",
     "LangNameJP": "일본어",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "작업 표시줄에 Collapse 창 숨기기",
     "Taskbar_ShowConsole": "Collapse 콘솔 창 표시",
     "Taskbar_HideConsole": "작업 표시줄에 Collapse 콘솔 창 숨기기",
-    "Taskbar_ExitApp": "Collapse Launcher 종료"
+    "Taskbar_ExitApp": "Collapse Launcher 종료",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "손상된 파일을 찾을 수 없어요.",
     "ExtremeGraphicsSettingsWarnTitle": "매우 높은 설정 프리셋이 선택되었어요!",
     "ExtremeGraphicsSettingsWarnSubtitle": "설정 프리셋을 매우 높음으로 설정할려고 해요!\r\n매우 높음 설정 프리셋은 기본적으로 MSAA가 활성화되면 렌더 스케일이 2배가 되며 전혀 최적화되어있지 않아요! (NASA의 슈퍼컴퓨터를 가지고 있지 않다면 말이죠).\r\n\r\n이 설정을 사용하시겠어요?",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "기존 설치가 감지되었어요!",
     "ExistingInstallSubtitle": "게임이 다음 위치에 이미 설치되어 있어요:\r\n\r\n{0}\r\n\r\n게임을 Collapse Launcher로 이동하는 것을 추천드려요.\r\n게임을 이동하더라도 공식 런처를 사용하여 게임을 시작할 수 있어요.\r\n\r\n계속하시겠어요?",
     "ExistingInstallBHI3LTitle": "BetterHi3Launcher의 기존 설치가 감지되었어요!",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "변환 작업이 실패했어요! :(\n변환 작업을 다시 시작해 보세요.",
     "InstallDataCorruptTitle": "게임 설치 손상됨",
     "InstallDataCorruptSubtitle": "다운로드된 파일이 손상되었어요.\r\n\r\n서버 해시: {0}\r\n다운로드된 해시: {1}\r\n\r\n파일을 다시 다운로드하시겠어요?",
+    "InstallCorruptDataAnywayTitle": "Extract Corrupted Data",
+    "InstallCorruptDataAnywaySubtitle1": "You're about to extract this corrupted data: ",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} bytes)",
+    "InstallCorruptDataAnywaySubtitle3": ". Keep in-mind that the extraction for this data might fail or renders the game fail to run.\r\n\r\nAre you sure to extract this data anyway?",
     "InstallDataDownloadResumeTitle": "다운로드를 다시 시작하시겠어요?",
     "InstallDataDownloadResumeSubtitle": "이전에 게임의 {0}/{1}을(를) 다운로드했어요.\r\n\r\n다운로드를 다시 시작하시겠어요?",
     "InsufficientDiskTitle": "디스크 공간 부족",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "Your current internet connection was detected as being 'Metered'! Continuing the update process may incur additional charges from your internet provider. Do you wish to proceed?",
 
     "ResetKbShortcutsTitle": "Are you sure you want to reset all shortcuts?",
-    "ResetKbShortcutsSubtitle": "This means every shortcut will be changed to their default key combination. \n\nDo you wish to proceed?\n\nNote: This has no impact on how Collapse operates and you can still change the combination of shortcuts by accessing the Keyboard Shortcuts menu."
+    "ResetKbShortcutsSubtitle": "This means every shortcut will be changed to their default key combination. \n\nDo you wish to proceed?\n\nNote: This has no impact on how Collapse operates and you can still change the combination of shortcuts by accessing the Keyboard Shortcuts menu.",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ Modifier - Shift, Control or Alt/Menu",
     "ChangeShortcut_Help3": "・ Key - Alphabetical (A to Z) or Tab",
     "ChangeShortcut_Help4": "You can choose any combination consisting of one value from each category, unless it is reserved by the system or is already being used."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Southeast Asia",
+    "Global": "Global",
+    "Mainland China": "Mainland China",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Korea",
+    "Japan": "Japan",
+    "Bilibili": "Bilibili"
   }
 }

--- a/Hi3Helper.Core/Lang/pt_PT.json
+++ b/Hi3Helper.Core/Lang/pt_PT.json
@@ -4,7 +4,7 @@
   "Author": "gablm",
 
   "_StartupPage": {
-    "SelectLang": "Select your language",
+    "SelectLang": "Seleciona o teu idioma",
     "SelectLangDesc": "Please select your language to start this launcher for the first time!",
     "SelectWindowSize": "Select your preferred window size",
     "SelectCDN": "Select your preferred CDN",
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "Não mostrar novamente",
     "NotifNoNewNotifs": "Sem novas notificações",
     "NavigationMenu": "Menu",
-    "NavigationUtilities":  "Utilitários"
+    "NavigationUtilities": "Utilitários"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "Usar efeito de desfoque acrílico",
     "EnableDownloadChunksMerging": "Combinar porções de pacotes descarregados",
+    "UseExternalBrowser": "Always Use External Browser",
 
     "LowerCollapsePrioOnGameLaunch": "Diminuir o uso de recursos do Collapse quando um jogo for iniciado",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "Desativa o carrousel da página principal e diminui a prioridade do Collapse para \"Abaixo do normal\" ",
@@ -444,6 +445,7 @@
     "Close": "Fechar",
     "UseCurrentDir": "Usar pasta atual",
     "UseDefaultDir": "Usar predefinição",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "Localizar pasta",
     "Okay": "Okay",
     "OkaySad": "Okay ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "Sim, realocar",
     "YesMigrateIt": "Sim, migrar",
     "YesConvertIt": "Sim, converter",
+    "YesImReallySure": "Yes, I'm really sure!",
     "YesIHaveBeefyPC": "Sim, tenho um PC bom!",
     "YesChangeLocation": "Sim, mudar localização",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "Não, ignorar",
     "NoOtherLocation": "Não, continuar a instalar",
     "NotSelected": "Não selecionado",
+    "ExtractAnyway": "Extract Anyway!",
 
     "LangNameENUS": "Inglês (EUA)",
     "LangNameJP": "Japonês",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "Esconder janela do Collapse na gaveta de aplicações",
     "Taskbar_ShowConsole": "Mostrar janela da consola do Collapse",
     "Taskbar_HideConsole": "Esconder janela da consola do Collapse na gaveta de aplicações",
-    "Taskbar_ExitApp": "Fechar o Collapse Launcher"
+    "Taskbar_ExitApp": "Fechar o Collapse Launcher",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "Nenhum ficheiro está corrompido.",
     "ExtremeGraphicsSettingsWarnTitle": "Definição \"Muito alto\" selecionada!",
     "ExtremeGraphicsSettingsWarnSubtitle": "Estás prestes a mudar esta definição para \"Muito alto\"!\r\nLembra-te que a definição \"Muito alto\" é basicamente 2x a escala de renderização com o MSAA ativo e NÃO É OTIMIZADO! (a não ser que tenhas um Super PC da NASA para rodá-lo).\r\n\r\nTens a certeza que queres usar esta definição?",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "Instalação existente foi detetada!",
     "ExistingInstallSubtitle": "O jogo já está instalado nesta localização:\r\n\r\n{0}\r\n\r\nÉ recomendado migrá-lo para o Collapse Launcher para uma melhor integração e suporte.\r\nNo entanto, ainda poderás usar o Launcher oficial para iniciar o jogo.\r\n\r\nQueres continuar?",
     "ExistingInstallBHI3LTitle": "Instalação existente no BetterHI3Launcher detetada!",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "Desculpa mas, o processo de conversão falhou! :(\nPor favor tenta começar de novo o processo de conversão.",
     "InstallDataCorruptTitle": "Oops! A instalação do jogo está corrompida",
     "InstallDataCorruptSubtitle": "Um dos ficheiros descarregados está corrompido.\r\n\r\nServer Hash: {0}\r\nDownload Hash: {1}\r\n\r\nQueres descarregar o ficheiro novamente?",
+    "InstallCorruptDataAnywayTitle": "Extract Corrupted Data",
+    "InstallCorruptDataAnywaySubtitle1": "You're about to extract this corrupted data: ",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} bytes)",
+    "InstallCorruptDataAnywaySubtitle3": ". Keep in-mind that the extraction for this data might fail or renders the game fail to run.\r\n\r\nAre you sure to extract this data anyway?",
     "InstallDataDownloadResumeTitle": "Retomar descarregamento?",
     "InstallDataDownloadResumeSubtitle": "Já baixaste {0}/{1} do jogo anteriormente.\r\n\r\nQueres retomar?",
     "InsufficientDiskTitle": "Espaço de disco insuficiente",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "A tua conexão à internet atual foi detectada como 'tráfego limitado'! Continuar o processo de atualização poderá resultar em taxas suplementares por parte da tua operadora. Queres continuar?",
 
     "ResetKbShortcutsTitle": "Tens a certeza que queres redefinir todos os atalhos?",
-    "ResetKbShortcutsSubtitle": "Isto significa que todos os atalhos irão ser mudados para a sua combinação predefinida.\n\nQueres continuar?\n\nNota: Isto não impacta o modo como o Collapse opera e poderás alterar os atalhos a qualquer momento através do menu \"Atalhos de teclado\"."
+    "ResetKbShortcutsSubtitle": "Isto significa que todos os atalhos irão ser mudados para a sua combinação predefinida.\n\nQueres continuar?\n\nNota: Isto não impacta o modo como o Collapse opera e poderás alterar os atalhos a qualquer momento através do menu \"Atalhos de teclado\".",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ Modificador - Shift, Control ou Alt/Menu",
     "ChangeShortcut_Help3": "・ Tecla - Alfabética (A a Z) ou Tab",
     "ChangeShortcut_Help4": "Podes escolher qualquer combinação que consista de um valor de cada uma das categorias, a não ser que esteja reservada para o sistema ou já estiver a ser usada."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Sudeste asiático",
+    "Global": "Global",
+    "Mainland China": "China continental",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Coreia",
+    "Japan": "Japão",
+    "Bilibili": "Bilibili"
   }
 }

--- a/Hi3Helper.Core/Lang/ru_RU.json
+++ b/Hi3Helper.Core/Lang/ru_RU.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "Больше не показывать",
     "NotifNoNewNotifs": "No new notifications",
     "NavigationMenu": "Menu",
-    "NavigationUtilities":  "Utilities"
+    "NavigationUtilities": "Utilities"
   },
 
   "_HomePage": {
@@ -401,13 +401,14 @@
     "Disclaimer3": "и полностью open-source, любой вклад приветствуется.",
 
     "DiscordBtn1": "Присоединяйтесь к нам в Discord!",
-    "DiscordBtn2": "Honkai Impact 3rd Discord",
+    "DiscordBtn2": "Дискорд Honkai Impact 3rd",
     "DiscordBtn3": "Официальный Discord сервер Collapse!",
 
     "AppChangeReleaseChannel": "Изменить на {0} канал релиза",
 
     "EnableAcrylicEffect": "Использовать эффект акрилового размытия",
     "EnableDownloadChunksMerging": "Merge Downloaded Package Chunks",
+    "UseExternalBrowser": "Использовать внешний браузер",
 
     "LowerCollapsePrioOnGameLaunch": "Уменьшение использования ресурсов процесса Collapse при запуске игры",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "Disables Carousel in main page and lower Collapse's priority to Below Normal",
@@ -416,7 +417,7 @@
     "KbShortcuts_ShowBtn": "Показать сочетания",
     "KbShortcuts_ResetBtn": "Восстановить по умолчанию",
 
-    "AppBehavior_Title": "App Behavior",
+    "AppBehavior_Title": "Поведение приложения",
     "AppBehavior_PostGameLaunch": "После запуска игры",
     "AppBehavior_PostGameLaunch_Minimize": "Свернуть",
     "AppBehavior_PostGameLaunch_ToTray": "Скрыть в меню скрытых значков",
@@ -444,6 +445,7 @@
     "Close": "Закрыть",
     "UseCurrentDir": "Использовать текущую директорию",
     "UseDefaultDir": "Использовать директорию по умолчанию",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "Определить директорию",
     "Okay": "Хорошо",
     "OkaySad": "Окей ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "Да, продолжить",
     "YesMigrateIt": "Да, переместить",
     "YesConvertIt": "Да, преобразовать",
+    "YesImReallySure": "Да, я действительно уверен!",
     "YesIHaveBeefyPC": "Да, у меня мощный ПК! ᕦ(ò_ó)ᕤ",
     "YesChangeLocation": "Да, изменить местоположение",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "Игнорировать",
     "NoOtherLocation": "Продолжить установку",
     "NotSelected": "Не выбрано",
+    "ExtractAnyway": "Распаковать в любом случае! ",
 
     "LangNameENUS": "Английский (США)",
     "LangNameJP": "Японский",
@@ -504,7 +508,7 @@
     "CDNDescription_Cloudflare": "Зеркало официального (основного) репозитория, развернутое на Cloudflare R2.",
     "CDNDescription_Bitbucket": "Зеркало официального (основного) репозитория, развернутое на Bitbucket.",
 
-    "LocateExecutable": "Locate Executable",
+    "LocateExecutable": "Найти исполняемый файл",
     "OpenDownloadPage": "Открыть страницу загрузки",
 
     "DiscordRP_Play": "Играет в",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "Скрыть окно Collapse на панель задач",
     "Taskbar_ShowConsole": "Показать окно консоли Collapse",
     "Taskbar_HideConsole": "Скрыть окно консоли Collapse на панель задач",
-    "Taskbar_ExitApp": "Выйти из Collapse Лаунчера"
+    "Taskbar_ExitApp": "Выйти из Collapse Лаунчера",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "Поврежденных файлов не найдено.",
     "ExtremeGraphicsSettingsWarnTitle": "Пресет \"Очень высокие\" выбран!",
     "ExtremeGraphicsSettingsWarnSubtitle": "Вы собираетесь установить пресет \"Очень высокие\"!\nОчень высокими настройками, по сути, является 2x масштаб визуализации с включенным MSAA, что ОЧЕНЬ ПЛОХО ОПТИМИЗИРОВАНО!\n\nВы уверены, что хотите использовать эту настройку?",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "Обнаружена существующая установка!",
     "ExistingInstallSubtitle": "Игра уже установлена в:\n\n{0}\n\nРекомендуется перенести игру на Collapse Launcher для лучшей поддержки и интеграции.\nНе беспокойтесь, Вы все еще можете использовать официальный лаунчер для начала игры.\n\nЖелаете продолжить?",
     "ExistingInstallBHI3LTitle": "Обнаружена существующая установка через BetterHI3Launcher!",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "Процесс преобразования не удался! :(\nПожалуйста, попробуйте инициировать процесс снова.",
     "InstallDataCorruptTitle": "Сбой установки игры",
     "InstallDataCorruptSubtitle": "Один из загруженных файлов поврежден.\n\nСерверная хэш-сумма: {0}\nЗагруженная хэш-сумма: {1}\n\nХотите попробовать повторно загрузить файл?",
+    "InstallCorruptDataAnywayTitle": "Распаковать повреждённые данные",
+    "InstallCorruptDataAnywaySubtitle1": "Вы собираетесь распаковать эти поврежденные данные:",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} байта)",
+    "InstallCorruptDataAnywaySubtitle3": ". Имейте в виду, что распаковка этих данных может закончиться неудачей или привести к тому, что игра не запустится.\n\nУверены что распаковать эти данные все равно нужно?",
     "InstallDataDownloadResumeTitle": "Возобновить загрузку?",
     "InstallDataDownloadResumeSubtitle": "Ранее вы скачали {0}/{1} игры.\n\nХотите возобновить загрузку?",
     "InsufficientDiskTitle": "Недостаточно места на диске",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "Ваше текущее подключение к Интернету было определено как \"Лимитное\"! Продолжение процесса обновления может повлечь за собой дополнительную плату со стороны вашего интернет-провайдера. Хотите ли вы продолжить?",
 
     "ResetKbShortcutsTitle": "Вы уверены что хотите сбросить все сочетания?",
-    "ResetKbShortcutsSubtitle": "Это означает, что каждое сочетание будет изменено на комбинацию клавиш по умолчанию.\n\nВы хотите продолжить?\n\nПримечание: Это никак не повлияет на работу Collapse, и вы по-прежнему сможете изменить комбинацию клавиш, зайдя в меню \"Сочетания клавиш\"."
+    "ResetKbShortcutsSubtitle": "Это означает, что каждое сочетание будет изменено на комбинацию клавиш по умолчанию.\n\nВы хотите продолжить?\n\nПримечание: Это никак не повлияет на работу Collapse, и вы по-прежнему сможете изменить комбинацию клавиш, зайдя в меню \"Сочетания клавиш\".",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -752,50 +791,50 @@
     "UpdateCountdownMessage2": "(Нажмите",
     "UpdateCountdownMessage3": "чтобы отменить обратный отсчёт)",
 
-    "ApplyUpdateTitle1": "We're updating",
+    "ApplyUpdateTitle1": "Мы обновляем",
     "ApplyUpdateTitle2": "Collapse Launcher",
-    "ApplyUpdateCDNSelectorTitle": "Select your CDN for update",
-    "ApplyUpdateCDNSelectorSubtitle": "Select the CDN options and click \"{0}\" to start the update!",
+    "ApplyUpdateCDNSelectorTitle": "Выберите CDN для обновления",
+    "ApplyUpdateCDNSelectorSubtitle": "Выберите CDN и нажмите \"{0}\" для начала обновления!",
     "ApplyUpdateCDNSelectorSubtitleCount": "The CDN will be automatically selected in: {0}",
-    "ApplyUpdateUpdateNowBtn": "Update Now!",
+    "ApplyUpdateUpdateNowBtn": "Обновить сейчас!",
 
-    "ApplyUpdateUpdateVersionTitle": "Update:",
-    "ApplyUpdateUpdateChannelTitle": "Channel:",
-    "ApplyUpdateUpdateChannelSubtitlePlaceholder": "Unknown",
-    "ApplyUpdateUpdateStatusTitle": "Status:",
+    "ApplyUpdateUpdateVersionTitle": "Обновление:",
+    "ApplyUpdateUpdateChannelTitle": "Канал:",
+    "ApplyUpdateUpdateChannelSubtitlePlaceholder": "Неизвестный",
+    "ApplyUpdateUpdateStatusTitle": "Статус:",
     "ApplyUpdateMiscIdle": "Idle",
     "ApplyUpdateMiscNone": "None",
     "ApplyUpdateVersionSeparator": "to",
 
-    "ApplyUpdateErrCollapseRunTitle": "Please close Collapse before applying the update!",
-    "ApplyUpdateErrCollapseRunSubtitle": "Waiting for Collapse to close...",
-    "ApplyUpdateErrReleaseFileNotFoundTitle": "ERROR:\r\n\"release\" file doesn't have \"stable\" or \"preview\" string in it",
-    "ApplyUpdateErrReleaseFileNotFoundSubtitle": "Please check your \"release\" file and try again.",
+    "ApplyUpdateErrCollapseRunTitle": "Пожалуйста, закройте Collapse перед применением обновления!",
+    "ApplyUpdateErrCollapseRunSubtitle": "Ждем закрытия Collapse...",
+    "ApplyUpdateErrReleaseFileNotFoundTitle": "ОШИБКА:\nВ файле \"release\" нет строки \"stable\" или \"preview\"",
+    "ApplyUpdateErrReleaseFileNotFoundSubtitle": "Пожалуйста, проверьте файл \"release\" и повторите попытку.",
 
-    "ApplyUpdateDownloadSizePlaceholder": "- B / - B",
-    "ApplyUpdateDownloadSpeed": "{0}/s",
-    "ApplyUpdateDownloadSpeedPlaceholder": "- B/s",
-    "ApplyUpdateDownloadTimeEst": "{0:%h}h{0:%m}m{0:%s}s left",
-    "ApplyUpdateDownloadTimeEstPlaceholder": "--h--m--s left",
+    "ApplyUpdateDownloadSizePlaceholder": "- Б / - Б",
+    "ApplyUpdateDownloadSpeed": "{0}/с",
+    "ApplyUpdateDownloadSpeedPlaceholder": "- Б/с",
+    "ApplyUpdateDownloadTimeEst": "{0:%h}ч{0:%m}м{0:%s}с осталось",
+    "ApplyUpdateDownloadTimeEstPlaceholder": "--ч--м--с осталось",
 
-    "ApplyUpdateTaskLegacyVerFoundTitle": "A previous legacy installation of Collapse v{0} detected!",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle1": "We detected that you have a legacy Collapse v{0} installed on your PC. ",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle2": "The updater needs to clean-up all the old files inside its directory.\r\n",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle3": "Please make sure you don't have any important files inside of the Collapse directory or it will be COMPLETELY WIPED OUT!",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle4": "\r\n\r\nClick \"Yes\" to proceed or \"No\" to cancel.",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle5": "Click \"Yes\" once again to confirm.",
-    "ApplyUpdateTaskLegacyCleanupCount": "Clean-up process will be started in {0}...",
-    "ApplyUpdateTaskLegacyDeleting": "Deleting: {0}...",
+    "ApplyUpdateTaskLegacyVerFoundTitle": "Обнаружена предыдущая установка Collapse v{0}!",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle1": "Мы обнаружили, что на вашем компьютере установлена старая версия Collapse v{0}.",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle2": "Программа обновления должна очистить все старые файлы в своей папке.\n",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle3": "Убедитесь, что в папке Collapse нет важных файлов, иначе они будут потеряны НАВСЕГДА!",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle4": "\n\nНажмите \"Да\" для продолжения или \"Нет\" для отмены.",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle5": "Нажмите \"Да\" ещё раз для подтверждения.",
+    "ApplyUpdateTaskLegacyCleanupCount": "Очистка будет запущена через {0}...",
+    "ApplyUpdateTaskLegacyDeleting": "Удаление: {0}...",
 
-    "ApplyUpdateTaskDownloadingPkgTitle": "Downloading package",
-    "ApplyUpdateTaskExtractingPkgTitle": "Extracting package",
-    "ApplyUpdateTaskRemoveOldPkgTitle": "Removing old package",
-    "ApplyUpdateTaskMovingExtractFileTitle": "Moving extracted files",
+    "ApplyUpdateTaskDownloadingPkgTitle": "Загрузка пакета",
+    "ApplyUpdateTaskExtractingPkgTitle": "Распаковка пакета",
+    "ApplyUpdateTaskRemoveOldPkgTitle": "Удаление старых пакетов",
+    "ApplyUpdateTaskMovingExtractFileTitle": "Перемещение распакованных файлов",
 
-    "ApplyUpdateTaskLauncherUpdatedTitle": "Launcher has been updated to: {0}!",
-    "ApplyUpdateTaskLauncherUpdatedSubtitle": "Launching Collapse in {0}...",
+    "ApplyUpdateTaskLauncherUpdatedTitle": "Лаунчер был обновлен до: {0}!",
+    "ApplyUpdateTaskLauncherUpdatedSubtitle": "Запуск Collapse {0}...",
 
-    "ApplyUpdateTaskError": "ERROR:\r\nError occurred while applying update!\r\n{0}"
+    "ApplyUpdateTaskError": "ОШИБКА:\nПроизошла ошибка при применении обновления!\n{0}"
   },
 
   "_AppNotification": {
@@ -922,7 +961,7 @@
     "Graphics_TeamPageBackground": "Фон экрана настройки отряда меняется в зависимости от текущего местоположения",
     "Graphics_GlobalIllumination": "Общее освещение",
     "Graphics_GlobalIllumination_Help1": "Только на поддерживаемом оборудовании!",
-    "Graphics_GlobalIllumination_Help2": "More information (en)",
+    "Graphics_GlobalIllumination_Help2": "Больше информации (en)",
     "Graphics_HDR": "HDR",
     "Graphics_HDR_Enable": "Включить HDR",
     "Graphics_HDR_NotSupported1": "Ваш дисплей не поддерживает HDR",
@@ -947,7 +986,7 @@
     "SpecHigh": "Высокое",
     "SpecVeryHigh": "Очень высокое",
     "SpecExtreme": "Ультра",
-    "SpecPartiallyOff": "Partially Off",
+    "SpecPartiallyOff": "Частично",
 
     "ApplyBtn": "Применить настройки",
     "SettingsApplied": "Изменения сохранены!",
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ Модификатор - Shift, Control или Alt/Menu",
     "ChangeShortcut_Help3": "・ Клавиша - Алфавит (от А до Я) или Tab",
     "ChangeShortcut_Help4": "Вы можете выбрать любую комбинацию, состоящую из одного значения из каждой категории, если только оно не зарезервировано системой или уже используется."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Юго-Восточной Азии",
+    "Global": "Глобальный",
+    "Mainland China": "Материкового Китая",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Кореи",
+    "Japan": "Японии",
+    "Bilibili": "Bilibili"
   }
 }

--- a/Hi3Helper.Core/Lang/th_TH.json
+++ b/Hi3Helper.Core/Lang/th_TH.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "ไม่ต้องแสดงอีก",
     "NotifNoNewNotifs": "ไม่มีการแจ้งเตือนใหม่ในขณะนี้",
     "NavigationMenu": "เมนู",
-    "NavigationUtilities":  "ยูทิลิตี้"
+    "NavigationUtilities": "ยูทิลิตี้"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "ใช้งานเบลอแบบ Acrylic",
     "EnableDownloadChunksMerging": "รวมแพ็คเกจที่ดาวน์โหลด",
+    "UseExternalBrowser": "Always Use External Browser",
 
     "LowerCollapsePrioOnGameLaunch": "ลดการใช้ทรัพยากรของ Collapse ลงเมื่อเกมถูกเปิดใช้งาน",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "ปิดการใช้งาน Carousel ในหน้าหลักและลดลำดับการยุติของ Collapse เป็น Below Normal",
@@ -444,6 +445,7 @@
     "Close": "ปิด",
     "UseCurrentDir": "ใช้ไดเรกทอรีปัจจุบัน",
     "UseDefaultDir": "ใช้ไดเรกทอรีเริ่มต้น",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "ค้นหาไดเรกทอรี",
     "Okay": "ตกลง",
     "OkaySad": "ตกลง ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "ยืนยัน, ดำเดินการต่อ",
     "YesMigrateIt": "ยืนยัน, ย้ายข้อมูล",
     "YesConvertIt": "ยืนยัน, แปลงข้อมูล",
+    "YesImReallySure": "Yes, I'm really sure!",
     "YesIHaveBeefyPC": "ยืนยัน, ฉันมีคอมที่โครตแรง! ᕦ(ò_ó)ᕤ",
     "YesChangeLocation": "ยืนยัน, เปลี่ยนตำแหน่ง",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "ละเว้น",
     "NoOtherLocation": "ทำการติดตั้งต่อไป",
     "NotSelected": "ไม่ได้เลือก",
+    "ExtractAnyway": "Extract Anyway!",
 
     "LangNameENUS": "ภาษาอังกฤษ (สหรัฐฯ)",
     "LangNameJP": "ภาษาญี่ปุ่น",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "ซ่อนหน้าต่างยุบไปที่ทาสก์บาร์",
     "Taskbar_ShowConsole": "แสดงหน้าต่างคอนโซลยุบ",
     "Taskbar_HideConsole": "ซ่อนหน้าต่างคอนโซลยุบไปที่ทาสก์บาร์",
-    "Taskbar_ExitApp": "ออกจาก Collapse Launcher"
+    "Taskbar_ExitApp": "ออกจาก Collapse Launcher",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "ไม่พบไฟล์ที่เสียหาย",
     "ExtremeGraphicsSettingsWarnTitle": "เลือกพรีเซ็ตการตั้งค่า สูง!",
     "ExtremeGraphicsSettingsWarnSubtitle": "คุณกำลังจะตั้งค่าพรีเซ็ตเป็นสูงมาก!\nค่าพรีเซ็ตที่สูงมากนั้นโดยพื้นฐานแล้วจะเป็นการเรนเดอร์สเกล 2x พร้อมเปิดใช้งาน MSAA และไม่แนะนำเป็นอย่างมาก!\n\nคุณแน่ใจหรือไม่ว่าต้องการใช้การตั้งค่านี้",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "ตรวจพบการติดตั้ง!",
     "ExistingInstallSubtitle": "เกมได้รับการติดตั้งแล้วที่:\n\n{0}\n\nขอแนะนำให้ย้ายเกมไปยัง Collapse Launcher เพื่อการรองรับและปรับแต่งที่ดียิ่งขึ้น\nมั่นใจได้ว่าคุณยังคงสามารถใช้ Official Launcher เพื่อเริ่มเกมได้\n\nคุณต้องการดำเนินการต่อหรือไม่?",
     "ExistingInstallBHI3LTitle": "ตรวจพบการติดตั้งผ่าน BetterHI3Launcher!",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "กระบวนการแปลงล้มเหลว! :(\nโปรดลองเริ่มกระบวนการแปลงอีกครั้ง.",
     "InstallDataCorruptTitle": "การติดตั้งเกมเสียหาย",
     "InstallDataCorruptSubtitle": "ไฟล์ที่ดาวน์โหลดมาไฟล์มีการเสียหาย\n\nแฮชของเซิร์ฟเวอร์: {0}\nแฮชที่ดาวน์โหลด: {1}\n\nคุณต้องการลองดาวน์โหลดไฟล์อีกครั้งหรือไม่",
+    "InstallCorruptDataAnywayTitle": "Extract Corrupted Data",
+    "InstallCorruptDataAnywaySubtitle1": "You're about to extract this corrupted data: ",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} bytes)",
+    "InstallCorruptDataAnywaySubtitle3": ". Keep in-mind that the extraction for this data might fail or renders the game fail to run.\r\n\r\nAre you sure to extract this data anyway?",
     "InstallDataDownloadResumeTitle": "ดาวน์โหลดต่อ?",
     "InstallDataDownloadResumeSubtitle": "คุณได้ดาวน์โหลด {0}/{1} ของเกมก่อนหน้านี้\n\nคุณต้องการดาวน์โหลดต่อหรือไม่?",
     "InsufficientDiskTitle": "พื้นที่เก็บข้อมูลไม่เพียงพอ",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "การเชื่อมต่ออินเทอร์เน็ตปัจจุบันของคุณถูกตรวจพบว่าเป็น 'ถูกจำกัด'! การดำเนินการอัปเดตต่ออาจมีค่าใช้จ่ายเพิ่มเติมจากผู้ให้บริการอินเทอร์เน็ตของคุณ คุณต้องการดำเนินการต่อหรือไม่?",
 
     "ResetKbShortcutsTitle": "คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ตทางลัดทั้งหมด?",
-    "ResetKbShortcutsSubtitle": "ซึ่งหมายความว่าทุกทางลัดจะถูกเปลี่ยนเป็นคีย์ค่าเริ่มต้น. \n\nคุณต้องการดำเนินการต่อหรือไม่?\n\nหมายเหตุ: สิ่งนี้ไม่มีผลกระทบต่อวิธีการทำงานของ Collapse และคุณยังคงสามารถเปลี่ยนชุดทางลัดได้โดยเข้าไปที่เมนูแป้นพิมพ์ลัด."
+    "ResetKbShortcutsSubtitle": "ซึ่งหมายความว่าทุกทางลัดจะถูกเปลี่ยนเป็นคีย์ค่าเริ่มต้น. \n\nคุณต้องการดำเนินการต่อหรือไม่?\n\nหมายเหตุ: สิ่งนี้ไม่มีผลกระทบต่อวิธีการทำงานของ Collapse และคุณยังคงสามารถเปลี่ยนชุดทางลัดได้โดยเข้าไปที่เมนูแป้นพิมพ์ลัด.",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ ตัวแก้ไข - Shift, Control หรือ Alt/Menu",
     "ChangeShortcut_Help3": "・ คีย์ - ตัวอักษร (A ถึง Z) หรือแท็บ",
     "ChangeShortcut_Help4": "คุณสามารถเลือกคอมบิเนชั่นใดก็ได้ที่ประกอบด้วยค่าหนึ่งจากแต่ละหมวดหมู่ ยกเว้นกรณีที่ถูกสงวนโดยระบบหรือถูกใช้งานอยู่แล้ว."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Southeast Asia",
+    "Global": "Global",
+    "Mainland China": "Mainland China",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Korea",
+    "Japan": "Japan",
+    "Bilibili": "Bilibili"
   }
 }

--- a/Hi3Helper.Core/Lang/vi_VN.json
+++ b/Hi3Helper.Core/Lang/vi_VN.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "Không hiển thị lại",
     "NotifNoNewNotifs": "Không có thông báo mới",
     "NavigationMenu": "Menu",
-    "NavigationUtilities":  "Tiện ích"
+    "NavigationUtilities": "Tiện ích"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "Dùng hiệu ứng làm mờ",
     "EnableDownloadChunksMerging": "Gộp các gói đã tải xuống",
+    "UseExternalBrowser": "Always Use External Browser",
 
     "LowerCollapsePrioOnGameLaunch": "Giảm mức sử dụng tài nguyên sử dụng của Collapse khi trò chơi được khởi động",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "Vô hiệu hóa Carousel trong trang chính và giảm mức độ ưu tiên của Collapse xuống Dưới mức bình thường",
@@ -444,6 +445,7 @@
     "Close": "Đóng",
     "UseCurrentDir": "Dùng thư mục hiện tại",
     "UseDefaultDir": "Dùng thư mục mặc định",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "Vị trí thư mục",
     "Okay": "Okay",
     "OkaySad": "Okay ;-;",
@@ -461,6 +463,7 @@
     "YesRelocate": "Có, hãy tiếp tục",
     "YesMigrateIt": "Có, hãy di chuyển nó",
     "YesConvertIt": "Có, hãy chuyển đổi nó",
+    "YesImReallySure": "Yes, I'm really sure!",
     "YesIHaveBeefyPC": "Tôi có máy tính đủ mạnh! ᕦ(ò_ó)ᕤ",
     "YesChangeLocation": "Có, hãy thay đổi vị trí",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "Không, hãy mặc kệ nó",
     "NoOtherLocation": "Không, hãy tiếp tục cài đặt",
     "NotSelected": "Chưa được chọn",
+    "ExtractAnyway": "Extract Anyway!",
 
     "LangNameENUS": "Tiếng Anh (Mỹ)",
     "LangNameJP": "Tiếng Nhật",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "Ẩn cửa sổ Collapse xuống thanh tác vụ",
     "Taskbar_ShowConsole": "Show Collapse console window",
     "Taskbar_HideConsole": "Hide Collapse console window to taskbar",
-    "Taskbar_ExitApp": "Thoát trình khởi chạy Collapse"
+    "Taskbar_ExitApp": "Thoát trình khởi chạy Collapse",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "Không có tệp nào lỗi.",
     "ExtremeGraphicsSettingsWarnTitle": "Đã chọn tuỳ chọn đồ hoạ cao nhất!",
     "ExtremeGraphicsSettingsWarnSubtitle": "Bạn đã đặt độ hoạ ở mức rất cao!\r\nĐồ hoạ cao cũng đồng nghĩa số lần render cao gấp đôi với MSAA được bật và nó CHƯA ĐƯỢC TỐI ƯU! (trừ khi bạn sài siêu máy tính của NASA).\r\n\r\nBạn có muốn tiếp tục chứ?",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "Đã phát hiện vị trí trò chơi hiện tại!",
     "ExistingInstallSubtitle": "Trò chơi đã được cài ở thư mục:\r\n\r\n{0}\r\n\r\nChúng tôi khuyến khích nên tích hợp trò chơi vào trình khởi chạy.\r\nĐừng lo lắng vì bạn vẫn dùng được trình khởi chạy gốc để mở trò chơi.\r\n\r\nBạn có muốn tiếp tục không?",
     "ExistingInstallBHI3LTitle": "Đã phát hiện vị trí cài đặt của BetterHI3trình khởi chạy hiện tại!",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "Quá trình chuyển đổi đã thất bại! :(\nVui lòng thử lại quá trình chuyển đổi.",
     "InstallDataCorruptTitle": "Cài đặt trò chơi đã bị hỏng",
     "InstallDataCorruptSubtitle": "Một trong những tệp đã tải đã bị hỏng.\r\n\r\nHash server: {0}\r\nHash đã tải: {1}\r\n\r\nBạn có muốn tải lại tệp này không?",
+    "InstallCorruptDataAnywayTitle": "Extract Corrupted Data",
+    "InstallCorruptDataAnywaySubtitle1": "You're about to extract this corrupted data: ",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} bytes)",
+    "InstallCorruptDataAnywaySubtitle3": ". Keep in-mind that the extraction for this data might fail or renders the game fail to run.\r\n\r\nAre you sure to extract this data anyway?",
     "InstallDataDownloadResumeTitle": "Tiếp tục tải?",
     "InstallDataDownloadResumeSubtitle": "Bạn đã tải {0}/{1} trước đó.\r\n\r\nBạn có muốn tiếp tục tải?",
     "InsufficientDiskTitle": "Dung lượng ổ cứng không đủ",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "Kết nối internet hiện tại của bạn được phát hiện là 'Internet có giới hạn dữ liệu'! Tiếp tục quá trình cập nhật có thể phải trả thêm phí từ nhà cung cấp internet của bạn. Bạn có muốn tiếp tục không?",
 
     "ResetKbShortcutsTitle": "Bạn có chắc chắn muốn đặt lại tất cả các phím tắt không?",
-    "ResetKbShortcutsSubtitle": "Điều này có nghĩa là mọi phím tắt sẽ được thay đổi thành tổ hợp phím mặc định của chúng. \n\nBạn có muốn tiếp tục không?\n\nLưu ý: Điều này không ảnh hưởng đến cách Collapse hoạt động và bạn vẫn có thể thay đổi tổ hợp phím tắt bằng cách truy cập menu Phím tắt."
+    "ResetKbShortcutsSubtitle": "Điều này có nghĩa là mọi phím tắt sẽ được thay đổi thành tổ hợp phím mặc định của chúng. \n\nBạn có muốn tiếp tục không?\n\nLưu ý: Điều này không ảnh hưởng đến cách Collapse hoạt động và bạn vẫn có thể thay đổi tổ hợp phím tắt bằng cách truy cập menu Phím tắt.",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ Modifier - Shift, Control or Alt/Menu",
     "ChangeShortcut_Help3": "・ Key - Alphabetical (A to Z) or Tab",
     "ChangeShortcut_Help4": "You can choose any combination consisting of one value from each category, unless it is reserved by the system or is already being used."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Southeast Asia",
+    "Global": "Global",
+    "Mainland China": "Mainland China",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Korea",
+    "Japan": "Japan",
+    "Bilibili": "Bilibili"
   }
 }

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "不再显示",
     "NotifNoNewNotifs": "没有新的通知",
     "NavigationMenu": "菜单",
-    "NavigationUtilities":  "工具"
+    "NavigationUtilities": "工具"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "使用亚克力模糊效果",
     "EnableDownloadChunksMerging": "合并已下载的软件包块",
+    "UseExternalBrowser": "永远使用外部浏览器",
 
     "LowerCollapsePrioOnGameLaunch": "在游戏启动后降低 Collapse 进程的资源占用",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "禁用主页轮播，并降低 Collapse 的优先级至“低于正常”",
@@ -428,7 +429,7 @@
 
   "_Misc": {
     "UpdateCompleteTitle": "更新完成！",
-    "UpdateCompleteSubtitle": "您的启动器版本已更新为{0}！（发布渠道：{1}）",
+    "UpdateCompleteSubtitle": "您的启动器版本已更新为{0}！（发布频道：{1}）",
     "FeatureUnavailableTitle": "此功能暂时不可用",
     "FeatureUnavailableSubtitle": "请稍候再试！",
     "TimeRemain": "剩余时间",
@@ -444,6 +445,7 @@
     "Close": "关闭",
     "UseCurrentDir": "使用当前目录",
     "UseDefaultDir": "使用默认目录",
+    "MoveToDifferentDir": "移动到不同的目录",
     "LocateDir": "查找目录",
     "Okay": "好的",
     "OkaySad": "好的 ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "是的，恢复",
     "YesMigrateIt": "是的，迁移",
     "YesConvertIt": "是的，转换",
+    "YesImReallySure": "是的，我非常确定！",
     "YesIHaveBeefyPC": "是的，我有强大的电脑！ᕦ(ò_ó)ᕤ",
     "YesChangeLocation": "是的，改变位置",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "不，忽略它",
     "NoOtherLocation": "继续安装",
     "NotSelected": "未选择",
+    "ExtractAnyway": "不管怎样都提取！",
 
     "LangNameENUS": "英语（美国）",
     "LangNameJP": "日语",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "隐藏 Collapse 窗口到任务栏",
     "Taskbar_ShowConsole": "显示 Collapse 控制台窗口",
     "Taskbar_HideConsole": "隐藏 Collapse 控制台窗口到任务栏",
-    "Taskbar_ExitApp": "退出 Collapse 启动器"
+    "Taskbar_ExitApp": "退出 Collapse 启动器",
+
+    "LauncherNameOfficial": "官方启动器",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(启动器名称未知)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "未找到损坏的文件。",
     "ExtremeGraphicsSettingsWarnTitle": "您选择了“非常高”的设置预设！",
     "ExtremeGraphicsSettingsWarnSubtitle": "您将把设置预设为非常高！\n非常高的设置预设基本上是2倍的渲染比例，并启用了MSAA，它是非常不稳定的！（除非您有NASA的超级计算机来运行）。\n\n您确定您要使用这个设置吗？",
+    "MigrateExistingMoveDirectoryTitle": "移动已存在的安装到：{0}",
+    "MigrateExistingInstallChoiceTitle": "在 {0} 检测到到已存在的安装！",
+    "MigrateExistingInstallChoiceSubtitle1": "您已经在这个目录中存在一个使用 {0} 安装了的游戏：",
+    "MigrateExistingInstallChoiceSubtitle2": "您可以选择将现有游戏数据移动到另一个目录或使用当前目录作为现有目录。建议您使用当前目录作为已安装的目录，以确保您仍然可以使用 {0} 启动游戏。",
     "ExistingInstallTitle": "检测到现有安装！",
     "ExistingInstallSubtitle": "游戏已经安装在此位置：\n\n{0}\n\n建议将游戏迁移到 Collapse。\n然而，您仍然可以使用官方启动器来开始游戏。\n\n您想要继续吗？",
     "ExistingInstallBHI3LTitle": "检测到 BetterHI3 启动器上已有安装！",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "转换过程失败！:(\n请尝试重新启动转换过程。",
     "InstallDataCorruptTitle": "游戏安装已损坏",
     "InstallDataCorruptSubtitle": "已下载的文件之一已损坏。\n\n服务器哈希：{0}\n已下载哈希：{1}\n\n您想尝试重新下载该文件吗？",
+    "InstallCorruptDataAnywayTitle": "提取损坏的数据",
+    "InstallCorruptDataAnywaySubtitle1": "您即将提取这些损坏的数据：",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} （{2} 字节）",
+    "InstallCorruptDataAnywaySubtitle3": "。请牢记，这些数据的提取可能会失败或导致游戏无法运行。\r\n\r\n您确定不管怎样都要提取这些数据吗？",
     "InstallDataDownloadResumeTitle": "修复下载？",
     "InstallDataDownloadResumeSubtitle": "您以前已经下载了 {0}/{1} 游戏。\n\n您想要恢复下载吗？",
     "InsufficientDiskTitle": "磁盘空间不足",
@@ -612,7 +629,7 @@
     "PrivilegeMustRunTitle": "Collapse 需要管理员权限！",
     "PrivilegeMustRunSubtitle": "Collapse 需要管理员权限才能正常工作。是否要重新启动 Collapse 并以管理员身份运行它？",
     "ReleaseChannelChangeTitle": "更改发布频道",
-    "ReleaseChannelChangeSubtitle1": "您将要更改您的发行频道为：",
+    "ReleaseChannelChangeSubtitle1": "您将要更改您的发布频道为：",
     "ReleaseChannelChangeSubtitle2": "注：",
     "ReleaseChannelChangeSubtitle3": "此操作可能会导致不可逆的更改和/或导致您当前的设置中断。我们不应对与您的游戏相关的任何数据丢失或损坏负责。",
     "ChangePlaytimeTitle": "是否确认更改游戏时间？",
@@ -628,10 +645,32 @@
     "StopGameTitle": "强制停止游戏",
     "StopGameSubtitle": "您确定要强制中止当前正在运行的游戏吗？\n您的游戏进度可能会丢失。",
     "MeteredConnectionWarningTitle": "检测到按流量计费的连接！",
-    "MeteredConnectionWarningSubtitle": "您当前的互联网连接按流量计费！继续更新可能会让互联网提供商收取额外费用。您希望继续吗？",
+    "MeteredConnectionWarningSubtitle": "检测到您当前的互联网连接'按流量计费'！继续更新可能会让互联网提供商收取额外费用。您希望继续吗？",
 
     "ResetKbShortcutsTitle": "您确定要重置所有快捷键吗？",
-    "ResetKbShortcutsSubtitle": "这意味着每个快捷键都将更改为默认值。\n\n您想继续吗？\n\n注意：这不会影响 Collapse 的运行，您仍然可以通过访问“键盘快捷键”菜单来更改快捷键。"
+    "ResetKbShortcutsSubtitle": "这意味着每个快捷键都将更改为默认值。\n\n您想继续吗？\n\n注意：这不会影响 Collapse 的运行，您仍然可以通过访问“键盘快捷键”菜单来更改快捷键。",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "驱动器 {0} 的磁盘空间不足！",
+    "OperationErrorDiskSpaceInsufficientMsg": "您没有足够的可用空间在 {2} 驱动器上执行该操作！\r\n\r\n空余空间：{0}\r\n需要空间：{1}.\r\n\r\n继续之前请确保您有足够的磁盘空间。",
+
+    "OperationWarningNotCancellableTitle": "注意：这一操作是 不！可！取！消！的！",
+    "OperationWarningNotCancellableMsg1": "您可能需要检查计算机上是否没有运行任何繁重的任务，以避免运行处理时可能出现的问题。请牢记，您",
+    "OperationWarningNotCancellableMsg2": "无！法！取！消！此！过！程！",
+    "OperationWarningNotCancellableMsg3": "当它运行时！\r\n\r\n点击 \"",
+    "OperationWarningNotCancellableMsg4": "\" 或 \" 以开始处理",
+    "OperationWarningNotCancellableMsg5": "\" 以取消操作。"
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "移动中：",
+    "SpeedIndicatorTitle": "速度：",
+    "FileCountIndicatorTitle": "已处理的文件：",
+    "LocateFolderSubtitle": "选择将文件/文件夹移动到目标路径的位置。",
+    "ChoosePathTextBoxPlaceholder": "选择目标路径……",
+    "ChoosePathButton": "选择目标",
+    "ChoosePathErrorPathUnselected": "请在继续之前选择您的路径！",
+    "ChoosePathErrorPathNotExist": "路径不存在！",
+    "ChoosePathErrorPathNoPermission": "您没有访问此位置的权限！请选择其他位置！"
   },
 
   "_InstallMgmt": {
@@ -724,7 +763,7 @@
     "PageTitle2": "更新！",
     "VerCurLabel": "当前版本：",
     "VerNewLabel": "最新版本：",
-    "VerChannelLabel": "更新通道：",
+    "VerChannelLabel": "更新频道：",
     "VerDateLabel": "编译于：",
     "ReleaseNote": "发行说明",
     "NeverShowNotification": "不再显示",
@@ -752,50 +791,50 @@
     "UpdateCountdownMessage2": "（点击这里",
     "UpdateCountdownMessage3": "中止倒计时）",
 
-    "ApplyUpdateTitle1": "We're updating",
-    "ApplyUpdateTitle2": "Collapse Launcher",
-    "ApplyUpdateCDNSelectorTitle": "Select your CDN for update",
-    "ApplyUpdateCDNSelectorSubtitle": "Select the CDN options and click \"{0}\" to start the update!",
-    "ApplyUpdateCDNSelectorSubtitleCount": "The CDN will be automatically selected in: {0}",
-    "ApplyUpdateUpdateNowBtn": "Update Now!",
+    "ApplyUpdateTitle1": "我们正在更新",
+    "ApplyUpdateTitle2": "Collapse 启动器",
+    "ApplyUpdateCDNSelectorTitle": "选择您用于更新的CDN",
+    "ApplyUpdateCDNSelectorSubtitle": "选择 CDN 选项并点击“{0}”以开始更新！",
+    "ApplyUpdateCDNSelectorSubtitleCount": "CDN 将会在 {0} 后自动选择",
+    "ApplyUpdateUpdateNowBtn": "现在更新！",
 
-    "ApplyUpdateUpdateVersionTitle": "Update:",
-    "ApplyUpdateUpdateChannelTitle": "Channel:",
-    "ApplyUpdateUpdateChannelSubtitlePlaceholder": "Unknown",
-    "ApplyUpdateUpdateStatusTitle": "Status:",
-    "ApplyUpdateMiscIdle": "Idle",
-    "ApplyUpdateMiscNone": "None",
-    "ApplyUpdateVersionSeparator": "to",
+    "ApplyUpdateUpdateVersionTitle": "更新：",
+    "ApplyUpdateUpdateChannelTitle": "频道：",
+    "ApplyUpdateUpdateChannelSubtitlePlaceholder": "未知",
+    "ApplyUpdateUpdateStatusTitle": "状态：",
+    "ApplyUpdateMiscIdle": "闲置",
+    "ApplyUpdateMiscNone": "无",
+    "ApplyUpdateVersionSeparator": "至",
 
-    "ApplyUpdateErrCollapseRunTitle": "Please close Collapse before applying the update!",
-    "ApplyUpdateErrCollapseRunSubtitle": "Waiting for Collapse to close...",
-    "ApplyUpdateErrReleaseFileNotFoundTitle": "ERROR:\r\n\"release\" file doesn't have \"stable\" or \"preview\" string in it",
-    "ApplyUpdateErrReleaseFileNotFoundSubtitle": "Please check your \"release\" file and try again.",
+    "ApplyUpdateErrCollapseRunTitle": "请在应用更新前关闭 Collapse！",
+    "ApplyUpdateErrCollapseRunSubtitle": "等待 Collapse 关闭……",
+    "ApplyUpdateErrReleaseFileNotFoundTitle": "错误：\r\n\"release\" 文件中没有 \"stable\" 或 \"preview\" 字符串",
+    "ApplyUpdateErrReleaseFileNotFoundSubtitle": "请检查您的 \"release\" 文件并重试。",
 
     "ApplyUpdateDownloadSizePlaceholder": "- B / - B",
     "ApplyUpdateDownloadSpeed": "{0}/s",
     "ApplyUpdateDownloadSpeedPlaceholder": "- B/s",
-    "ApplyUpdateDownloadTimeEst": "{0:%h}h{0:%m}m{0:%s}s left",
-    "ApplyUpdateDownloadTimeEstPlaceholder": "--h--m--s left",
+    "ApplyUpdateDownloadTimeEst": "还剩{0:%h}时{0:%m}分{0:%s}秒",
+    "ApplyUpdateDownloadTimeEstPlaceholder": "还剩--时--分--秒",
 
-    "ApplyUpdateTaskLegacyVerFoundTitle": "A previous legacy installation of Collapse v{0} detected!",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle1": "We detected that you have a legacy Collapse v{0} installed on your PC. ",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle2": "The updater needs to clean-up all the old files inside its directory.\r\n",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle3": "Please make sure you don't have any important files inside of the Collapse directory or it will be COMPLETELY WIPED OUT!",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle4": "\r\n\r\nClick \"Yes\" to proceed or \"No\" to cancel.",
-    "ApplyUpdateTaskLegacyVerFoundSubtitle5": "Click \"Yes\" once again to confirm.",
-    "ApplyUpdateTaskLegacyCleanupCount": "Clean-up process will be started in {0}...",
-    "ApplyUpdateTaskLegacyDeleting": "Deleting: {0}...",
+    "ApplyUpdateTaskLegacyVerFoundTitle": "检测到以前安装的旧版本的 Collapse v{0}！",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle1": "我们检测到您的 PC 上安装了旧版本的 Collapse v{0}。",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle2": "更新程序需要清理其目录中的所有旧文件。\r\n",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle3": "请确保 Collapse 目录中没有任何重要文件，否则它将被 完！全！删！除！",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle4": "\r\n\r\n点击“是”以处理或“否”以取消。",
+    "ApplyUpdateTaskLegacyVerFoundSubtitle5": "再次单击“是”进行确认。",
+    "ApplyUpdateTaskLegacyCleanupCount": "清理将于 {0} 后开始...",
+    "ApplyUpdateTaskLegacyDeleting": "删除中：{0}……",
 
-    "ApplyUpdateTaskDownloadingPkgTitle": "Downloading package",
-    "ApplyUpdateTaskExtractingPkgTitle": "Extracting package",
-    "ApplyUpdateTaskRemoveOldPkgTitle": "Removing old package",
-    "ApplyUpdateTaskMovingExtractFileTitle": "Moving extracted files",
+    "ApplyUpdateTaskDownloadingPkgTitle": "下载软件包中",
+    "ApplyUpdateTaskExtractingPkgTitle": "解压软件包中",
+    "ApplyUpdateTaskRemoveOldPkgTitle": "移除旧软件包中",
+    "ApplyUpdateTaskMovingExtractFileTitle": "移动解压后的文件中",
 
-    "ApplyUpdateTaskLauncherUpdatedTitle": "Launcher has been updated to: {0}!",
-    "ApplyUpdateTaskLauncherUpdatedSubtitle": "Launching Collapse in {0}...",
+    "ApplyUpdateTaskLauncherUpdatedTitle": "启动器版本已更新为 {0}！",
+    "ApplyUpdateTaskLauncherUpdatedSubtitle": "正在启动 Collapse {0} ……",
 
-    "ApplyUpdateTaskError": "ERROR:\r\nError occurred while applying update!\r\n{0}"
+    "ApplyUpdateTaskError": "错误：\r\n应用更新时出错！\r\n{0}"
   },
 
   "_AppNotification": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ 修饰键 - Ctrl 或 Alt/Menu",
     "ChangeShortcut_Help3": "・ 按键 - 字母（A - Z）或 Tab",
     "ChangeShortcut_Help4": "您可以任意选择由每个类别中的一个值组成的组合，除非其被系统保留或已被使用。"
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "崩坏3",
+    "Genshin Impact": "原神",
+    "Honkai: Star Rail": "崩坏：星穹铁道",
+    "Zenless Zone Zero": "绝区零"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "东南亚",
+    "Global": "全球",
+    "Mainland China": "中国大陆",
+    "TW/HK/MO": "港澳台",
+    "Korea": "韩国",
+    "Japan": "日本",
+    "Bilibili": "哔哩哔哩"
   }
 }

--- a/Hi3Helper.Core/Lang/zh_TW.json
+++ b/Hi3Helper.Core/Lang/zh_TW.json
@@ -94,7 +94,7 @@
     "NotifNeverAsk": "不再顯示",
     "NotifNoNewNotifs": "沒有新的通知",
     "NavigationMenu": "目錄",
-    "NavigationUtilities":  "工具箱"
+    "NavigationUtilities": "工具箱"
   },
 
   "_HomePage": {
@@ -408,6 +408,7 @@
 
     "EnableAcrylicEffect": "使用壓克力模糊效果",
     "EnableDownloadChunksMerging": "合併已下載的軟體包區塊",
+    "UseExternalBrowser": "Always Use External Browser",
 
     "LowerCollapsePrioOnGameLaunch": "Lower Collapse process resource usage when a game is launched",
     "LowerCollapsePrioOnGameLaunch_Tooltip": "Disables Carousel in main page and lower Collapse's priority to Below Normal",
@@ -444,6 +445,7 @@
     "Close": "關閉",
     "UseCurrentDir": "使用當前路徑",
     "UseDefaultDir": "使用預設路徑",
+    "MoveToDifferentDir": "Move to different directory",
     "LocateDir": "定位目錄",
     "Okay": "好",
     "OkaySad": "好 ;-;)",
@@ -461,6 +463,7 @@
     "YesRelocate": "是，繼續",
     "YesMigrateIt": "是，進行遷移",
     "YesConvertIt": "是，進行轉換",
+    "YesImReallySure": "Yes, I'm really sure!",
     "YesIHaveBeefyPC": "是，我有台強大的電腦！ᕦ(ò_ó)ᕤ",
     "YesChangeLocation": "是，更改位置",
 
@@ -471,6 +474,7 @@
     "NoIgnoreIt": "忽略它",
     "NoOtherLocation": "繼續安裝",
     "NotSelected": "尚未選擇",
+    "ExtractAnyway": "Extract Anyway!",
 
     "LangNameENUS": "英文（美國）",
     "LangNameJP": "日文",
@@ -525,7 +529,12 @@
     "Taskbar_HideApp": "Hide Collapse window to taskbar",
     "Taskbar_ShowConsole": "Show Collapse console window",
     "Taskbar_HideConsole": "Hide Collapse console window to taskbar",
-    "Taskbar_ExitApp": "Exit Collapse Launcher"
+    "Taskbar_ExitApp": "Exit Collapse Launcher",
+
+    "LauncherNameOfficial": "Official Launcher",
+    "LauncherNameBHI3L": "BetterHi3Launcher",
+    "LauncherNameSteam": "Steam",
+    "LauncherNameUnknown": "(Launcher Name is Unknown)"
   },
 
   "_BackgroundNotification": {
@@ -565,6 +574,10 @@
     "RepairCompletedSubtitleNoBroken": "未找到已損壞的文件。",
     "ExtremeGraphicsSettingsWarnTitle": "已選擇「非常高」的圖像預設方案！",
     "ExtremeGraphicsSettingsWarnSubtitle": "您正打算將畫面預設方案設定到「非常高」！\n「非常高」畫面預設方案實質上是兩倍的渲染比例並開啟 MSAA，並且優化非常差！\n\n您是否確定要使用這個預設方案？",
+    "MigrateExistingMoveDirectoryTitle": "Moving Existing Installation for: {0}",
+    "MigrateExistingInstallChoiceTitle": "An Existing Installation of {0} is Detected!",
+    "MigrateExistingInstallChoiceSubtitle1": "You have an existing installation of the game using {0} on this directory:",
+    "MigrateExistingInstallChoiceSubtitle2": "You have an option to move your existing game data into another directory or use the current directory as the existing one. It's recommended that you use the current directory as the one already installed to ensure that you can still launch your game using {0}.",
     "ExistingInstallTitle": "檢測到現有安裝！",
     "ExistingInstallSubtitle": "此遊戲已經在以下目錄安裝：\n\n{0}\n\n建議將遊戲遷移至 Collapse 啟動器以獲得更好的支援和整合。\n然而，你仍然可以使用官方的啟動器來開始遊戲。\n\n是否繼續？",
     "ExistingInstallBHI3LTitle": "偵測到 BetterHi3 啟動器上已有安裝！",
@@ -579,6 +592,10 @@
     "SteamConvertFailedSubtitle": "轉換程序失敗了！ :(\n請嘗試重新開始轉換程序。",
     "InstallDataCorruptTitle": "遊戲檔案已損毀",
     "InstallDataCorruptSubtitle": "其中一個已下載的檔案發生損毀。\n\n伺服器雜湊值：{0}\n下載檔案的雜湊值：{1}\n\n是否要重新下載該檔案？",
+    "InstallCorruptDataAnywayTitle": "Extract Corrupted Data",
+    "InstallCorruptDataAnywaySubtitle1": "You're about to extract this corrupted data: ",
+    "InstallCorruptDataAnywaySubtitle2": "{0} - {1} ({2} bytes)",
+    "InstallCorruptDataAnywaySubtitle3": ". Keep in-mind that the extraction for this data might fail or renders the game fail to run.\r\n\r\nAre you sure to extract this data anyway?",
     "InstallDataDownloadResumeTitle": "繼續下載？",
     "InstallDataDownloadResumeSubtitle": "您先前已下載遊戲的{0}/{1}。\n\n是否要繼續下載？",
     "InsufficientDiskTitle": "硬碟空間不足",
@@ -631,7 +648,29 @@
     "MeteredConnectionWarningSubtitle": "Your current internet connection was detected as being 'Metered'! Continuing the update process may incur additional charges from your internet provider. Do you wish to proceed?",
 
     "ResetKbShortcutsTitle": "Are you sure you want to reset all shortcuts?",
-    "ResetKbShortcutsSubtitle": "This means every shortcut will be changed to their default key combination. \n\nDo you wish to proceed?\n\nNote: This has no impact on how Collapse operates and you can still change the combination of shortcuts by accessing the Keyboard Shortcuts menu."
+    "ResetKbShortcutsSubtitle": "This means every shortcut will be changed to their default key combination. \n\nDo you wish to proceed?\n\nNote: This has no impact on how Collapse operates and you can still change the combination of shortcuts by accessing the Keyboard Shortcuts menu.",
+
+    "OperationErrorDiskSpaceInsufficientTitle": "Disk Space for Drive: {0} is Insufficient!",
+    "OperationErrorDiskSpaceInsufficientMsg": "You do not have enough free space to do the operation on your {2} drive!\r\n\r\nFree Space: {0}\r\nRequired Space: {1}.\r\n\r\nPlease ensure that you have enough disk space before proceeding.",
+
+    "OperationWarningNotCancellableTitle": "Attention: This Operation is NOT CANCELLABLE!",
+    "OperationWarningNotCancellableMsg1": "You might need to check that you don't have any heavy tasks running on your computer to avoid possible issues while the process is running. Keep in-mind that you ",
+    "OperationWarningNotCancellableMsg2": "CANNOT CANCEL THIS PROCESS",
+    "OperationWarningNotCancellableMsg3": " while it's running!\r\n\r\nClick \"",
+    "OperationWarningNotCancellableMsg4": "\" to start the process or \"",
+    "OperationWarningNotCancellableMsg5": "\" to cancel the operation."
+  },
+
+  "_FileMigrationProcess": {
+    "PathActivityPanelTitle": "Moving: ",
+    "SpeedIndicatorTitle": "Speed: ",
+    "FileCountIndicatorTitle": "File processed: ",
+    "LocateFolderSubtitle": "Choose the location to move the file/folder to the target path.",
+    "ChoosePathTextBoxPlaceholder": "Choose the target path...",
+    "ChoosePathButton": "Choose Target",
+    "ChoosePathErrorPathUnselected": "Please choose your path before continue!",
+    "ChoosePathErrorPathNotExist": "Path does not exist!",
+    "ChoosePathErrorPathNoPermission": "You don't have a permission to access this location! Please choose another location!"
   },
 
   "_InstallMgmt": {
@@ -1029,5 +1068,22 @@
     "ChangeShortcut_Help2": "・ Modifier - Shift, Control or Alt/Menu",
     "ChangeShortcut_Help3": "・ Key - Alphabetical (A to Z) or Tab",
     "ChangeShortcut_Help4": "You can choose any combination consisting of one value from each category, unless it is reserved by the system or is already being used."
+  },
+
+  "_GameClientTitles": {
+    "Honkai Impact 3rd": "Honkai Impact 3rd",
+    "Genshin Impact": "Genshin Impact",
+    "Honkai: Star Rail": "Honkai: Star Rail",
+    "Zenless Zone Zero": "Zenless Zone Zero"
+  },
+
+  "_GameClientRegions": {
+    "Southeast Asia": "Southeast Asia",
+    "Global": "Global",
+    "Mainland China": "Mainland China",
+    "TW/HK/MO": "TW/HK/MO",
+    "Korea": "Korea",
+    "Japan": "Japan",
+    "Bilibili": "Bilibili"
   }
 }

--- a/README.md
+++ b/README.md
@@ -222,9 +222,15 @@ To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLaun
 ***
 
 # Prerequisites for Building Locally/Development
-> ### More information can be found in [**Contribution Guidelines**](https://github.com/neon-nyan/Collapse/blob/main/CONTRIBUTING.md)
+> ### More information can be found in [**Contribution Guidelines**](CONTRIBUTING.md)
 
 ***
+
+# Code Signing Policy
+> Free code signing provided by [SignPath.io], certificate by [SignPath Foundation]
+- This program will not transfer any information to other networked systems.
+- Read our full [**Privacy Policy**](PRIVACY.md)
+- Also read our [**Third Party Notices**](THIRD_PARTY_NOTICES.md) for license used by third party libraries that we use.
 
 # Third-party repositories and libraries used in this project
 - [**Windows UI Library**](https://github.com/microsoft/microsoft-ui-xaml) by Microsoft
@@ -269,3 +275,6 @@ Made by all captains around the world with ❤️. Fight for all that is beautif
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+[SignPath Foundation]:https://signpath.org
+[SignPath.io]:https://signpath.io

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -129,7 +129,7 @@ for:
 
     deploy:
     - provider: Webhook
-      url: https://app.signpath.io/API/v1/6988fc60-19f4-4710-8eb7-e837c60c83b4/Integrations/AppVeyor?ProjectSlug=Collapse&SigningPolicySlug=test-signing&ArtifactConfigurationSlug=initial
+      url: https://app.signpath.io/API/v1/6988fc60-19f4-4710-8eb7-e837c60c83b4/Integrations/AppVeyor?ProjectSlug=Collapse&SigningPolicySlug=release-signing&ArtifactConfigurationSlug=initial
       authorization:
         secure: B8zpDU6wkKuCBRz65VfTFxUCxY7HniWmRbJP/E3tE40kGmHKdaFnMCDSURQFWwR1pCcXHqbkJd3YX76tnTXQow==
       on:
@@ -265,7 +265,7 @@ for:
 
     deploy:
     - provider: Webhook
-      url: https://app.signpath.io/API/v1/6988fc60-19f4-4710-8eb7-e837c60c83b4/Integrations/AppVeyor?ProjectSlug=Collapse&SigningPolicySlug=test-signing&ArtifactConfigurationSlug=initial
+      url: https://app.signpath.io/API/v1/6988fc60-19f4-4710-8eb7-e837c60c83b4/Integrations/AppVeyor?ProjectSlug=Collapse&SigningPolicySlug=release-signing&ArtifactConfigurationSlug=initial
       authorization:
         secure: B8zpDU6wkKuCBRz65VfTFxUCxY7HniWmRbJP/E3tE40kGmHKdaFnMCDSURQFWwR1pCcXHqbkJd3YX76tnTXQow==
       on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -243,15 +243,14 @@ for:
 
         mkdir SignArtifact
 
-        mkdir SignArtifact\BuildArtifact
+        mkdir SignArtifact\BuildArtifact-%version%
 
         mkdir SignArtifact\Squirrel-Stub
 
         mkdir SignArtifact\InnoInstaller
 
-        echo . >SignArtifact\Version-%version%
 
-        xcopy "CollapseLauncher\%channel%-build\*" "SignArtifact\BuildArtifact\" /E /K /Y /I
+        xcopy "CollapseLauncher\%channel%-build\*" "SignArtifact\BuildArtifact-%version%\" /E /K /Y /I
 
         copy DeployResource\CollapseLauncher.exe SignArtifact\Squirrel-Stub\CollapseLauncher.exe
 


### PR DESCRIPTION
https://github.com/CollapseLauncher/Collapse/compare/CL-v1.73.0-pre...main

# What's New? - 1.73.1
- **[New]** Open Collapse straight to specified region using command argument (thanks @gablm !)
  - Now you can launch Collapse straight to your specified region (optionally also launch the game) directly using command line arguments!
  - Note: You don't need to close your current Collapse process and it will redirect the command to already running instance! (Assuming you did not enable Multi instance in the settings)
  - Usage : 
     CollapseLauncher open [options]
  - Options:
     -g, --game <game> (REQUIRED)  Game number/name
                                e.g. 0 or "Honkai Impact 3rd"
     -r, --region <region>         Region number/name
                                e.g. For Genshin Impact, 0 or "Global" would load the Global region for the game
    -p, --play                    Start Game after loading the Game/Region
    -?, -h, --help                Show help and usage information

- **[New]** URL Protocol support (thanks @gablm !)
  - This is the extension of the command argument feature. With this, you can open Collapse and use either `open` or `tray` argument using `collapse://[argument]` either in Windows Run, Browser, or as an icon.
  - Usage example `collapse://tray` to open Collapse straight to tray menu
  - To use this feature, you have to run Collapse at least once after the update!
  - These 2 new features is an extension from WIP feature to add the games icon to Steam and Desktop using Collapse! Hopefully this feature will come in near future~
 
- **[Imp]** Builds now signed by SignPath!
  - Thank you SignPath Foundation for providing us with Authenticode signing for Collapse!
  - Collapse build are now signed with EV certificate issued by SignPath Foundation. This is our step forward to make user more comfortable using our launcher as you can trust that we only publish the program that you can see all the source code that we made!
  - Disclaimer: user might still see the Windows SmartScreen warning when they run the app for the first time as it will take time for Microsoft build trust for Collapse.
  
- **[Imp]** Community Tools for different zone (thanks @shatyuka !)
  - Community Tools section is now separated by regions!
  - Global and Mainland China (including Bilibili) will now have different setlist of available tools to choose. This also fixes the Official Tools link which are different for the CN regions.
 
- **[Fix]** Fixed Genshin Game Settings causing Collapse to crash
  - This usually happens when the config is not found in the registry, either due to a new install or user wiped the configuration manually.
  - With this, default value is loaded whenever Collapse cannot retrieve the config from registry.

- **[Imp]** Documentations improvements
  - We now have our Privacy Policy which you can read here: https://github.com/CollapseLauncher/Collapse/blob/main/PRIVACY.md
  - We will be fully committed to not collect any data from the user and respect everyone's privacy by using our program. Although currently there is no feasible way to fully avoid that with 3rd party services that we need to use to make Collapse work. All of those are listed there and users are encouraged to read it!

- **[Imp]** Backends chores
  - NuGet and submodule updates

- **[Loc]** Sync translation from Transifex (thank you all localizer!)

Template:
**[New]**
**[Imp]**
**[Fix]**
**[Loc]**