### PR TITLE
Preview 1.80.2 Emergency Hotfix Release

### DIFF
--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -188,13 +188,29 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
             }
 
             string? localeLang  = Locale.Lang.LanguageID.ToLower();
+            // HACK! HoYo API does not respond with certain locale, force change locale.
+            switch (localeLang)
+            {
+                case "es-419":
+                    localeLang = "es-es";
+                    break;
+                case "pt-br":
+                    localeLang = "pt-pt";
+                    break;
+                //case "pl-pl":
+                //    localeLang = "en-us";
+                //    break;
+                //case "uk-ua":
+                //    localeLang = "en-us";
+                //    break;
+            }
             bool    isMultilingual = PresetConfig.LauncherSpriteURLMultiLang ?? false;
 
             LauncherGameNews? regionResourceProp =
                 await LoadLauncherNewsInner(isMultilingual, localeLang, PresetConfig, onTimeoutRoutine, token);
             int backgroundVersion = regionResourceProp?.Content?.Background?.BackgroundVersion ?? 5;
 
-            if (backgroundVersion <= 4 && PresetConfig.GameType == GameNameType.Honkai)
+            if (regionResourceProp?.Content?.Background == null || (backgroundVersion <= 4 && PresetConfig.GameType == GameNameType.Honkai))
             {
                 string? localeFallback = PresetConfig.LauncherSpriteURLMultiLangFallback ?? "en-us";
                 regionResourceProp =

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- General Properties -->
 		<OutputType>WinExe</OutputType>
@@ -15,7 +15,7 @@
 		<Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
 		<Copyright>Copyright 2022-2024 $(Company)</Copyright>
 		<!-- Versioning -->
-		<Version>1.80.1</Version>
+		<Version>1.80.2</Version>
 		<LangVersion>preview</LangVersion>
 		<!-- Target Settings -->
 		<Platforms>x64</Platforms>
@@ -98,7 +98,7 @@
 		<PackageReference Include="FFmpegInteropX" Version="*-*" Condition="$(DefineConstants.Contains('USEFFMPEGFORVIDEOBG'))" />
 		
 		<PackageReference Include="GitInfo" Version="3.3.4" PrivateAssets="all" />
-		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.124" />
+		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.129" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
 		<PackageReference Include="ImageEx" Version="2.1.1" />
 		<PackageReference Include="Markdig.Signed" Version="0.37.0" />

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -98,7 +98,7 @@
 		<PackageReference Include="FFmpegInteropX" Version="*-*" Condition="$(DefineConstants.Contains('USEFFMPEGFORVIDEOBG'))" />
 		
 		<PackageReference Include="GitInfo" Version="3.3.4" PrivateAssets="all" />
-		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.129" />
+		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.124" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
 		<PackageReference Include="ImageEx" Version="2.1.1" />
 		<PackageReference Include="Markdig.Signed" Version="0.37.0" />

--- a/CollapseLauncher/XAMLs/MainApp/Pages/UpdatePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/UpdatePage.xaml
@@ -26,7 +26,7 @@
                        FontWeight="Light"
                        Style="{ThemeResource DisplayTextBlockStyle}"
                        Text="{x:Bind helper:Locale.Lang._UpdatePage.PageTitle1}" />
-            <TextBlock Margin="0,-22,0,0"
+            <TextBlock Margin="0,-18,0,0"
                        FontSize="32"
                        FontWeight="ExtraBold"
                        Style="{ThemeResource DisplayTextBlockStyle}"

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -123,11 +123,11 @@
       },
       "H.NotifyIcon.WinUI": {
         "type": "Direct",
-        "requested": "[2.0.129, )",
-        "resolved": "2.0.129",
-        "contentHash": "pQo5zTSDwCe0pqMaHqg2K0zQEbjECQKnjNoN/LVeBGotRPmrYVGIE7iVq1nGQaMhQ15pPmBnz4g8RL6p/CYjZQ==",
+        "requested": "[2.0.124, )",
+        "resolved": "2.0.124",
+        "contentHash": "ME3h/+AknWAq+blhKsx3le7mYnCN4T3ez89ZRymVGbC3r0iViTirnzuZCb85p+SYfYgnNOUdU0ibgg4dHVt+oQ==",
         "dependencies": {
-          "H.NotifyIcon": "2.0.129",
+          "H.NotifyIcon": "2.0.124",
           "Microsoft.WindowsAppSDK": "1.4.231115000"
         }
       },
@@ -360,18 +360,18 @@
       },
       "H.GeneratedIcons.System.Drawing": {
         "type": "Transitive",
-        "resolved": "2.0.129",
-        "contentHash": "3yrlWN2ckNAw23uj+GgZIXTQNk9MHi/3JE6cO64soG+I2YIhhGCK+j/CHeM3Mw/SPX7uVVz63LeEabUqoFKTQA==",
+        "resolved": "2.0.124",
+        "contentHash": "HP8OdWxrujKbLlmpcnNd+B9MGygGZ4g7RbzlBUmwNvJPVUfL7H+OQoiiCKUT/pfLzX75Nt0smE1RIJ/+SLeFfg==",
         "dependencies": {
           "System.Drawing.Common": "8.0.0"
         }
       },
       "H.NotifyIcon": {
         "type": "Transitive",
-        "resolved": "2.0.129",
-        "contentHash": "xdCv9tTFBZ+vSr14ibGJmgEVA26E2of3GfujTUtWPY7RC4v3/hgJt3FjnBYM++yjvL9YkMyIs6O6KkBdBvOCqw==",
+        "resolved": "2.0.124",
+        "contentHash": "wifXuToNRNBxW0RIb2H8gLlUeDOjScuakbwFyk7y/OFPZs15PF1uSMuOORzgSDUfT+NHjeaKlNHlinzLw7Ct9Q==",
         "dependencies": {
-          "H.GeneratedIcons.System.Drawing": "2.0.129"
+          "H.GeneratedIcons.System.Drawing": "2.0.124"
         }
       },
       "Microsoft.CSharp": {

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -123,11 +123,11 @@
       },
       "H.NotifyIcon.WinUI": {
         "type": "Direct",
-        "requested": "[2.0.124, )",
-        "resolved": "2.0.124",
-        "contentHash": "ME3h/+AknWAq+blhKsx3le7mYnCN4T3ez89ZRymVGbC3r0iViTirnzuZCb85p+SYfYgnNOUdU0ibgg4dHVt+oQ==",
+        "requested": "[2.0.129, )",
+        "resolved": "2.0.129",
+        "contentHash": "pQo5zTSDwCe0pqMaHqg2K0zQEbjECQKnjNoN/LVeBGotRPmrYVGIE7iVq1nGQaMhQ15pPmBnz4g8RL6p/CYjZQ==",
         "dependencies": {
-          "H.NotifyIcon": "2.0.124",
+          "H.NotifyIcon": "2.0.129",
           "Microsoft.WindowsAppSDK": "1.4.231115000"
         }
       },
@@ -360,18 +360,18 @@
       },
       "H.GeneratedIcons.System.Drawing": {
         "type": "Transitive",
-        "resolved": "2.0.124",
-        "contentHash": "HP8OdWxrujKbLlmpcnNd+B9MGygGZ4g7RbzlBUmwNvJPVUfL7H+OQoiiCKUT/pfLzX75Nt0smE1RIJ/+SLeFfg==",
+        "resolved": "2.0.129",
+        "contentHash": "3yrlWN2ckNAw23uj+GgZIXTQNk9MHi/3JE6cO64soG+I2YIhhGCK+j/CHeM3Mw/SPX7uVVz63LeEabUqoFKTQA==",
         "dependencies": {
           "System.Drawing.Common": "8.0.0"
         }
       },
       "H.NotifyIcon": {
         "type": "Transitive",
-        "resolved": "2.0.124",
-        "contentHash": "wifXuToNRNBxW0RIb2H8gLlUeDOjScuakbwFyk7y/OFPZs15PF1uSMuOORzgSDUfT+NHjeaKlNHlinzLw7Ct9Q==",
+        "resolved": "2.0.129",
+        "contentHash": "xdCv9tTFBZ+vSr14ibGJmgEVA26E2of3GfujTUtWPY7RC4v3/hgJt3FjnBYM++yjvL9YkMyIs6O6KkBdBvOCqw==",
         "dependencies": {
-          "H.GeneratedIcons.System.Drawing": "2.0.124"
+          "H.GeneratedIcons.System.Drawing": "2.0.129"
         }
       },
       "Microsoft.CSharp": {

--- a/Hi3Helper.Core/Lang/ja_JP.json
+++ b/Hi3Helper.Core/Lang/ja_JP.json
@@ -220,7 +220,7 @@
     "ListCol6": "R.CRC",
     "ListCol7": "ステータス",
     "Status1": "キャッシュの更新を確認するには、 \"クイックチェック\"または\"フルチェック\"をクリックしてください。",
-    "Status2": "Trying to determine \"{0}\" cache asset availability: {1}",
+    "Status2": "{0} 件のキャッシュファイルの可用性を検証中: {1}",
     "CachesStatusHeader1": "総進行状況",
     "CachesStatusCancelled": "操作がキャンセルされました！",
     "CachesStatusFetchingType": "キャッシュタイプを読み込み中: {0}",

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -220,7 +220,7 @@
     "ListCol6": "远程CRC",
     "ListCol7": "状态",
     "Status1": "点击“快速检查”或“完整检查”以检查缓存的更新情况",
-    "Status2": "Trying to determine \"{0}\" cache asset availability: {1}",
+    "Status2": "正在尝试确认“{0}”缓存资源可用性：{1}",
     "CachesStatusHeader1": "总进度",
     "CachesStatusCancelled": "操作已被取消！",
     "CachesStatusFetchingType": "正在获取缓存类型：{0}",
@@ -886,8 +886,8 @@
   },
 
   "_UpdatePage": {
-    "PageTitle1": "有可用",
-    "PageTitle2": "更新！",
+    "PageTitle1": "更新",
+    "PageTitle2": "已可用！",
     "VerCurLabel": "当前版本：",
     "VerNewLabel": "最新版本：",
     "VerChannelLabel": "更新频道：",

--- a/Hi3Helper.Core/packages.lock.json
+++ b/Hi3Helper.Core/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.4, )",
+        "resolved": "8.0.4",
+        "contentHash": "PZb5nfQ+U19nhnmnR9T1jw+LTmozhuG2eeuzuW5A7DqxD/UXW2ucjmNJqnqOuh8rdPzM3MQXoF8AfFCedJdCUw=="
+      },
       "Google.Protobuf": {
         "type": "Transitive",
         "resolved": "3.26.1",
@@ -11,25 +17,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "ne1843evDugl0md7Fjzy6QjJrzsjh46ZKbhf8GwBXb5f/gw97J4bxMs0NQKifDuThh/f0bZ0e62NPl1jzTuRqA=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "8.0.3",
-        "contentHash": "hpagS9joOwv6efWfrMmV9MjQXpiXZH72PgN067Ysfr6AWMSD1/1hEcvh/U5mUpPLezEWsOJSuVrmqDIVD958iA==",
-        "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0"
-        }
-      },
-      "discordrpc": {
-        "type": "Project",
-        "dependencies": {
-          "System.Text.Json": "[8.0.3, )"
-        }
       },
       "hi3helper.enctool": {
         "type": "Project",
@@ -42,6 +29,7 @@
       "hi3helper.http": {
         "type": "Project"
       }
-    }
+    },
+    "net8.0/win-x64": {}
   }
 }

--- a/InnoSetupHelper/packages.lock.json
+++ b/InnoSetupHelper/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.4, )",
+        "resolved": "8.0.4",
+        "contentHash": "PZb5nfQ+U19nhnmnR9T1jw+LTmozhuG2eeuzuW5A7DqxD/UXW2ucjmNJqnqOuh8rdPzM3MQXoF8AfFCedJdCUw=="
+      },
       "System.IO.Hashing": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -31,6 +37,7 @@
       "hi3helper.http": {
         "type": "Project"
       }
-    }
+    },
+    "net8.0/win-x64": {}
   }
 }

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 [<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.73.8/CL-1.73.8-stable_Installer.exe)
 > **Note**: The version for this build is `1.73.8` (Released on: March 26th, 2024).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.0-pre/CL-1.80-preview_Installer.exe)
-> **Note**: The version for this build is `1.80.0` (Released on: April 12th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.1-pre/CL-1.80.1-preview_Installer.exe)
+> **Note**: The version for this build is `1.80.1` (Released on: April 28th, 2024).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 


### PR DESCRIPTION
# What's new? - 1.80.2
- **[Fix]** Crash on launch when using certain language, by @bagusnl & @shatyuka 
  - This due to HoYo does not have response in their API for `es-419` and `pt-br` locales. For background and news area, fallback `es-419` to `es-es` and `pt-br` to `pt-pt`.
- **[Imp]** Adjusted Update page tittle padding, by @shatyuka 
- **[Loc]** Sync localization from Transifex, by localizers <3


Template:
**[New]**
**[Imp]**
**[Fix]**
**[Loc]**
**[Doc]**