### PR TITLE
Resizable Game Window

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
@@ -35,6 +35,13 @@ namespace CollapseLauncher.GameSettings.Universal
         public bool UseBorderlessScreen { get; set; } = false;
 
         /// <summary>
+        /// This defines if the game should run in Resizable window. <br/>
+        /// The window should run in windowed-mode and would not work with any fullscreen modes. <br/><br/>
+        /// Default: false
+        /// </summary>
+        public bool UseResizableWindow { get; set; } = false;
+
+        /// <summary>
         /// This defines the Graphics API will be used for the game to run.<br/><br/>
         /// Values:<br/>
         ///     - 0 = DirectX 11 (Feature Level: 10.1)<br/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.Ext.cs
@@ -92,10 +92,13 @@ namespace CollapseLauncher.Pages
                 Settings.SettingsScreen.isfullScreen = value;
                 if (value)
                 {
+                    GameWindowResizable.IsEnabled = false;
+                    GameWindowResizable.IsChecked = false;
                     GameResolutionFullscreenExclusive.IsEnabled = !IsCustomResolutionEnabled;
                     GameResolutionBorderless.IsChecked = false;
                     return;
                 }
+                GameWindowResizable.IsEnabled = true;
                 GameResolutionFullscreenExclusive.IsEnabled = false;
                 GameResolutionFullscreenExclusive.IsChecked = false;
                 GameResolutionBorderless.IsEnabled = true;
@@ -110,10 +113,16 @@ namespace CollapseLauncher.Pages
                 Settings.SettingsCollapseScreen.UseBorderlessScreen = value;
                 if (value)
                 {
+                    GameWindowResizable.IsEnabled = false;
+                    GameWindowResizable.IsChecked = false;
                     GameResolutionFullscreen.IsEnabled = false;
                     GameResolutionFullscreen.IsChecked = false;
                 }
-                GameResolutionFullscreen.IsEnabled = true;
+                else
+                {
+                    GameWindowResizable.IsEnabled = true;
+                    GameResolutionFullscreen.IsEnabled = true;
+                }
             }
         }
 
@@ -174,6 +183,17 @@ namespace CollapseLauncher.Pages
                 }
                 GameCustomResolutionCheckbox.IsEnabled = true;
             }
+        }
+
+        public bool IsCanResizableWindow
+        {
+            get => !Settings.SettingsScreen.isfullScreen && !IsExclusiveFullscreenEnabled;
+        }
+
+        public bool IsResizableWindow
+        {
+            get => Settings.SettingsCollapseScreen.UseResizableWindow;
+            set => Settings.SettingsCollapseScreen.UseResizableWindow = value;
         }
 
         public int ResolutionW

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.xaml
@@ -39,6 +39,34 @@
                                         <CheckBox x:Name="GameResolutionBorderless" Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Borderless}"
                                                   HorizontalAlignment="Left" VerticalAlignment="Center"
                                                   IsChecked="{x:Bind IsBorderlessEnabled, Mode=TwoWay}"/>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox x:Name="GameWindowResizable" Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_ResizableWindow}"
+                                                  HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                  IsEnabled="{x:Bind IsCanResizableWindow, Mode=OneWay}"
+                                                  IsChecked="{x:Bind IsResizableWindow, Mode=TwoWay}"/>
+                                            <Button Grid.Column="1" Margin="8,-4,0,0" Style="{ThemeResource ButtonRevealStyle}">
+                                                <Button.Content>
+                                                    <FontIcon
+                                                        FontFamily="{ThemeResource FontAwesome}"
+                                                        FontSize="12"
+                                                        Glyph="&#x3f;" />
+                                                </Button.Content>
+                                                <Button.Flyout>
+                                                    <Flyout AllowFocusOnInteraction="True">
+                                                        <TextBlock
+                                                            Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_ResizableWindowTooltip}"
+                                                            MaxWidth="360"
+                                                            TextWrapping="Wrap"
+                                                            TextAlignment="Center"
+                                                            FontWeight="SemiBold"/>
+                                                    </Flyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </Grid>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
                                         <ComboBox CornerRadius="14" x:Name="GameResolutionSelector"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -17,10 +17,13 @@ namespace CollapseLauncher.Pages
                 Settings.SettingsScreen.isfullScreen = value;
                 if (value)
                 {
+                    GameWindowResizable.IsEnabled = false;
+                    GameWindowResizable.IsChecked = false;
                     GameResolutionFullscreenExclusive.IsEnabled = !IsCustomResolutionEnabled;
                     GameResolutionBorderless.IsChecked = false;
                     return;
                 }
+                GameWindowResizable.IsEnabled = true;
                 GameResolutionFullscreenExclusive.IsEnabled = false;
                 GameResolutionFullscreenExclusive.IsChecked = false;
                 GameResolutionBorderless.IsEnabled = true;
@@ -35,10 +38,16 @@ namespace CollapseLauncher.Pages
                 Settings.SettingsCollapseScreen.UseBorderlessScreen = value;
                 if (value)
                 {
+                    GameWindowResizable.IsEnabled = false;
+                    GameWindowResizable.IsChecked = false;
                     GameResolutionFullscreen.IsEnabled = false;
                     GameResolutionFullscreen.IsChecked = false;
                 }
-                GameResolutionFullscreen.IsEnabled = true;
+                else
+                {
+                    GameWindowResizable.IsEnabled = true;
+                    GameResolutionFullscreen.IsEnabled = true;
+                }
             }
         }
 
@@ -99,6 +108,17 @@ namespace CollapseLauncher.Pages
                 }
                 GameCustomResolutionCheckbox.IsEnabled = true;
             }
+        }
+
+        public bool IsCanResizableWindow
+        {
+            get => !Settings.SettingsScreen.isfullScreen && !IsExclusiveFullscreenEnabled;
+        }
+
+        public bool IsResizableWindow
+        {
+            get => Settings.SettingsCollapseScreen.UseResizableWindow;
+            set => Settings.SettingsCollapseScreen.UseResizableWindow = value;
         }
 
         public int ResolutionW

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -36,14 +36,42 @@
                             <StackPanel x:Name="GameResolutionPanel" Margin="0,0">
                                 <StackPanel>
                                     <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_ResolutionPanel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,16"/>
-                                    <StackPanel x:Name="GameResolutionWindow" Orientation="Vertical" Margin="0,0,0,0">
+                                    <StackPanel x:Name="GameResolutionWindow" Orientation="Vertical" Margin="0,0,0,8">
                                         <CheckBox x:Name="VSyncToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VSync}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind VerticalSync, Mode=TwoWay}"/>
                                         <CheckBox x:Name="GameResolutionFullscreen" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_Fullscreen}"
                                             HorizontalAlignment="Left" VerticalAlignment="Center"
-                                            IsChecked="{x:Bind IsFullscreenEnabled, Mode=TwoWay}" Margin="0,0,0,0"/>
+                                            IsChecked="{x:Bind IsFullscreenEnabled, Mode=TwoWay}"/>
                                         <CheckBox x:Name="GameResolutionBorderless" Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Borderless}"
                                             HorizontalAlignment="Left" VerticalAlignment="Center"
-                                            IsChecked="{x:Bind IsBorderlessEnabled, Mode=TwoWay}" Margin="0,0,0,8"/>
+                                            IsChecked="{x:Bind IsBorderlessEnabled, Mode=TwoWay}"/>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox x:Name="GameWindowResizable" Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_ResizableWindow}"
+                                                  HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                  IsEnabled="{x:Bind IsCanResizableWindow, Mode=OneWay}"
+                                                  IsChecked="{x:Bind IsResizableWindow, Mode=TwoWay}"/>
+                                            <Button Grid.Column="1" Margin="8,-4,0,0" Style="{ThemeResource ButtonRevealStyle}">
+                                                <Button.Content>
+                                                    <FontIcon
+                                                        FontFamily="{ThemeResource FontAwesome}"
+                                                        FontSize="12"
+                                                        Glyph="&#x3f;" />
+                                                </Button.Content>
+                                                <Button.Flyout>
+                                                    <Flyout AllowFocusOnInteraction="True">
+                                                        <TextBlock
+                                                            Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_ResizableWindowTooltip}"
+                                                            MaxWidth="360"
+                                                            TextWrapping="Wrap"
+                                                            TextAlignment="Center"
+                                                            FontWeight="SemiBold"/>
+                                                    </Flyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </Grid>
                                         <!--
                                         Exclusive Fullscreen option is disabled for Genshin due to the amount of bugs it caused
                                         Ref: https://www.pcgamingwiki.com/wiki/Genshin_Impact#G-Sync_.2F_Variable_Refresh_Rate_Does_Not_Work

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -1213,11 +1213,12 @@ namespace CollapseLauncher.Pages
             InstallGameBtn.Visibility = Visibility.Visible;
             CancelDownloadBtn.Visibility = Visibility.Collapsed;
         }
-
-        CancellationTokenSource WatchOutputLog = new CancellationTokenSource();
         #endregion
 
         #region Game Start/Stop Method
+
+        CancellationTokenSource WatchOutputLog = new CancellationTokenSource();
+        CancellationTokenSource ResizableWindowHookToken;
         private async void StartGame(object sender, RoutedEventArgs e)
         {
             try
@@ -1230,10 +1231,10 @@ namespace CollapseLauncher.Pages
                 if (CurrentGameProperty._GameVersion.GameType == GameType.Genshin && GetAppConfigValue("ForceGIHDREnable").ToBool())
                     GenshinHDREnforcer();
 
-                Process proc = new Process();
-                proc.StartInfo.FileName = Path.Combine(NormalizePath(GameDirPath), CurrentGameProperty._GameVersion.GamePreset.GameExecutableName);
-                proc.StartInfo.UseShellExecute = true;
-                proc.StartInfo.Arguments = GetLaunchArguments();
+                Process proc                    = new Process();
+                proc.StartInfo.FileName         = Path.Combine(NormalizePath(GameDirPath), CurrentGameProperty._GameVersion.GamePreset.GameExecutableName);
+                proc.StartInfo.UseShellExecute  = true;
+                proc.StartInfo.Arguments        = GetLaunchArguments(_Settings);
                 LogWriteLine($"Running game with parameters:\r\n{proc.StartInfo.Arguments}");
                 // proc.StartInfo.WorkingDirectory = CurrentGameProperty._GameVersion.GamePreset.ZoneName == "Bilibili" ||
                 //     (CurrentGameProperty._GameVersion.GameType == GameType.Genshin
@@ -1245,12 +1246,18 @@ namespace CollapseLauncher.Pages
                 proc.StartInfo.Verb             = "runas";
                 proc.Start();
 
-                WatchOutputLog = new CancellationTokenSource();
-
+                // Start the resizable window payload (also use the same token as PlaytimeToken)
+                StartResizableWindowPayload(
+                    CurrentGameProperty._GameVersion.GamePreset.GameName,
+                    _Settings,
+                    CurrentGameProperty._GameVersion.GamePreset.GameType);
                 GameRunningWatcher();
 
                 if (GetAppConfigValue("EnableConsole").ToBool())
+                {
+                    WatchOutputLog = new CancellationTokenSource();
                     ReadOutputLog();
+                }
 
                 switch (GetAppConfigValue("GameLaunchedBehavior").ToString())
                 {
@@ -1267,9 +1274,6 @@ namespace CollapseLauncher.Pages
                         (m_window as MainWindow).Minimize();
                         break;
                 }
-
-                // Start the resizable window payload (also use the same token as PlaytimeToken)
-                StartResizableWindowPayload(CurrentGameProperty._GameVersion.GamePreset, PlaytimeToken.Token);
 
                 StartPlaytimeCounter(CurrentGameProperty._GameVersion.GamePreset.ConfigRegistryLocation, proc, CurrentGameProperty._GameVersion.GamePreset);
                 AutoUpdatePlaytimeCounter(true, PlaytimeToken.Token);
@@ -1312,6 +1316,8 @@ namespace CollapseLauncher.Pages
                 await Task.Delay(3000);
             }
 
+            if (ResizableWindowHookToken != null) ResizableWindowHookToken.Cancel();
+
             // Stopping GameLogWatcher
             if (GetAppConfigValue("EnableConsole").ToBool())
                 WatchOutputLog.Cancel();
@@ -1353,39 +1359,45 @@ namespace CollapseLauncher.Pages
         #endregion
 
         #region Game Resizable Window Payload
-        public async void StartResizableWindowPayload(PresetConfigV2 gamePreset, CancellationToken token)
+        internal async void StartResizableWindowPayload(string executableName, IGameSettingsUniversal settings, GameType gameType)
         {
             try
             {
                 // Check if the game is using Resizable Window settings
-                IGameSettingsUniversal _Settings = CurrentGameProperty._GameSettings.AsIGameSettingsUniversal();
-                if (!_Settings.SettingsCollapseScreen.UseResizableWindow) return;
+                if (!settings.SettingsCollapseScreen.UseResizableWindow) return;
+                ResizableWindowHookToken = new CancellationTokenSource();
 
-                string executableName = Path.GetFileNameWithoutExtension(gamePreset.GameExecutableName);
+                executableName = Path.GetFileNameWithoutExtension(executableName);
                 ResizableWindowHook resizableWindowHook = new ResizableWindowHook();
 
                 // Set the pos + size reinitialization to true if the game is Honkai: Star Rail
                 // This is required for Honkai: Star Rail since the game will reset its pos + size. Making
                 // it impossible to use custom resolution (but since you are using Collapse, it's now
                 // possible :teriStare:)
-                bool isNeedToResetPos = gamePreset.GameType == GameType.StarRail;
-                await resizableWindowHook.StartHook(executableName, token, isNeedToResetPos);
+                bool isNeedToResetPos = gameType == GameType.StarRail;
+                await resizableWindowHook.StartHook(executableName, ResizableWindowHookToken.Token, isNeedToResetPos);
             }
             catch (Exception ex)
             {
                 LogWriteLine($"Error while initializing Resizable Window payload!\r\n{ex}");
                 ErrorSender.SendException(ex, ErrorType.GameError);
             }
+            finally
+            {
+                if (ResizableWindowHookToken != null)
+                {
+                    ResizableWindowHookToken.Dispose();
+                }
+            }
         }
         #endregion
 
         #region Game Launch Argument Builder
         bool RequireWindowExclusivePayload = false;
-        public string GetLaunchArguments()
+        internal string GetLaunchArguments(IGameSettingsUniversal _Settings)
         {
             StringBuilder parameter = new StringBuilder();
 
-            IGameSettingsUniversal _Settings = CurrentGameProperty._GameSettings.AsIGameSettingsUniversal();
             if (CurrentGameProperty._GameVersion.GameType == GameType.Honkai)
             {
                 if (_Settings.SettingsCollapseScreen.UseExclusiveFullscreen)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.Ext.cs
@@ -16,10 +16,13 @@ namespace CollapseLauncher.Pages
                 Settings.SettingsScreen.isfullScreen = value;
                 if (value)
                 {
+                    GameWindowResizable.IsEnabled = false;
+                    GameWindowResizable.IsChecked = false;
                     GameResolutionFullscreenExclusive.IsEnabled = !IsCustomResolutionEnabled;
                     GameResolutionBorderless.IsChecked = false;
                     return;
                 }
+                GameWindowResizable.IsEnabled = true;
                 GameResolutionFullscreenExclusive.IsEnabled = false;
                 GameResolutionFullscreenExclusive.IsChecked = false;
                 GameResolutionBorderless.IsEnabled = true;
@@ -34,10 +37,16 @@ namespace CollapseLauncher.Pages
                 Settings.SettingsCollapseScreen.UseBorderlessScreen = value;
                 if (value)
                 {
+                    GameWindowResizable.IsEnabled = false;
+                    GameWindowResizable.IsChecked = false;
                     GameResolutionFullscreen.IsEnabled = false;
                     GameResolutionFullscreen.IsChecked = false;
                 }
-                GameResolutionFullscreen.IsEnabled = true;
+                else
+                {
+                    GameWindowResizable.IsEnabled = true;
+                    GameResolutionFullscreen.IsEnabled = true;
+                }
             }
         }
 
@@ -98,6 +107,34 @@ namespace CollapseLauncher.Pages
                 }
                 GameCustomResolutionCheckbox.IsEnabled = true;
             }
+        }
+
+        public bool IsCanResizableWindow
+        {
+            get => !Settings.SettingsScreen.isfullScreen && !IsExclusiveFullscreenEnabled;
+        }
+
+        public bool IsResizableWindow
+        {
+            get => Settings.SettingsCollapseScreen.UseResizableWindow;
+            set
+            {
+                Settings.SettingsCollapseScreen.UseResizableWindow = value;
+                if (value)
+                {
+                    GameCustomResolutionCheckbox.IsEnabled = true;
+                }
+                else
+                {
+                    GameCustomResolutionCheckbox.IsEnabled = false;
+                    GameCustomResolutionCheckbox.IsChecked = false;
+                }
+            }
+        }
+
+        public bool IsCanCustomResolution
+        {
+            get => Settings.SettingsCollapseScreen.UseResizableWindow && !IsExclusiveFullscreenEnabled;
         }
 
         public int ResolutionW

--- a/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.xaml
@@ -35,8 +35,36 @@
                                                   HorizontalAlignment="Left" VerticalAlignment="Center"
                                                   IsChecked="{x:Bind IsFullscreenEnabled, Mode=TwoWay}"/>
                                         <CheckBox x:Name="GameResolutionBorderless" Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Borderless}"
-          HorizontalAlignment="Left" VerticalAlignment="Center"
-          IsChecked="{x:Bind IsBorderlessEnabled, Mode=TwoWay}"/>
+                                                  HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                  IsChecked="{x:Bind IsBorderlessEnabled, Mode=TwoWay}"/>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox x:Name="GameWindowResizable" Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_ResizableWindow}"
+                                                  HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                  IsEnabled="{x:Bind IsCanResizableWindow, Mode=OneWay}"
+                                                  IsChecked="{x:Bind IsResizableWindow, Mode=TwoWay}"/>
+                                            <Button Grid.Column="1" Margin="8,-4,0,0" Style="{ThemeResource ButtonRevealStyle}">
+                                                <Button.Content>
+                                                    <FontIcon
+                                                        FontFamily="{ThemeResource FontAwesome}"
+                                                        FontSize="12"
+                                                        Glyph="&#x3f;" />
+                                                </Button.Content>
+                                                <Button.Flyout>
+                                                    <Flyout AllowFocusOnInteraction="True">
+                                                        <TextBlock
+                                                            Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_ResizableWindowTooltip}"
+                                                            MaxWidth="360"
+                                                            TextWrapping="Wrap"
+                                                            TextAlignment="Center"
+                                                            FontWeight="SemiBold"/>
+                                                    </Flyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </Grid>
                                         <!--
                                         Exclusive Fullscreen option is disabled in Honkai:Star Rail due to it being ignored by the game
                                         Delete `Visibility="Collapsed"' to revert this change
@@ -51,10 +79,34 @@
                                                   PlaceholderText="{x:Bind helper:Locale.Lang._StarRailGameSettingsPage.Graphics_ResSelectPlaceholder}" Width="128"
                                                   IsEnabled="{x:Bind IsCustomResolutionEnabled, Mode=OneWay, Converter={StaticResource BooleanInverse}}"
                                                   SelectedItem="{x:Bind ResolutionSelected, Mode=TwoWay}"/>
-                                        <CheckBox x:Name="GameCustomResolutionCheckbox" Content="{x:Bind helper:Locale.Lang._StarRailGameSettingsPage.Graphics_ResCustom}"
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox x:Name="GameCustomResolutionCheckbox" Content="{x:Bind helper:Locale.Lang._StarRailGameSettingsPage.Graphics_ResCustom}"
                                                   VerticalAlignment="Center" Margin="16,0,0,0"
-                                                  IsEnabled="{x:Bind IsExclusiveFullscreenEnabled, Mode=OneWay, Converter={StaticResource BooleanInverse}}"
+                                                  IsEnabled="{x:Bind IsCanCustomResolution, Mode=OneWay}"
                                                   IsChecked="{x:Bind IsCustomResolutionEnabled, Mode=TwoWay}"/>
+                                            <Button Grid.Column="1" Margin="8,-4,0,0" Style="{ThemeResource ButtonRevealStyle}">
+                                                <Button.Content>
+                                                    <FontIcon
+                                                        FontFamily="{ThemeResource FontAwesome}"
+                                                        FontSize="12"
+                                                        Glyph="&#x3f;" />
+                                                </Button.Content>
+                                                <Button.Flyout>
+                                                    <Flyout AllowFocusOnInteraction="True">
+                                                        <TextBlock
+                                                            Text="{x:Bind helper:Locale.Lang._StarRailGameSettingsPage.Graphics_ResCustomTooltip}"
+                                                            MaxWidth="360"
+                                                            TextWrapping="Wrap"
+                                                            TextAlignment="Center"
+                                                            FontWeight="SemiBold"/>
+                                                    </Flyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </Grid>
                                     </StackPanel>
                                 </StackPanel>
                                 <StackPanel x:Name="GameCustomResolutionPanel" Orientation="Horizontal">

--- a/Hi3Helper.Core/Lang/Locale/LangGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangGameSettingsPage.cs
@@ -14,6 +14,8 @@
                 public string Graphics_Fullscreen { get; set; } = LangFallback?._GameSettingsPage.Graphics_Fullscreen;
                 public string Graphics_Borderless { get; set; } = LangFallback?._GameSettingsPage.Graphics_Borderless;
                 public string Graphics_ExclusiveFullscreen { get; set; } = LangFallback?._GameSettingsPage.Graphics_ExclusiveFullscreen;
+                public string Graphics_ResizableWindow { get; set; } = LangFallback?._GameSettingsPage.Graphics_ResizableWindow;
+                public string Graphics_ResizableWindowTooltip { get; set; } = LangFallback?._GameSettingsPage.Graphics_ResizableWindowTooltip;
                 public string Graphics_ResSelectPlaceholder { get; set; } = LangFallback?._GameSettingsPage.Graphics_ResSelectPlaceholder;
                 public string Graphics_ResCustom { get; set; } = LangFallback?._GameSettingsPage.Graphics_ResCustom;
                 public string Graphics_ResCustomW { get; set; } = LangFallback?._GameSettingsPage.Graphics_ResCustomW;

--- a/Hi3Helper.Core/Lang/Locale/LangStarRailGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangStarRailGameSettingsPage.cs
@@ -15,6 +15,7 @@
                 public string Graphics_ExclusiveFullscreen { get; set; } = LangFallback?._StarRailGameSettingsPage.Graphics_ExclusiveFullscreen;
                 public string Graphics_ResSelectPlaceholder { get; set; } = LangFallback?._StarRailGameSettingsPage.Graphics_ResSelectPlaceholder;
                 public string Graphics_ResCustom { get; set; } = LangFallback?._StarRailGameSettingsPage.Graphics_ResCustom;
+                public string Graphics_ResCustomTooltip { get; set; } = LangFallback?._StarRailGameSettingsPage.Graphics_ResCustomTooltip;
                 public string Graphics_ResCustomW { get; set; } = LangFallback?._StarRailGameSettingsPage.Graphics_ResCustomW;
                 public string Graphics_ResCustomH { get; set; } = LangFallback?._StarRailGameSettingsPage.Graphics_ResCustomH;
                 public string OverlayNotInstalledTitle { get; set; } = LangFallback?._StarRailGameSettingsPage.OverlayNotInstalledTitle;

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -238,6 +238,8 @@
     "Graphics_Borderless": "Use Borderless Windowed Mode",
     "Graphics_Fullscreen": "Fullscreen",
     "Graphics_ExclusiveFullscreen": "Use Exclusive Fullscreen",
+    "Graphics_ResizableWindow": "Use Resizable Window",
+    "Graphics_ResizableWindowTooltip": "This setting can only be used with Fullscreen mode disabled.",
     "Graphics_ResSelectPlaceholder": "Select",
     "Graphics_ResCustom": "Use Custom Resolution",
     "Graphics_ResCustomW": "W",
@@ -868,6 +870,7 @@
     "Graphics_ExclusiveFullscreen": "Use Exclusive Fullscreen",
     "Graphics_ResSelectPlaceholder": "Select",
     "Graphics_ResCustom": "Use Custom Resolution",
+    "Graphics_ResCustomTooltip": "Custom Resolution can only be used with Resizable Window enabled",
     "Graphics_ResCustomW": "W",
     "Graphics_ResCustomH": "H",
 


### PR DESCRIPTION
# What's new?
This PR brings the "Resizable Window" which enables the Game Window to be resizable. This feature could only work on Windowed mode (not including borderless).

This feature works by using Win32 functions by manipulating the game window's ``GWL_STYLE`` flag.
https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles

# Behavior Changes
### For Honkai: Star Rail
"Use Custom Resolution" mode can only be used with "Resizable Window" enabled. If the "Resizable Window" is disabled, the checkbox for "Use Custom Resolution" will be disabled.

# Feature Preview

https://github.com/CollapseLauncher/Collapse/assets/30566970/84a0d709-16f2-449f-9af2-52221b5a7f26

