### PR TITLE
Instant Region Change

### DIFF
--- a/CollapseLauncher.sln.DotSettings
+++ b/CollapseLauncher.sln.DotSettings
@@ -63,5 +63,9 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/Abbreviations/=SFX/@EntryIndexedValue">SFX</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/Abbreviations/=VO/@EntryIndexedValue">VO</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Shcore/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
+++ b/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
@@ -713,6 +713,16 @@ namespace CollapseLauncher
             LauncherFrame.BackStack.Clear();
         }
 
+        private async void ChangeRegionInstant()
+        {
+            CurrentGameCategory = ComboBoxGameCategory.SelectedIndex;
+            CurrentGameRegion = ComboBoxGameRegion.SelectedIndex;
+            await LoadRegionRootButton();
+            InvokeLoadingRegionPopup(false);
+            MainFrameChanger.ChangeMainFrame(m_appMode == AppMode.Hi3CacheUpdater ? typeof(CachesPage) : typeof(HomePage));
+            LauncherFrame.BackStack.Clear();
+        }
+
         private async void ChangeRegion(object sender, RoutedEventArgs e)
         {
             // Disable ChangeRegionBtn and hide flyout

--- a/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
+++ b/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
@@ -753,7 +753,7 @@ namespace CollapseLauncher
             ShowAsyncLoadingTimedOutPill();
             if (await LoadRegionFromCurrentConfigV2(Preset))
             {
-                LogWriteLine($"Region changed to {Preset.ZoneFullname}", Hi3Helper.LogType.Scheme, true);
+                LogWriteLine($"Region changed to {Preset.ZoneFullname}", LogType.Scheme, true);
 #if !DISABLEDISCORD
                 if (GetAppConfigValue("EnableDiscordRPC").ToBool())
                     AppDiscordPresence.SetupPresence();

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -1003,14 +1003,11 @@ namespace CollapseLauncher
             object selValue = ((ComboBox)sender).SelectedValue;
             if (selValue == null) return;
 
-            if (selValue != null)
-            {
-                string category = GetComboBoxGameRegionValue(ComboBoxGameCategory.SelectedValue);
-                string region = GetComboBoxGameRegionValue(selValue);
-                PresetConfigV2 preset = ConfigV2.MetadataV2[category][region];
-                ChangeRegionWarningText.Text = preset.GameChannel != GameChannel.Stable ? string.Format(Lang._MainPage.RegionChangeWarnExper1, preset.GameChannel) : string.Empty;
-                ChangeRegionWarning.Visibility = preset.GameChannel != GameChannel.Stable ? Visibility.Visible : Visibility.Collapsed;
-            }
+            string category = GetComboBoxGameRegionValue(ComboBoxGameCategory.SelectedValue);
+            string region = GetComboBoxGameRegionValue(selValue);
+            PresetConfigV2 preset = ConfigV2.MetadataV2[category][region];
+            ChangeRegionWarningText.Text = preset.GameChannel != GameChannel.Stable ? string.Format(Lang._MainPage.RegionChangeWarnExper1, preset.GameChannel) : string.Empty;
+            ChangeRegionWarning.Visibility = preset.GameChannel != GameChannel.Stable ? Visibility.Visible : Visibility.Collapsed;
             ChangeRegionConfirmBtn.IsEnabled          = !LockRegionChangeBtn;
             ChangeRegionConfirmBtnNoWarning.IsEnabled = !LockRegionChangeBtn;
             

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -1001,6 +1001,8 @@ namespace CollapseLauncher
             }
 
             object selValue = ((ComboBox)sender).SelectedValue;
+            if (selValue == null) return;
+
             if (selValue != null)
             {
                 string category = GetComboBoxGameRegionValue(ComboBoxGameCategory.SelectedValue);

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -104,7 +104,7 @@ namespace CollapseLauncher
         {
             try
             {
-                if (IsInstantRegionChange)
+                if (!IsShowRegionChangeWarning && IsInstantRegionChange)
                 {
                     ChangeRegionConfirmBtn.Visibility = Visibility.Collapsed;
                     ChangeRegionConfirmBtnNoWarning.Visibility = Visibility.Collapsed;
@@ -1011,7 +1011,7 @@ namespace CollapseLauncher
             ChangeRegionConfirmBtn.IsEnabled          = !LockRegionChangeBtn;
             ChangeRegionConfirmBtnNoWarning.IsEnabled = !LockRegionChangeBtn;
             
-            if (IsInstantRegionChange) ChangeRegionInstant();
+            if (!IsShowRegionChangeWarning && IsInstantRegionChange) ChangeRegionInstant();
         }
         #endregion
 

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Numerics;
 using System.Security.Principal;
 using System.Text.Json;
 using System.Threading;
@@ -61,7 +60,7 @@ namespace CollapseLauncher
         private RegionResourceProp _gameAPIProp { get; set; }
 
         private  static bool         IsChangeDragArea        = true;
-        internal static List<string> PreviousTagString       = new List<string>();
+        internal static List<string> PreviousTagString       = new();
         #endregion
 
         #region Main Routine
@@ -105,9 +104,17 @@ namespace CollapseLauncher
         {
             try
             {
-                ChangeRegionConfirmBtn.Visibility = !IsShowRegionChangeWarning ? Visibility.Collapsed : Visibility.Visible;
-                ChangeRegionConfirmBtnNoWarning.Visibility = !IsShowRegionChangeWarning ? Visibility.Visible : Visibility.Collapsed;
-
+                if (IsInstantRegionChange)
+                {
+                    ChangeRegionConfirmBtn.Visibility = Visibility.Collapsed;
+                    ChangeRegionConfirmBtnNoWarning.Visibility = Visibility.Collapsed;
+                }
+                else
+                {
+                    ChangeRegionConfirmBtn.Visibility = !IsShowRegionChangeWarning ? Visibility.Collapsed : Visibility.Visible;
+                    ChangeRegionConfirmBtnNoWarning.Visibility = !IsShowRegionChangeWarning ? Visibility.Visible : Visibility.Collapsed;
+                }
+                
                 if (!await CheckForAdminAccess(this))
                 {
                     (m_window as MainWindow)?.CloseApp();
@@ -1004,6 +1011,8 @@ namespace CollapseLauncher
             }
             ChangeRegionConfirmBtn.IsEnabled          = !LockRegionChangeBtn;
             ChangeRegionConfirmBtnNoWarning.IsEnabled = !LockRegionChangeBtn;
+            
+            if (IsInstantRegionChange) ChangeRegionInstant();
         }
         #endregion
 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -483,19 +483,21 @@
                                    Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}"
                                    TextWrapping="Wrap"
                                    Visibility="Collapsed" />
-                        <ToggleSwitch x:Name="ToggleChangeRegionInstant"
-                                      Margin="0,4"
-                                      Header="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionInstant_Toggle}"
-                                      IsOn="{x:Bind IsInstantRegionChange, Mode=TwoWay}"
-                                      OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}"
-                                      OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" />
-                        <TextBlock x:Name="InstantRegionToggleWarning"
-                                   Margin="0,0,0,8"
-                                   FontWeight="Bold"
-                                   Foreground="{ThemeResource AccentColor}"
-                                   Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}"
-                                   TextWrapping="Wrap"
-                                   Visibility="Collapsed" />
+                        <StackPanel x:Name="PanelChangeRegionInstant">
+                            <ToggleSwitch x:Name="ToggleChangeRegionInstant"
+                                          Margin="0,4"
+                                          Header="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionInstant_Toggle}"
+                                          IsOn="{x:Bind IsInstantRegionChange, Mode=TwoWay}"
+                                          OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}"
+                                          OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" />
+                            <TextBlock x:Name="InstantRegionToggleWarning"
+                                       Margin="0,0,0,8"
+                                       FontWeight="Bold"
+                                       Foreground="{ThemeResource AccentColor}"
+                                       Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}"
+                                       TextWrapping="Wrap"
+                                       Visibility="Collapsed" />
+                        </StackPanel>
                         <ToggleSwitch Margin="0,4"
                                       Header="{x:Bind helper:Locale.Lang._SettingsPage.UseExternalBrowser}"
                                       IsOn="{x:Bind IsAlwaysUseExternalBrowser, Mode=TwoWay}"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -483,6 +483,19 @@
                                    Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}"
                                    TextWrapping="Wrap"
                                    Visibility="Collapsed" />
+                        <ToggleSwitch x:Name="ToggleChangeRegionInstant"
+                                      Margin="0,4"
+                                      Header="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionInstant_Toggle}"
+                                      IsOn="{x:Bind IsInstantRegionChange, Mode=TwoWay}"
+                                      OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}"
+                                      OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" />
+                        <TextBlock x:Name="InstantRegionToggleWarning"
+                                   Margin="0,0,0,8"
+                                   FontWeight="Bold"
+                                   Foreground="{ThemeResource AccentColor}"
+                                   Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}"
+                                   TextWrapping="Wrap"
+                                   Visibility="Collapsed" />
                         <ToggleSwitch Margin="0,4"
                                       Header="{x:Bind helper:Locale.Lang._SettingsPage.UseExternalBrowser}"
                                       IsOn="{x:Bind IsAlwaysUseExternalBrowser, Mode=TwoWay}"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -78,8 +78,11 @@ namespace CollapseLauncher.Pages
             if (IsAppLangNeedRestart)
                 AppLangSelectionWarning.Visibility = Visibility.Visible;
 
-            if (IsChangeRegionWarningNeedRestart)
+            if (IsChangeRegionWarningNeedRestart) 
                 ChangeRegionToggleWarning.Visibility = Visibility.Visible;
+
+            if (IsInstantRegionNeedRestart)
+                InstantRegionToggleWarning.Visibility = Visibility.Visible;
 
             string SwitchToVer = IsPreview ? "Stable" : "Preview";
             ChangeReleaseBtnText.Text = string.Format(Lang._SettingsPage.AppChangeReleaseChannel, SwitchToVer);
@@ -788,16 +791,42 @@ namespace CollapseLauncher.Pages
 
         private bool IsShowRegionChangeWarning
         {
-            get => LauncherConfig.IsShowRegionChangeWarning;
+            get
+            { 
+                var value = LauncherConfig.IsShowRegionChangeWarning;
+
+                ToggleChangeRegionInstant.Visibility = !value ? Visibility.Visible : Visibility.Collapsed;
+                return value;
+            }
             set
             {
                 IsChangeRegionWarningNeedRestart = true;
                 ChangeRegionToggleWarning.Visibility = Visibility.Visible;
 
                 LauncherConfig.IsShowRegionChangeWarning = value;
+                ToggleChangeRegionInstant.Visibility     = !value ? Visibility.Visible : Visibility.Collapsed;
+
+                if (value)
+                {
+                    // Disable instant region change and suppress its warning
+                    ToggleChangeRegionInstant.IsOn        = false;
+                    InstantRegionToggleWarning.Visibility = Visibility.Collapsed;
+                    IsInstantRegionNeedRestart            = false;
+                }
             }
         }
 
+        private bool IsInstantRegionChange
+        {
+            get => LauncherConfig.IsInstantRegionChange;
+            set
+            {
+                IsInstantRegionNeedRestart            = true;
+                InstantRegionToggleWarning.Visibility = Visibility.Visible;
+                
+                LauncherConfig.IsInstantRegionChange = value;
+            }
+        }
         private bool IsUseDownloadChunksMerging
         {
             get => GetAppConfigValue("UseDownloadChunksMerging").ToBool();

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -43,14 +43,19 @@ namespace CollapseLauncher.Pages
         #region Properties
 
         private const string _collapseStartupTaskName = "CollapseLauncherStartupTask";
-        private const string RepoUrl = "https://github.com/CollapseLauncher/Collapse/commit/";
-
+        private const string RepoUrl                  = "https://github.com/CollapseLauncher/Collapse/commit/";
+        
+        private readonly bool _initIsInstantRegionChange;
+        private readonly bool _initIsShowRegionChangeWarning;
         #endregion
 
         #region Settings Page Handler
         public SettingsPage()
         {
-            this.InitializeComponent();
+            _initIsInstantRegionChange     = LauncherConfig.IsInstantRegionChange;
+            _initIsShowRegionChangeWarning = LauncherConfig.IsShowRegionChangeWarning;
+                
+            InitializeComponent();
             this.EnableImplicitAnimation(true);
             AboutApp.FindAndSetTextBlockWrapping(TextWrapping.Wrap, HorizontalAlignment.Center, TextAlignment.Center, true);
 
@@ -78,7 +83,7 @@ namespace CollapseLauncher.Pages
             if (IsAppLangNeedRestart)
                 AppLangSelectionWarning.Visibility = Visibility.Visible;
 
-            if (IsChangeRegionWarningNeedRestart) 
+            if (IsChangeRegionWarningNeedRestart)
                 ChangeRegionToggleWarning.Visibility = Visibility.Visible;
 
             if (IsInstantRegionNeedRestart)
@@ -795,34 +800,28 @@ namespace CollapseLauncher.Pages
             { 
                 var value = LauncherConfig.IsShowRegionChangeWarning;
 
-                ToggleChangeRegionInstant.Visibility = !value ? Visibility.Visible : Visibility.Collapsed;
+                PanelChangeRegionInstant.Visibility = !value ? Visibility.Visible : Visibility.Collapsed;
                 return value;
             }
             set
             {
-                IsChangeRegionWarningNeedRestart = true;
-                ChangeRegionToggleWarning.Visibility = Visibility.Visible;
-
                 LauncherConfig.IsShowRegionChangeWarning = value;
-                ToggleChangeRegionInstant.Visibility     = !value ? Visibility.Visible : Visibility.Collapsed;
-
-                if (value)
-                {
-                    // Disable instant region change and suppress its warning
-                    ToggleChangeRegionInstant.IsOn        = false;
-                    InstantRegionToggleWarning.Visibility = Visibility.Collapsed;
-                    IsInstantRegionNeedRestart            = false;
-                }
+                IsChangeRegionWarningNeedRestart         = true;
+                
+                var valueConfig = _initIsShowRegionChangeWarning;
+                ChangeRegionToggleWarning.Visibility = value != valueConfig ? Visibility.Visible : Visibility.Collapsed;
+                PanelChangeRegionInstant.Visibility  = !value ? Visibility.Visible : Visibility.Collapsed;
             }
         }
-
+        
         private bool IsInstantRegionChange
         {
             get => LauncherConfig.IsInstantRegionChange;
             set
             {
-                IsInstantRegionNeedRestart            = true;
-                InstantRegionToggleWarning.Visibility = Visibility.Visible;
+                IsInstantRegionNeedRestart = true;
+                var valueConfig = _initIsInstantRegionChange;
+                InstantRegionToggleWarning.Visibility = value != valueConfig ? Visibility.Visible : Visibility.Collapsed;
                 
                 LauncherConfig.IsInstantRegionChange = value;
             }

--- a/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
+++ b/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
@@ -320,7 +320,7 @@ public static DiscordPresenceManager AppDiscordPresence;
             { "EnableWaifu2X", false },
             { "BackgroundAudioVolume", 0.75d },
             { "BackgroundAudioIsMute", true },
-            { "UseInstantRegionChange", false }
+            { "UseInstantRegionChange", true }
         };
         #endregion
     }

--- a/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
+++ b/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
@@ -249,6 +249,7 @@ public static DiscordPresenceManager AppDiscordPresence;
         public static bool IsPreview                        = false;
         public static bool IsAppThemeNeedRestart            = false;
         public static bool IsChangeRegionWarningNeedRestart = false;
+        public static bool IsInstantRegionNeedRestart       = false;
         public static bool IsFirstInstall                   = false;
         public static bool IsConsoleEnabled
         {
@@ -264,6 +265,12 @@ public static DiscordPresenceManager AppDiscordPresence;
         {
             get => GetAppConfigValue("ShowRegionChangeWarning").ToBool();
             set => SetAndSaveConfigValue("ShowRegionChangeWarning", value);
+        }
+
+        public static bool IsInstantRegionChange
+        {
+            get => GetAppConfigValue("UseInstantRegionChange").ToBool();
+            set => SetAndSaveConfigValue("UseInstantRegionChange", value);
         }
 
         public static bool                 ForceInvokeUpdate     = false;
@@ -313,6 +320,7 @@ public static DiscordPresenceManager AppDiscordPresence;
             { "EnableWaifu2X", false },
             { "BackgroundAudioVolume", 0.75d },
             { "BackgroundAudioIsMute", true },
+            { "UseInstantRegionChange", false }
         };
         #endregion
     }

--- a/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
+++ b/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
@@ -267,9 +267,14 @@ public static DiscordPresenceManager AppDiscordPresence;
             set => SetAndSaveConfigValue("ShowRegionChangeWarning", value);
         }
 
+        private static bool? _cachedIsInstantRegionChange = null;
         public static bool IsInstantRegionChange
         {
-            get => GetAppConfigValue("UseInstantRegionChange").ToBool();
+            get
+            {
+                _cachedIsInstantRegionChange ??= GetAppConfigValue("UseInstantRegionChange").ToBool();
+                return (bool)_cachedIsInstantRegionChange;
+            }
             set => SetAndSaveConfigValue("UseInstantRegionChange", value);
         }
 

--- a/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
@@ -14,6 +14,7 @@
                 public string Debug_IncludeGameLogs                 { get; set; } = LangFallback?._SettingsPage.Debug_IncludeGameLogs;
                 public string Debug_MultipleInstance                { get; set; } = LangFallback?._SettingsPage.Debug_MultipleInstance;
                 public string ChangeRegionWarning_Toggle            { get; set; } = LangFallback?._SettingsPage.ChangeRegionWarning_Toggle;
+                public string ChangeRegionInstant_Toggle            { get; set; } = LangFallback?._SettingsPage.ChangeRegionInstant_Toggle;
                 public string ChangeRegionWarning_Warning           { get; set; } = LangFallback?._SettingsPage.ChangeRegionWarning_Warning;
                 public string Language                              { get; set; } = LangFallback?._SettingsPage.Language;
                 public string LanguageEntry                         { get; set; } = LangFallback?._SettingsPage.LanguageEntry;
@@ -89,7 +90,7 @@
                 public string EnableAcrylicEffect                   { get; set; } = LangFallback?._SettingsPage.EnableAcrylicEffect;
                 public string EnableDownloadChunksMerging           { get; set; } = LangFallback?._SettingsPage.EnableDownloadChunksMerging;
                 public string LowerCollapsePrioOnGameLaunch         { get; set; } = LangFallback?._SettingsPage.LowerCollapsePrioOnGameLaunch;
-                public string LowerCollapsePrioOnGameLaunch_Tooltip {get;  set;}  = LangFallback?._SettingsPage.LowerCollapsePrioOnGameLaunch_Tooltip;
+                public string LowerCollapsePrioOnGameLaunch_Tooltip { get; set; }  = LangFallback?._SettingsPage.LowerCollapsePrioOnGameLaunch_Tooltip;
                 public string UseExternalBrowser                    { get; set; } = LangFallback?._SettingsPage.UseExternalBrowser;
 				public string KbShortcuts_Title                     { get; set; } = LangFallback?._SettingsPage.KbShortcuts_Title;
                 public string KbShortcuts_ShowBtn                   { get; set; } = LangFallback?._SettingsPage.KbShortcuts_ShowBtn;

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -369,6 +369,7 @@
     "Debug_MultipleInstance": "Allow running multiple instances of Collapse",
 
     "ChangeRegionWarning_Toggle": "Show Region Change Warning",
+    "ChangeRegionInstant_Toggle": "Instantly Change Region on Selection",
     "ChangeRegionWarning_Warning": "*You need to restart the app for this setting to take effect.",
 
     "Language": "App Language",


### PR DESCRIPTION
- Instantly change the region when selected game or region is changed.
- Hide the "Change" button.
- Enabled by default when "Show Region Warning" is disabled
 
![image](https://github.com/CollapseLauncher/Collapse/assets/28079733/e67f97d7-554a-47ac-ae01-bc5450559f19)

# Video Showcase

https://github.com/CollapseLauncher/Collapse/assets/28079733/05ede866-d9e7-413e-81ae-f327ad35ccb8
