### PR TITLE
Fix "Change Release" and "Force Update"

### DIFF
--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -142,12 +142,12 @@ namespace CollapseLauncher
             Option<AppReleaseChannel> o_Channel = new Option<AppReleaseChannel>(new string[] { "--channel", "-c" }, "App release channel") { IsRequired = true }.FromAmong();
             command.AddOption(o_Input);
             command.AddOption(o_Channel);
-            command.Handler = CommandHandler.Create((string Input, AppReleaseChannel ReleaseChannel) =>
+            command.Handler = CommandHandler.Create((string Input, AppReleaseChannel Channel) =>
             {
                 m_arguments.Updater = new ArgumentUpdater
                 {
                     AppPath = Input,
-                    UpdateChannel = ReleaseChannel
+                    UpdateChannel = Channel
                 };
             });
         }


### PR DESCRIPTION
For some reason, a CommandLine Command Handler tries to match the Option name with the Handler parameters name?
Thanks Microsoft!

This has been broken since at least 1.72.11 from my limited testing, maybe even earlier.
Because of this, forcing update is currently changing Preview to Stable release and Stable can't change to Preview back. 

Edit: Actually since 1.72.4