### PR TITLE
(Discord RPC) Catch SEHException on Dispose

### DIFF
--- a/Hi3Helper.Core/Classes/DiscordPresence/src/Core.cs
+++ b/Hi3Helper.Core/Classes/DiscordPresence/src/Core.cs
@@ -1084,7 +1084,14 @@ namespace Discord
         {
             if (MethodsPtr != IntPtr.Zero)
             {
-                Methods.Destroy(MethodsPtr);
+                try
+                {
+                    Methods.Destroy(MethodsPtr);
+                }
+                catch (SEHException e)
+                {
+                    // Ignore CloseHandle SEH exception caused by Discord SDK
+                }
             }
             SelfHandle.Free();
             Marshal.FreeHGlobal(EventsPtr);


### PR DESCRIPTION
Discord will call `CloseHandle` on an already closed named pipe "discord-ipc-0" handle if Discord client was closed before we call `Destroy`.
Only affects debug mode.