### PR TITLE
Fix parsing for ```LastPlayTime``` in the Steam Shortcuts Parser 

### DIFF
--- a/CollapseLauncher/Classes/ShortcutCreator/SteamShortcut.cs
+++ b/CollapseLauncher/Classes/ShortcutCreator/SteamShortcut.cs
@@ -36,7 +36,7 @@ namespace CollapseLauncher.ShortcutUtils
         public bool Devkit = false;
         public string DevkitGameID = "";
         public bool DevkitOverrideAppID = false;
-        public string LastPlayTime = "\x00\x00\x00";
+        public string LastPlayTime = "\x00\x00\x00\x00";
         public string FlatpakAppID = "";
         public string tags = "";
         #endregion
@@ -80,7 +80,7 @@ namespace CollapseLauncher.ShortcutUtils
                     + '\x02' + "Devkit" + '\x00' + BoolToByte(Devkit) + "\x00\x00\x00"
                     + '\x01' + "DevkitGameID" + '\x00' + DevkitGameID + '\x00'
                     + '\x02' + "DevkitOverrideAppID" + '\x00' + BoolToByte(DevkitOverrideAppID) + "\x00\x00\x00"
-                    + '\x02' + "LastPlayTime" + '\x00' + LastPlayTime + '\x00'
+                    + '\x02' + "LastPlayTime" + '\x00' + LastPlayTime
                     + '\x01' + "FlatpakAppID" + '\x00' + FlatpakAppID + '\x00'
                     + '\x00' + "tags" + '\x00' + tags + "\x08\x08";
         }

--- a/CollapseLauncher/Classes/ShortcutCreator/SteamShortcutParser.cs
+++ b/CollapseLauncher/Classes/ShortcutCreator/SteamShortcutParser.cs
@@ -33,7 +33,7 @@ namespace CollapseLauncher.ShortcutUtils
             {
                 _shortcuts.RemoveAll(x => x.preliminaryAppID == shortcut.preliminaryAppID);
             }
-                
+            
             _shortcuts.Add(shortcut);
             shortcut.MoveImages(_path, preset);
         }
@@ -110,7 +110,11 @@ namespace CollapseLauncher.ShortcutUtils
                             parse = parse == ParseType.NameStr ? ParseType.ValueStr : ParseType.ValueBool;
                             string key = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
                             if (key == "LastPlayTime")
+                            {
                                 parse = ParseType.ValueTime;
+                                if (i < ln.Length - 1 && ln[i + 1] == 0)
+                                    i++;
+                            }
                             if (key == "appid")
                                 parse = ParseType.ValueAppid;
                             buffer = [];
@@ -119,13 +123,12 @@ namespace CollapseLauncher.ShortcutUtils
                         buffer.Add(ln[i]);
                         break;
                     case ParseType.ValueTime:
-                        if (ln[i] == 0)
+                        if (ln[i] == 1 || ln[i] == 2)
                         {
-                            newShortcut.LastPlayTime = buffer.Count != 0 ? ANSI.GetString(buffer.ToArray(), 0, buffer.Count) : "\x00\x00\x00";
+                            newShortcut.LastPlayTime = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
                             buffer = [];
                             parse = ParseType.FindType;
-                            while (i < ln.Length - 1 && ln[i + 1] == 0)
-                                i++;
+                            i--;
                             continue;
                         }
                         buffer.Add(ln[i]);

--- a/CollapseLauncher/Classes/ShortcutCreator/SteamShortcutParser.cs
+++ b/CollapseLauncher/Classes/ShortcutCreator/SteamShortcutParser.cs
@@ -134,7 +134,6 @@ namespace CollapseLauncher.ShortcutUtils
                             newShortcut.LastPlayTime = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
                             buffer = [];
                             parse = ParseType.FindType;
-                            continue;
                         }
                         break;
                     case ParseType.ValueAppid:

--- a/CollapseLauncher/Classes/ShortcutCreator/SteamShortcutParser.cs
+++ b/CollapseLauncher/Classes/ShortcutCreator/SteamShortcutParser.cs
@@ -110,35 +110,10 @@ namespace CollapseLauncher.ShortcutUtils
                             parse = parse == ParseType.NameStr ? ParseType.ValueStr : ParseType.ValueBool;
                             string key = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
                             if (key == "LastPlayTime")
-                            {
                                 parse = ParseType.ValueTime;
-                                if (i < ln.Length - 1 && ln[i + 1] == 0)
-                                    i++;
-                            }
                             if (key == "appid")
                                 parse = ParseType.ValueAppid;
                             buffer = [];
-                            continue;
-                        }
-                        buffer.Add(ln[i]);
-                        break;
-                    case ParseType.ValueTime:
-                        if (ln[i] == 1 || ln[i] == 2)
-                        {
-                            newShortcut.LastPlayTime = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
-                            buffer = [];
-                            parse = ParseType.FindType;
-                            i--;
-                            continue;
-                        }
-                        buffer.Add(ln[i]);
-                        break;
-                    case ParseType.ValueAppid:
-                        if (ln[i] == 1)
-                        {
-                            newShortcut.appid = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
-                            buffer = [];
-                            parse = ParseType.NameStr;
                             continue;
                         }
                         buffer.Add(ln[i]);
@@ -148,6 +123,26 @@ namespace CollapseLauncher.ShortcutUtils
                         {
                             parse = ParseType.ValueTags;
                             buffer = [];
+                            continue;
+                        }
+                        buffer.Add(ln[i]);
+                        break;
+                    case ParseType.ValueTime:
+                        buffer.Add(ln[i]);
+                        if (buffer.Count == 4)
+                        {
+                            newShortcut.LastPlayTime = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
+                            buffer = [];
+                            parse = ParseType.FindType;
+                            continue;
+                        }
+                        break;
+                    case ParseType.ValueAppid:
+                        if (buffer.Count == 4)
+                        {
+                            newShortcut.appid = ANSI.GetString(buffer.ToArray(), 0, buffer.Count);
+                            buffer = [];
+                            parse = ParseType.NameStr;
                             continue;
                         }
                         buffer.Add(ln[i]);


### PR DESCRIPTION
https://gist.github.com/gablm/2a79355026bde51ac4f516d347fa1cd0 has a basic explanation of the ```shortcuts.vdf``` format. Hope it finds its way to anyone trying to decipher this file in the near future.
closes #400 
