### PR TITLE
Preview 1.80.3 Release

### DIFF
--- a/CollapseLauncher/App.xaml
+++ b/CollapseLauncher/App.xaml
@@ -315,6 +315,13 @@
                                           TintColor="#222222"
                                           TintLuminosityOpacity="0.30"
                                           TintOpacity="0.0"/>
+                            <!-- Window Caption Button Brush -->
+                            <SolidColorBrush x:Key="WindowCaptionBackground"
+                                     Color="#00FFFFFF"/>
+                            <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled"
+                                     Color="#00000000"/>
+                            <SolidColorBrush x:Key="WindowCaptionBackgroundClose"
+                                     Color="#00FF0000"/>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="Light">
                             <!--  For light theme  -->
@@ -610,6 +617,13 @@
                                           TintColor="#FFFFFF"
                                           TintLuminosityOpacity="0.80"
                                           TintOpacity="0.0"/>
+                            <!-- Window Caption Button Brush -->
+                            <SolidColorBrush x:Key="WindowCaptionBackground"
+                                     Color="#00000000"/>
+                            <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled"
+                                     Color="#00000000"/>
+                            <SolidColorBrush x:Key="WindowCaptionBackgroundClose"
+                                     Color="#00FF0000"/>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                     <!--  Font families  -->
@@ -618,6 +632,7 @@
                     <FontFamily x:Key="FontAwesomeSolid">ms-appx:///Assets/Fonts/FontAwesomeSolid6.otf#Font Awesome 6 Free Solid</FontFamily>
                     <!--  Navigation title-bar border thickness  -->
                     <Thickness x:Key="NavigationViewContentMargin">0,47,0,0</Thickness>
+
                     <!--  START: ToggleButton styles  -->
                     <Style x:Key="AcrylicToggleButtonStyle"
                            TargetType="ToggleButton">
@@ -2482,11 +2497,125 @@
                     <Style BasedOn="{StaticResource DefaultComboBoxStyle}"
                            TargetType="ComboBox"/>
                     <!--  WindowChrome min max close styles  -->
-                    <x:Double x:Key="WindowCaptionButtonStrokeWidth">1</x:Double>
-                    <SolidColorBrush x:Key="WindowCaptionBackground"
-                                     Color="#00000000"/>
-                    <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled"
-                                     Color="#00000000"/>
+                    <x:Double x:Key="WindowCaptionButtonStrokeWidth">2</x:Double>
+
+                    <Style x:Key="WindowCaptionButton" TargetType="Button">
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Background" Value="{ThemeResource WindowCaptionBackground}" />
+                        <Setter Property="IsTabStop" Value="False" />
+                        <Setter Property="VerticalAlignment" Value="Top" />
+                        <Setter Property="Width" Value="32" />
+                        <Setter Property="Height" Value="32" />
+
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="LayoutRoot"
+                                            Background="{TemplateBinding Background}"
+                                            BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            CornerRadius="{TemplateBinding CornerRadius}"
+                                            Padding="{TemplateBinding Padding}">
+                                        <Border.BackgroundTransition>
+                                            <BrushTransition Duration="0:0:0.050"/>
+                                        </Border.BackgroundTransition>
+
+                                        <Path x:Name="Path"
+                                              StrokeThickness="{ThemeResource WindowCaptionButtonStrokeWidth}"
+                                              Stroke="{TemplateBinding Foreground}"
+                                              Data="{TemplateBinding Content}"
+                                              Stretch="Fill"
+                                              UseLayoutRounding="True"
+                                              Width="10"
+                                              Height="10"
+                                              StrokeEndLineCap="Round"
+                                              StrokeStartLineCap="Round">
+                                        </Path>
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup x:Name="CommonStates">
+                                                <VisualState x:Name="Normal"/>
+                                                <VisualState x:Name="PointerOver">
+                                                    <Storyboard>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+                                                                                       Storyboard.TargetProperty="Background">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionButtonBackgroundPointerOver}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Path"
+                                                                                       Storyboard.TargetProperty="Stroke">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionForeground}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="Pressed">
+                                                    <Storyboard>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+                                                                                       Storyboard.TargetProperty="Background">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionButtonBackgroundPressed}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Path"
+                                                                                       Storyboard.TargetProperty="Stroke">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionForegroundDisabled}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </VisualState>
+                                                <!-- these 2 states are only for Close button, needed because they use fixed colors for a theme and cannot be changed by user -->
+                                                <VisualState x:Name="CloseButtonPointerOver">
+                                                    <Storyboard>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+                                                                                       Storyboard.TargetProperty="Background">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionButtonBackgroundPointerOver}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Path"
+                                                                                       Storyboard.TargetProperty="Stroke">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionButtonStrokePointerOver}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="CloseButtonPressed">
+                                                    <Storyboard>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+                                                                                       Storyboard.TargetProperty="Background">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionButtonBackgroundPressed}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Path"
+                                                                                       Storyboard.TargetProperty="Stroke">
+                                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                    Value="{ThemeResource WindowCaptionButtonStrokePressed}"/>
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="MinMaxStates">
+                                                <VisualState x:Name="WindowStateNormal">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="Path.Data" Value="M 1.516 -0.001 L 7.451 0.009 C 8.751 0.019 9 1 8.981 1.477 L 9.002 7.558 M 9.002 7.547 C 8.929 8.669 8 9 7.43 9.015 L 1.464 9.005 C 0.374 8.973 0 8 -0.004 7.484 L -0.004 1.477 C 0 1 0.415 0.009 1.527 -0.001" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                                <VisualState x:Name="WindowStateMaximized">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="Path.Data" Value="M 1.516 -0.001 L 7.451 0.009 C 8.751 0.019 9 1 8.981 1.477 L 9.002 7.558 M 11 6 L 11 2 C 11 0 10 -2 8.011 -1.946 L 7.06 -1.969 L 3 -2 M 9.002 7.547 C 8.929 8.669 8 9 7.43 9.015 L 1.464 9.005 C 0.374 8.973 0 8 -0.004 7.484 L -0.004 1.477 C 0 1 0.415 0.009 1.527 -0.001" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                        </VisualStateManager.VisualStateGroups>
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
                 </ResourceDictionary>
                 <!--  Custom controls styles  -->
                 <ResourceDictionary Source="ms-appx:///XAMLs/Theme/ContentDialogCollapse.xaml"/>

--- a/CollapseLauncher/Classes/CachesManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/Fetch.cs
@@ -36,7 +36,7 @@ namespace CollapseLauncher
                 await BuildGameRepoURL(token);
 
                 // Iterate type and do fetch
-                foreach (CacheAssetType type in Enum.GetValues(typeof(CacheAssetType)))
+                foreach (CacheAssetType type in Enum.GetValues<CacheAssetType>())
                 {
                     // Skip for unused type
                     switch (type)

--- a/CollapseLauncher/Classes/CachesManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/Fetch.cs
@@ -272,8 +272,8 @@ namespace CollapseLauncher
                         UpdateStatus();
 
                         // Check for the URL availability and is not available, then skip.
-                        using HttpResponseMessage urlStatus = await FallbackCDNUtil.GetURLHttpResponse(content.ConcatURL, cancellationToken);
-                        LogWriteLine($"The Cache {type} asset: {content.N} " + (urlStatus!.IsSuccessStatusCode ? "is" : "is not") + $" available (Status code: {urlStatus.StatusCode})", LogType.Default, true);
+                        var urlStatus = await client.GetURLStatusCode(content.ConcatURL, cancellationToken);
+                        LogWriteLine($"The Cache {type} asset: {content.N} " + (urlStatus.IsSuccessStatusCode ? "is" : "is not") + $" available (Status code: {urlStatus.StatusCode})", LogType.Default, true);
 
                         if (!urlStatus.IsSuccessStatusCode) return;
                     }

--- a/CollapseLauncher/Classes/CachesManagement/Honkai/HonkaiCache.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/HonkaiCache.cs
@@ -1,4 +1,5 @@
-﻿using CollapseLauncher.Interfaces;
+﻿using CollapseLauncher.Extension;
+using CollapseLauncher.Interfaces;
 using Hi3Helper.Data;
 using Hi3Helper.EncTool.Parser.KianaDispatch;
 using Microsoft.UI.Xaml;
@@ -41,6 +42,9 @@ namespace CollapseLauncher
 
         private async Task<bool> CheckRoutine()
         {
+            // Reset status and progress
+            ResetStatusAndProgress();
+
             // Initialize _updateAssetIndex
             _updateAssetIndex = new List<CacheAsset>();
 

--- a/CollapseLauncher/Classes/CachesManagement/StarRail/Fetch.cs
+++ b/CollapseLauncher/Classes/CachesManagement/StarRail/Fetch.cs
@@ -36,7 +36,7 @@ namespace CollapseLauncher
                     throw new InvalidDataException("The dispatcher response is invalid! Please open an issue to our GitHub page to report this issue.");
 
                 // Iterate type and do fetch
-                foreach (SRAssetType type in Enum.GetValues(typeof(SRAssetType)))
+                foreach (SRAssetType type in Enum.GetValues<SRAssetType>())
                 {
                     // Skip for unused type
                     switch (type)

--- a/CollapseLauncher/Classes/DiscordPresence/DiscordPresenceManager.cs
+++ b/CollapseLauncher/Classes/DiscordPresence/DiscordPresenceManager.cs
@@ -170,7 +170,7 @@
                             EnablePresence(AppDiscordApplicationID_GI);
                             return;
                         default:
-                            Logger.LogWriteLine("Discord Presence (Unknown Game)");
+                            Logger.LogWriteLine("Discord Presence (Unknown Game)", LogType.Error, true);
                             break;
                     }
                 }
@@ -252,17 +252,26 @@
 
             private void BuildActivityGameStatus(string activityName, bool isGameStatusEnabled)
             {
+                var curGameName   = LauncherMetadataHelper.CurrentMetadataConfigGameName;
+                var curGameNameTranslate =
+                    InnerLauncherConfig.GetGameTitleRegionTranslationString(curGameName, Lang._GameClientTitles);
+                var curGameRegion = LauncherMetadataHelper.CurrentMetadataConfigGameRegion;
+                var curGameRegionTranslate =
+                    InnerLauncherConfig.GetGameTitleRegionTranslationString(curGameRegion, Lang._GameClientRegions);
+                
                 _presence = new RichPresence
                 {
                     Details =
-                        $"{activityName} {(!isGameStatusEnabled ? LauncherMetadataHelper.CurrentMetadataConfigGameName : null)}",
-                    State = $"{Lang._Misc.DiscordRP_Region} {LauncherMetadataHelper.CurrentMetadataConfigGameRegion}",
+                        $"{activityName} {(!isGameStatusEnabled ? curGameName : null)}",
+                    State = $"{Lang._Misc.DiscordRP_Region} " +
+                            $"{curGameRegionTranslate}",
                     Assets = new Assets
                     {
                         LargeImageKey  = $"game-{LauncherMetadataHelper.CurrentMetadataConfig?.GameType.ToString().ToLower()}-logo",
-                        LargeImageText = $"{LauncherMetadataHelper.CurrentMetadataConfigGameName} - {LauncherMetadataHelper.CurrentMetadataConfigGameRegion}",
+                        LargeImageText = $"{curGameNameTranslate} - {curGameRegionTranslate}",
                         SmallImageKey  = "launcher-logo",
-                        SmallImageText = $"Collapse Launcher v{LauncherUpdateHelper.LauncherCurrentVersionString} {(IsPreview ? "Preview" : "Stable")}"
+                        SmallImageText = $"Collapse Launcher v{LauncherUpdateHelper.LauncherCurrentVersionString} " +
+                                         $"{(IsPreview ? "Preview" : "Stable")}"
                     },
                     Timestamps = new Timestamps
                     {
@@ -279,16 +288,24 @@
 
             private void BuildActivityAppStatus(string activityName)
             {
+                var curGameName   = LauncherMetadataHelper.CurrentMetadataConfigGameName;
+                var curGameNameTranslate =
+                    InnerLauncherConfig.GetGameTitleRegionTranslationString(curGameName, Lang._GameClientTitles);
+                var curGameRegion = LauncherMetadataHelper.CurrentMetadataConfigGameRegion;
+                var curGameRegionTranslate =
+                    InnerLauncherConfig.GetGameTitleRegionTranslationString(curGameRegion, Lang._GameClientRegions);
+                
                 _presence = new RichPresence
                 {
                     Details = activityName,
-                    State   = $"{Lang._Misc.DiscordRP_Region} {LauncherMetadataHelper.CurrentMetadataConfigGameRegion}",
+                    State   = $"{Lang._Misc.DiscordRP_Region} {curGameRegionTranslate}",
                     Assets  = new Assets
                     {
                         LargeImageKey  = $"game-{LauncherMetadataHelper.CurrentMetadataConfig?.GameType.ToString().ToLower()}-logo",
-                        LargeImageText = $"{LauncherMetadataHelper.CurrentMetadataConfigGameName}",
+                        LargeImageText = $"{curGameNameTranslate}",
                         SmallImageKey  = "launcher-logo",
-                        SmallImageText = $"Collapse Launcher v{LauncherUpdateHelper.LauncherCurrentVersionString} {(IsPreview ? "Preview" : "Stable")}"
+                        SmallImageText = $"Collapse Launcher v{LauncherUpdateHelper.LauncherCurrentVersionString} " +
+                                         $"{(IsPreview ? "Preview" : "Stable")}"
                     }
                 };
             }

--- a/CollapseLauncher/Classes/Extension/CancellationTokenExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/CancellationTokenExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace CollapseLauncher.Extension
+{
+    public class CancellationTokenSourceWrapper : CancellationTokenSource
+    {
+        public bool IsDisposed;
+        public bool IsCancelled = false;
+
+        public new void Cancel()
+        {
+            base.Cancel();
+            IsCancelled = true;
+        }
+
+        public new async ValueTask CancelAsync()
+        {
+            await base.CancelAsync();
+            IsCancelled = true;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -1,4 +1,5 @@
-﻿using CollapseLauncher.Helper.Animation;
+﻿using CollapseLauncher.Extension;
+using CollapseLauncher.Helper.Animation;
 using CommunityToolkit.WinUI.Animations;
 #if USEFFMPEGFORVIDEOBG
 using FFmpegInteropX;

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -106,7 +106,7 @@ namespace CollapseLauncher.InstallManager.Base
         }
         */
 
-        protected void ResetToken() => _token = new CancellationTokenSource();
+        protected void ResetToken() => _token = new CancellationTokenSourceWrapper();
 
         public void Dispose()
         {
@@ -575,7 +575,7 @@ namespace CollapseLauncher.InstallManager.Base
                 UpdateStatus();
 
                 // Run the check and assign to hashLocal variable
-                hashLocal = await Task.Run(() => base.CheckHash(fs, MD5.Create(), token, true));
+                hashLocal = await base.CheckHashAsync(fs, MD5.Create(), token, true).ConfigureAwait(false);
             }
 
             // Check for the hash differences. If found, then show dialog to delete or cancel the process
@@ -1337,7 +1337,7 @@ namespace CollapseLauncher.InstallManager.Base
 
             return _out;
         }
-#endregion
+        #endregion
 
         #region Private Methods - GetInstallationPath
         private async ValueTask<int> CheckExistingSteamInstallation()

--- a/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.UI.Xaml;
+﻿using CollapseLauncher.Extension;
+using Microsoft.UI.Xaml;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Threading;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 
 namespace CollapseLauncher.Interfaces
@@ -24,7 +24,7 @@ namespace CollapseLauncher.Interfaces
             _parentUI = parentUI;
             _gamePathField = gamePath;
             _gameRepoURL = gameRepoURL;
-            _token = new CancellationTokenSource();
+            _token = new CancellationTokenSourceWrapper();
             AssetEntry = new ObservableCollection<IAssetProperty>();
 
             // If the version override is not null, then assign the override value
@@ -35,6 +35,7 @@ namespace CollapseLauncher.Interfaces
         }
 
         protected const int _bufferLength = 4 << 10;
+        protected const int _bufferMediumLength = 512 << 10;
         protected const int _bufferBigLength = 1 << 20;
         protected const int _sizeForMultiDownload = 10 << 20;
         protected const string _userAgent = "UnityPlayer/2017.4.18f1 (UnityWebRequest/1.0, libcurl/7.51.0-DEV)";
@@ -42,7 +43,7 @@ namespace CollapseLauncher.Interfaces
         protected bool _isVersionOverride { get; init; }
         protected byte _downloadThreadCount { get => (byte)AppCurrentDownloadThread; }
         protected byte _threadCount { get => (byte)AppCurrentThread; }
-        protected CancellationTokenSource _token { get; set; }
+        protected CancellationTokenSourceWrapper _token { get; set; }
         protected Stopwatch _stopwatch { get; set; }
         protected Stopwatch _refreshStopwatch { get; set; }
         protected GameVersion _gameVersion { get => _isVersionOverride ? _gameVersionOverride : _gameVersionManager.GetGameExistingVersion().Value; }

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -213,7 +213,16 @@ namespace CollapseLauncher.Interfaces
                     _progress.ProgressTotalSpeed = _progressTotalSizeCurrent / _stopwatch!.Elapsed.TotalSeconds;
 
                     // Calculate the timelapse
-                    _progress.ProgressTotalTimeLeft = TimeSpan.FromSeconds((_progressTotalSize - _progressTotalSizeCurrent) / ConverterTool.Unzeroed(_progress.ProgressTotalSpeed));
+                    double seconds = (_progressTotalSize - _progressTotalSizeCurrent) / ConverterTool.Unzeroed(_progress.ProgressTotalSpeed);
+                    if (seconds <= TimeSpan.MaxValue.TotalSeconds && seconds >= TimeSpan.MinValue.TotalSeconds)
+                    {
+                        _progress.ProgressTotalTimeLeft = TimeSpan.FromSeconds(seconds);
+                    }
+                    else
+                    {
+                        // Fallback mechanism when seconds are out of range
+                        _progress.ProgressTotalTimeLeft = TimeSpan.MaxValue;
+                    }
                 }
 
                 lock (_status!)

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -923,8 +923,8 @@ namespace CollapseLauncher.Interfaces
 
         protected virtual void UpdateProgress()
         {
-            _progress!.ProgressPerFilePercentage = double.IsInfinity(_progress.ProgressPerFilePercentage) ? 0 : _progress.ProgressPerFilePercentage;
-            _progress.ProgressTotalPercentage = double.IsInfinity(_progress.ProgressTotalPercentage) ? 0 : _progress.ProgressTotalPercentage;
+            _progress!.ProgressPerFilePercentage = _progress.ProgressPerFilePercentage.UnNaNInfinity();
+            _progress.ProgressTotalPercentage = _progress.ProgressTotalPercentage.UnNaNInfinity();
             ProgressChanged?.Invoke(this, _progress);
         }
 

--- a/CollapseLauncher/Classes/Interfaces/Class/Structs.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/Structs.cs
@@ -8,10 +8,15 @@ namespace CollapseLauncher
 {
     internal class TotalPerfileProgress
     {
-        public double ProgressPerFilePercentage;
-        public double ProgressTotalPercentage;
-        public double ProgressTotalEntryCount;
-        public double ProgressTotalSpeed;
+        private double _progressPerFilePercentage;
+        private double _progressTotalPercentage;
+        private double _progressTotalEntryCount;
+        private double _progressTotalSpeed;
+
+        public double ProgressPerFilePercentage { get => _progressPerFilePercentage; set => _progressPerFilePercentage = value.UnNaNInfinity(); }
+        public double ProgressTotalPercentage { get => _progressTotalPercentage; set => _progressTotalPercentage = value.UnNaNInfinity(); }
+        public double ProgressTotalEntryCount { get => _progressTotalEntryCount; set => _progressTotalEntryCount = value.UnNaNInfinity(); }
+        public double ProgressTotalSpeed { get => _progressTotalSpeed; set => _progressTotalSpeed = value.UnNaNInfinity(); }
 
         // Extension for IGameInstallManager
         public long ProgressPerFileDownload { get; set; }

--- a/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
+++ b/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
@@ -1,52 +1,27 @@
-﻿using CollapseLauncher.Helper.Image;
-using CollapseLauncher.Helper.LauncherApiLoader;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+﻿using CollapseLauncher.Extension;
+using CollapseLauncher.Helper.Image;
 using CollapseLauncher.Helper.Loading;
 using CollapseLauncher.Helper.Metadata;
 using CollapseLauncher.Helper.Update;
 using CollapseLauncher.Pages;
 using CollapseLauncher.Statics;
 using Hi3Helper;
-using Hi3Helper.Data;
 using Hi3Helper.Shared.ClassStruct;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Win32;
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using static CollapseLauncher.InnerLauncherConfig;
-using static CollapseLauncher.RegionResourceListHelper;
 using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 
 namespace CollapseLauncher
 {
-    public class CancellationTokenSourceWrapper : CancellationTokenSource
-    {
-        public bool IsDisposed;
-        public bool IsCancelled = false;
-
-        public new async ValueTask CancelAsync()
-        {
-            await base.CancelAsync();
-            IsCancelled = true;
-        }
-        protected override void Dispose(bool disposing)
-        {
-            IsDisposed = true;
-            base.Dispose(disposing);
-        }
-    }
-
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "IdentifierTypo")]
     [SuppressMessage("ReSharper", "PossibleNullReferenceException")]

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -31,42 +31,43 @@ namespace CollapseLauncher
             CheckUnusedAsset(assetIndex, brokenAssetIndex);
 
             // Await the task for parallel processing
-            await Task.Run(() =>
+            try
             {
-                try
+                // Check for skippable assets to skip the check
+                RemoveSkippableAssets(assetIndex);
+
+                // Reset stopwatch
+                RestartStopwatch();
+
+                // Iterate assetIndex and check it using different method for each type and run it in parallel
+                await Parallel.ForEachAsync(assetIndex, new ParallelOptions { MaxDegreeOfParallelism = _threadCount, CancellationToken = token }, async (asset, threadToken) =>
                 {
-                    // Check for skippable assets to skip the check
-                    RemoveSkippableAssets(assetIndex);
-
-                    // Reset stopwatch
-                    RestartStopwatch();
-
-                    // Iterate assetIndex and check it using different method for each type and run it in parallel
-                    Parallel.ForEach(assetIndex, new ParallelOptions { MaxDegreeOfParallelism = _threadCount }, (asset) =>
+                    // Assign a task depends on the asset type
+                    switch (asset.FT)
                     {
-                        // Assign a task depends on the asset type
-                        switch (asset.FT)
-                        {
-                            case FileType.Blocks:
-                                CheckAssetTypeBlocks(asset, brokenAssetIndex, token);
-                                break;
-                            case FileType.Audio:
-                                CheckAssetTypeAudio(asset, brokenAssetIndex, token);
-                                break;
-                            case FileType.Video:
-                                CheckAssetTypeVideo(asset, brokenAssetIndex, token);
-                                break;
-                            default:
-                                CheckAssetTypeGeneric(asset, brokenAssetIndex, token);
-                                break;
-                        }
-                    });
-                }
-                catch (AggregateException ex)
-                {
-                    throw ex.Flatten().InnerExceptions.First();
-                }
-            }).ConfigureAwait(false);
+                        case FileType.Blocks:
+                            await CheckAssetTypeBlocks(asset, brokenAssetIndex, threadToken);
+                            break;
+                        case FileType.Audio:
+                            await CheckAssetTypeAudio(asset, brokenAssetIndex, threadToken);
+                            break;
+                        case FileType.Video:
+                            CheckAssetTypeVideo(asset, brokenAssetIndex);
+                            break;
+                        default:
+                            await CheckAssetTypeGeneric(asset, brokenAssetIndex, threadToken);
+                            break;
+                    }
+                }).ConfigureAwait(false);
+            }
+            catch (AggregateException ex)
+            {
+                throw ex.Flatten().InnerExceptions.First();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
 
             // Re-add the asset index with a broken asset index
             assetIndex.Clear();
@@ -74,7 +75,7 @@ namespace CollapseLauncher
         }
 
         #region VideoCheck
-        private void CheckAssetTypeVideo(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
+        private void CheckAssetTypeVideo(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex)
         {
             // Increment current total count
             // _progressTotalCountCurrent++;
@@ -113,7 +114,7 @@ namespace CollapseLauncher
         #endregion
 
         #region AudioCheck
-        private void CheckAssetTypeAudio(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
+        private async ValueTask CheckAssetTypeAudio(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
         {
             // Update activity status
             _status.ActivityStatus = string.Format(Lang._GameRepairPage.Status6, asset.N);
@@ -178,7 +179,7 @@ namespace CollapseLauncher
             using (FileStream filefs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, _bufferBigLength))
             {
                 // If pass the check above, then do MD5 Hash calculation
-                localCRC = CheckHash(filefs, MD5.Create(), token);
+                localCRC = await CheckHashAsync(filefs, MD5.Create(), token);
 
                 // Get size difference for summarize the _progressTotalSizeCurrent
                 long sizeDifference = asset.S - file.Length;
@@ -221,7 +222,7 @@ namespace CollapseLauncher
         #endregion
 
         #region GenericCheck
-        private void CheckAssetTypeGeneric(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
+        private async ValueTask CheckAssetTypeGeneric(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
         {
             // Update activity status
             _status.ActivityStatus = string.Format(Lang._GameRepairPage.Status6, asset.N);
@@ -274,7 +275,7 @@ namespace CollapseLauncher
             using (FileStream filefs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, _bufferBigLength))
             {
                 // If pass the check above, then do CRC calculation
-                byte[] localCRC = CheckHash(filefs, MD5.Create(), token);
+                byte[] localCRC = await CheckHashAsync(filefs, MD5.Create(), token);
 
                 // If local and asset CRC doesn't match, then add the asset
                 if (!IsArrayMatch(localCRC, asset.CRCArray))
@@ -348,7 +349,7 @@ namespace CollapseLauncher
             return block.BlockPatchInfo;
         }
 
-        private void CheckAssetTypeBlocks(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
+        private async ValueTask CheckAssetTypeBlocks(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex, CancellationToken token)
         {
             // Update activity status
             _status.ActivityStatus = string.Format(Lang._GameRepairPage.Status5, asset.CRC);
@@ -376,7 +377,7 @@ namespace CollapseLauncher
                 using (FileStream fileOldfs = new FileStream(filePathOld, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, _bufferBigLength))
                 {
                     // If pass the check above, then do CRC calculation
-                    byte[] localOldCRC = CheckHash(fileOldfs, MD5.Create(), token, false);
+                    byte[] localOldCRC = await CheckHashAsync(fileOldfs, MD5.Create(), token, false);
 
                     // If the hash matches, then add the patch
                     if (IsArrayMatch(localOldCRC, patchInfo?.PatchPairs[0].OldHash))
@@ -460,7 +461,7 @@ namespace CollapseLauncher
             {
                 // If pass the check above, then do CRC calculation
                 // Additional: the total file size progress is disabled and will be incremented after this
-                byte[] localCRC = CheckHash(filefs, MD5.Create(), token);
+                byte[] localCRC = await CheckHashAsync(filefs, MD5.Create(), token);
 
                 // If local and asset CRC doesn't match, then add the asset
                 if (!IsArrayMatch(localCRC, asset.CRCArray))

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
@@ -369,7 +369,7 @@ namespace CollapseLauncher
 
             // Set the URL and try get the status
             string cgURL = CombineURLFromString(baseURL, (_audioLanguage == AudioLanguageType.Japanese ? cgInfo.CgPathHighBitrateJP : cgInfo.CgPathHighBitrateCN) + ".usm");
-            using HttpResponseMessage urlStatus = await FallbackCDNUtil.GetURLHttpResponse(cgURL, token);
+            UrlStatus urlStatus = await FallbackCDNUtil.GetURLStatusCode(cgURL, token);
 
             LogWriteLine($"The CG asset: {(_audioLanguage == AudioLanguageType.Japanese ? cgInfo.CgPathHighBitrateJP : cgInfo.CgPathHighBitrateCN)} " + 
                          (urlStatus!.IsSuccessStatusCode ? "is" : "is not") + $" available (Status code: {urlStatus.StatusCode})", LogType.Default, true);
@@ -496,7 +496,7 @@ namespace CollapseLauncher
 
             // Set the URL and try get the status
             string audioURL = CombineURLFromString(string.Format(_audioBaseRemotePath!, $"{_gameVersion.Major}_{_gameVersion.Minor}", _gameServer!.Manifest!.ManifestAudio!.ManifestAudioRevision), audioInfo.Path);
-            using HttpResponseMessage urlStatus = await FallbackCDNUtil.GetURLHttpResponse(audioURL, token);
+            UrlStatus urlStatus = await FallbackCDNUtil.GetURLStatusCode(audioURL, token);
 
             LogWriteLine($"The audio asset: {audioInfo.Path} " + (urlStatus!.IsSuccessStatusCode ? "is" : "is not") + $" available (Status code: {urlStatus.StatusCode})", LogType.Default, true);
 

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -98,15 +98,15 @@
 		<PackageReference Include="FFmpegInteropX" Version="*-*" Condition="$(DefineConstants.Contains('USEFFMPEGFORVIDEOBG'))" />
 		
 		<PackageReference Include="GitInfo" Version="3.3.4" PrivateAssets="all" />
-		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.129" />
-		<PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
+		<PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.131" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
 		<PackageReference Include="ImageEx" Version="2.1.1" />
 		<PackageReference Include="Markdig.Signed" Version="0.37.0" />
 		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.2.0" />
 		<PackageReference Include="Microsoft.NETCore.Platforms" Version="8.0.0-preview.7.23375.6" />
 		<PackageReference Include="Microsoft.NETCore.Targets" Version="6.0.0-preview.4.21253.7" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240428000" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
 		<PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.2" />
 		<PackageReference Include="Roman-Numerals" Version="2.0.0" />
@@ -120,7 +120,7 @@
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.3" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="TaskScheduler" Version="2.10.1" />
+		<PackageReference Include="TaskScheduler" Version="2.11.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -15,7 +15,7 @@
 		<Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
 		<Copyright>Copyright 2022-2024 $(Company)</Copyright>
 		<!-- Versioning -->
-		<Version>1.80.2</Version>
+		<Version>1.80.3</Version>
 		<LangVersion>preview</LangVersion>
 		<!-- Target Settings -->
 		<Platforms>x64</Platforms>

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
@@ -139,22 +139,25 @@
               Grid.Row="0">
             <Grid x:Name="AppTitleBar">
                 <Button x:Name="MinimizeButton"
-                        Width="48"
-                        Height="48"
-                        Margin="0,0,48,0"
+                        Width="40"
+                        Height="40"
+                        Margin="4,4,48,4"
+                        CornerRadius="8"
                         HorizontalAlignment="Right"
                         x:FieldModifier="internal"
                         Click="MinimizeButton_Click"
                         Content="M 0 0 H 10"
                         Style="{StaticResource WindowCaptionButton}" />
                 <Button x:Name="CloseButton"
-                        Width="48"
-                        Height="48"
-                        Margin="0,0,0,0"
+                        Width="40"
+                        Height="40"
+                        Margin="4"
+                        CornerRadius="8"
                         HorizontalAlignment="Right"
                         x:FieldModifier="internal"
                         Click="CloseButton_Click"
                         Content="M 0 0 L 10 10 M 10 0 L 0 10"
+                        Background="{ThemeResource WindowCaptionBackgroundClose}"
                         Style="{StaticResource WindowCaptionButton}">
                     <Button.Resources>
                         <ResourceDictionary>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -857,10 +857,12 @@
                                     Orientation="Horizontal"
                                     Margin="0,0,0,2">
                             <TextBlock FontSize="16"
-                                       Text="😆" />
+                                       Text="😆"
+                                       Foreground="{ThemeResource TextFillColorInverse}"/>
                             <TextBlock Margin="8,2,0,0"
                                        VerticalAlignment="Center"
-                                       FontWeight="Medium">
+                                       FontWeight="Medium"
+                                       Foreground="{ThemeResource TextFillColorInverse}">
                                 <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_NewVer1}" />
                                 <Run x:Name="UpdateAvailableLabel"
                                      FontWeight="Bold"
@@ -885,11 +887,11 @@
                                        Text=""
                                        VerticalAlignment="Center"
                                        FontFamily="{ThemeResource FontAwesomeSolid}"
-                                       Foreground="{ThemeResource SystemColorCaptionTextBrush}"/>
+                                       Foreground="{ThemeResource TextFillColorInverse}"/>
                             <TextBlock Margin="8,0,0,0"
                                        VerticalAlignment="Center"
                                        FontWeight="Medium"
-                                       Foreground="{ThemeResource SystemColorCaptionTextBrush}"
+                                       Foreground="{ThemeResource TextFillColorInverse}"
                                        Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_LatestVer}" />
                         </StackPanel>
                     </Grid>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -374,7 +374,7 @@
                                                 <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThreads_Help3}" />
                                                 <Run FontWeight="Bold"
                                                      Foreground="{ThemeResource AccentColor}"
-                                                     Text="2 - 8" />
+                                                     Text="2 - 16" />
                                             </TextBlock>
                                             <TextBlock Margin="0,16,0,0"
                                                        Style="{ThemeResource SubtitleTextBlockStyle}"
@@ -436,7 +436,7 @@
                                        Width="128"
                                        VerticalAlignment="Bottom"
                                        Header="{x:Bind helper:Locale.Lang._SettingsPage.AppThreads_Download}"
-                                       Maximum="8"
+                                       Maximum="16"
                                        Minimum="2"
                                        SpinButtonPlacementMode="Compact"
                                        Value="{x:Bind CurrentAppThreadDownloadValue, Mode=TwoWay}" />

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -833,28 +833,34 @@
                         </Grid>
                     </Button>
                     <Grid x:Name="UpdateLoadingStatus"
-                          Width="300"
                           Margin="0,14,0,0"
-                          HorizontalAlignment="Left"
+                          HorizontalAlignment="Center"
                           VerticalAlignment="Center"
-                          Visibility="Collapsed">
+                          Visibility="Collapsed"
+                          Padding="8"
+                          Background="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
+                          CornerRadius="{x:Bind ext:UIElementExtensions.AttachRoundedKindCornerRadius(UpdateLoadingStatus)}">
                         <ProgressRing Width="20"
                                       Height="20"
                                       HorizontalAlignment="Center"
                                       IsIndeterminate="True" />
                     </Grid>
                     <Grid x:Name="UpdateAvailableStatus"
-                          Width="300"
                           Margin="0,12,0,0"
-                          HorizontalAlignment="Left"
+                          HorizontalAlignment="Center"
                           VerticalAlignment="Center"
-                          Visibility="Collapsed">
+                          Visibility="Collapsed"
+                          Padding="16,4"
+                          Background="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
+                          CornerRadius="{x:Bind ext:UIElementExtensions.AttachRoundedKindCornerRadius(UpdateAvailableStatus)}">
                         <StackPanel HorizontalAlignment="Center"
-                                    Orientation="Horizontal">
-                            <TextBlock FontSize="20"
+                                    Orientation="Horizontal"
+                                    Margin="0,0,0,2">
+                            <TextBlock FontSize="16"
                                        Text="😆" />
                             <TextBlock Margin="8,2,0,0"
-                                       VerticalAlignment="Center">
+                                       VerticalAlignment="Center"
+                                       FontWeight="Medium">
                                 <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_NewVer1}" />
                                 <Run x:Name="UpdateAvailableLabel"
                                      FontWeight="Bold"
@@ -865,17 +871,25 @@
                         </StackPanel>
                     </Grid>
                     <Grid x:Name="UpToDateStatus"
-                          Width="300"
                           Margin="0,12,0,0"
-                          HorizontalAlignment="Left"
+                          HorizontalAlignment="Center"
                           VerticalAlignment="Center"
-                          Visibility="Collapsed">
+                          Visibility="Collapsed"
+                          Padding="16,4"
+                          Background="{ThemeResource SystemFillColorSuccessBrush}"
+                          CornerRadius="{x:Bind ext:UIElementExtensions.AttachRoundedKindCornerRadius(UpToDateStatus)}">
                         <StackPanel HorizontalAlignment="Center"
-                                    Orientation="Horizontal">
-                            <TextBlock FontSize="20"
-                                       Text="✅" />
+                                    Orientation="Horizontal"
+                                    Margin="0,0,0,2">
+                            <TextBlock FontSize="16"
+                                       Text=""
+                                       VerticalAlignment="Center"
+                                       FontFamily="{ThemeResource FontAwesomeSolid}"
+                                       Foreground="{ThemeResource SystemColorCaptionTextBrush}"/>
                             <TextBlock Margin="8,0,0,0"
                                        VerticalAlignment="Center"
+                                       FontWeight="Medium"
+                                       Foreground="{ThemeResource SystemColorCaptionTextBrush}"
                                        Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_LatestVer}" />
                         </StackPanel>
                     </Grid>

--- a/CollapseLauncher/XAMLs/Updater/Classes/Updater.cs
+++ b/CollapseLauncher/XAMLs/Updater/Classes/Updater.cs
@@ -220,7 +220,7 @@ namespace CollapseLauncher
 
                 float elapsedMin = ((float)currentStopwatch.ElapsedMilliseconds / 1000) / 60;
                 float minLeft = (elapsedMin / counter) * (counterGoal - counter);
-                TimeLeft = TimeSpan.FromMinutes(float.IsInfinity(minLeft) || float.IsNaN(minLeft) ? 0 : minLeft);
+                TimeLeft = TimeSpan.FromMinutes(minLeft.UnNaNInfinity());
 
                 ProgressPercentage = counter;
             }

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -123,19 +123,19 @@
       },
       "H.NotifyIcon.WinUI": {
         "type": "Direct",
-        "requested": "[2.0.129, )",
-        "resolved": "2.0.129",
-        "contentHash": "pQo5zTSDwCe0pqMaHqg2K0zQEbjECQKnjNoN/LVeBGotRPmrYVGIE7iVq1nGQaMhQ15pPmBnz4g8RL6p/CYjZQ==",
+        "requested": "[2.0.131, )",
+        "resolved": "2.0.131",
+        "contentHash": "W+C+Nl1XhsGMbPjW0GyK311qJa8uTeqXZJ7WziPjgqTPDis8tIhWKh+/nB9Jz0XPBSQntQzmIkrSiUwmohee9g==",
         "dependencies": {
-          "H.NotifyIcon": "2.0.129",
+          "H.NotifyIcon": "2.0.131",
           "Microsoft.WindowsAppSDK": "1.4.231115000"
         }
       },
       "HtmlAgilityPack": {
         "type": "Direct",
-        "requested": "[1.11.60, )",
-        "resolved": "1.11.60",
-        "contentHash": "7Uzaf1Mxeuxne33LpTZfSsuRW4sRRX6FWMolOSxXcaAwcKvFevH2E+P6tb4dMWhdyUdBfi0N0yyPZ8hqodfEYg=="
+        "requested": "[1.11.61, )",
+        "resolved": "1.11.61",
+        "contentHash": "hqZASeEFHS9quHvfZSwaULoAJLWkOYVPiQjc3P9J4pQS8vSYzrP3bxe04Vm7vYYuxwbQhq9hCSVvZVLTyRaNaQ=="
       },
       "ImageEx": {
         "type": "Direct",
@@ -181,9 +181,9 @@
       },
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.5.240404000, )",
-        "resolved": "1.5.240404000",
-        "contentHash": "B06pJv0nH31vf4Df72Qoa8A+i12LBUQ/3LhpyWVEQ83opd2a5U49XnqqYrK/T8J6Zf4JTxfLvKBSM5fgXb1YXg==",
+        "requested": "[1.5.240428000, )",
+        "resolved": "1.5.240428000",
+        "contentHash": "gV+UHuwtbZLypWIysNlIX+WHqcm7q3I00E5n+GiDrX28fHXW4yr56d6GwP2banJLDl/JVku5zX2YUOW5X2WRZQ==",
         "dependencies": {
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
@@ -314,13 +314,13 @@
       },
       "TaskScheduler": {
         "type": "Direct",
-        "requested": "[2.10.1, )",
-        "resolved": "2.10.1",
-        "contentHash": "12b19oq9SOGbBq8745jQVQ08jAjgnsGXidQfclaZ94UZCtJRPkNfM8pz0D7pj04RHcQJQdZZnAUuC93reALqNg==",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "p9wH58XSNIyUtO7PIFAEldaKUzpYmlj+YWAfnUqBKnGxIZRY51I9BrsBGJijUVwlxrgmLLPUigRIv2ZTD4uPJA==",
         "dependencies": {
           "Microsoft.Win32.Registry": "5.0.0",
-          "System.Diagnostics.EventLog": "5.0.0",
-          "System.Security.AccessControl": "5.0.0"
+          "System.Diagnostics.EventLog": "8.0.0",
+          "System.Security.AccessControl": "6.0.1"
         }
       },
       "CommunityToolkit.WinUI.Animations": {
@@ -360,18 +360,18 @@
       },
       "H.GeneratedIcons.System.Drawing": {
         "type": "Transitive",
-        "resolved": "2.0.129",
-        "contentHash": "3yrlWN2ckNAw23uj+GgZIXTQNk9MHi/3JE6cO64soG+I2YIhhGCK+j/CHeM3Mw/SPX7uVVz63LeEabUqoFKTQA==",
+        "resolved": "2.0.131",
+        "contentHash": "QoNGQrhxzG+dQufa4xRjSqihMy5aVVVZqQUt0fLJbwhs7rcM4hpN1qVkZpZEkHsRgrHfFBC/Ursjh8STY/sg7A==",
         "dependencies": {
           "System.Drawing.Common": "8.0.0"
         }
       },
       "H.NotifyIcon": {
         "type": "Transitive",
-        "resolved": "2.0.129",
-        "contentHash": "xdCv9tTFBZ+vSr14ibGJmgEVA26E2of3GfujTUtWPY7RC4v3/hgJt3FjnBYM++yjvL9YkMyIs6O6KkBdBvOCqw==",
+        "resolved": "2.0.131",
+        "contentHash": "mdznQAfcJFehblFoDUvtmdm1Y9+u1eMN1ffORbdYv5EwreMxkCwvdj8qQn3qnUo9EIJ6h5Xdgqey9Nj4us8w7w==",
         "dependencies": {
-          "H.GeneratedIcons.System.Drawing": "2.0.129"
+          "H.GeneratedIcons.System.Drawing": "2.0.131"
         }
       },
       "Microsoft.CSharp": {
@@ -997,9 +997,9 @@
       },
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.5.240404000, )",
-        "resolved": "1.5.240404000",
-        "contentHash": "B06pJv0nH31vf4Df72Qoa8A+i12LBUQ/3LhpyWVEQ83opd2a5U49XnqqYrK/T8J6Zf4JTxfLvKBSM5fgXb1YXg==",
+        "requested": "[1.5.240428000, )",
+        "resolved": "1.5.240428000",
+        "contentHash": "gV+UHuwtbZLypWIysNlIX+WHqcm7q3I00E5n+GiDrX28fHXW4yr56d6GwP2banJLDl/JVku5zX2YUOW5X2WRZQ==",
         "dependencies": {
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }

--- a/Hi3Helper.Core/Lang/es_419.json
+++ b/Hi3Helper.Core/Lang/es_419.json
@@ -220,7 +220,7 @@
     "ListCol6": "R.CRC",
     "ListCol7": "Estado",
     "Status1": "Haz clic en \"Chequeo Rápido\" o \"Chequeo Completo\" para comprobar Cachés para actualizaciones",
-    "Status2": "Trying to determine \"{0}\" cache asset availability: {1}",
+    "Status2": "Determinando disponibilidad de archivos de \"{0}\": {1}",
     "CachesStatusHeader1": "Progreso Total",
     "CachesStatusCancelled": "¡La operación fue cancelada!",
     "CachesStatusFetchingType": "Obteniendo Tipo de Cachés: {0}",

--- a/Hi3Helper.Core/Lang/vi_VN.json
+++ b/Hi3Helper.Core/Lang/vi_VN.json
@@ -220,7 +220,7 @@
     "ListCol6": "R.CRC",
     "ListCol7": "Tình trạng",
     "Status1": "Ấn \"Kiểm tra cập nhật\" để cập nhật cache",
-    "Status2": "Trying to determine \"{0}\" cache asset availability: {1}",
+    "Status2": "Cố gắng xác định tính khả dụng của cache \"{0}\": {1}",
     "CachesStatusHeader1": "Tổng tiến trình",
     "CachesStatusCancelled": "Đã huỷ tác vụ!",
     "CachesStatusFetchingType": "Đang tìm kiếm loại cache: {0}",
@@ -370,7 +370,7 @@
     "Debug_MultipleInstance": "Cho phép chạy nhiều phiên bản Collapse",
 
     "ChangeRegionWarning_Toggle": "Hiển thị thông báo thay đổi vùng",
-    "ChangeRegionInstant_Toggle": "Instantly Change Region on Selection",
+    "ChangeRegionInstant_Toggle": "Thay đổi vùng được chọn ngay lập tức",
     "ChangeRegionWarning_Warning": "*Bạn cần phải khởi động lại ứng dụng để áp dụng cài đặt này.",
 
     "Language": "Ngôn ngữ",
@@ -391,7 +391,7 @@
 
     "AppBG": "Hình nền",
     "AppBG_Checkbox": "Dùng hình nền tuỳ chọn",
-    "AppBG_Note": "Accepted formats:\r\nImage: {0}\r\nVideo: {1}",
+    "AppBG_Note": "Định dạng được chấp nhận:\r\nẢnh: {0}\r\nVideo: {1}",
 
     "AppThreads": "Tải về",
     "AppThreads_Download": "Số lượng tải về",
@@ -416,9 +416,9 @@
     "DiscordRPC_GameStatusToggle": "Hiện trò chơi hiện tại trên trạng thái của Discord",
     "DiscordRPC_IdleStatusToggle": "Hiện RPC khi ở trạng thái chờ",
 
-    "VideoBackground": "Video Background Settings",
-    "VideoBackground_IsEnableAudio": "Enable Audio",
-    "VideoBackground_AudioVolume": "Audio Volume",
+    "VideoBackground": "Cài đặt video",
+    "VideoBackground_IsEnableAudio": "Bật âm thanh",
+    "VideoBackground_AudioVolume": "Âm lượng",
 
     "Update": "Cập nhật",
     "Update_CurVer": "Phiên bản hiện tại:",
@@ -484,7 +484,7 @@
 
     "Waifu2X_Toggle": "Dùng Waifu2X [Thử nghiệm]",
     "Waifu2X_Help": "Dùng Waifu2X để phóng lớn ảnh nền.\nKhi bật, chất lượng ảnh sẽ được cải thiện đáng kể, nhưng sẽ mất thêm một ít thời gian để tải ảnh lần đầu.",
-    "Waifu2X_Help2": "Only available for still images!",
+    "Waifu2X_Help2": "Chỉ khả dụng cho ảnh tĩnh!",
     "Waifu2X_Warning_CpuMode": "CẢNH BÁO: Không tìm thấy thiết bị GPU Vulcan có sẵn và sẽ sử dụng chế độ CPU. Điều này sẽ làm tăng đáng kể thời gian xử lý hình ảnh.",
     "Waifu2X_Warning_D3DMappingLayers": "CẢNH BÁO: Hệ thống của bạn có cài đặt \"Gói tương thích OpenCL™, OpenGL®, và Vulkan®\". Nó được cho là không tương thích với Vulkan Loader và sẽ crash trên một số GPU. Vui lòng gỡ bỏ gói này để bật chế độ GPU.",
     "Waifu2X_Error_Loader": "LỖI: Khởi tạo Vulkan Loader thất bại. Đảm bảo rằng GPU của bạn tương thích với Vulkan và đã cài đặt driver GPU cần thiết.",
@@ -905,7 +905,7 @@
     "UpdateHeader4": "Tốc độ:",
     "UpdateHeader5PlaceHolder": "Đang tải về cập nhật [- / -]:",
 
-    "UpdateForcedHeader": "The launcher will be forcely updated due to urgent changes to ensure the launcher to work properly.",
+    "UpdateForcedHeader": "Trình khởi chạy sẽ phải cập nhật bắt buộc do những thay đổi khẩn cấp để đảm bảo trình khởi chạy hoạt động bình thường.",
 
     "UpdateStatus1": "Đang đọc bản cập nhật:",
     "UpdateMessage1": "Đang kết nối với kho lưu trữ cập nhật...",
@@ -1250,8 +1250,8 @@
     "CustomizationSettingsStyleCustomBackgroundHeader": "Hình nền tùy chỉnh",
     "CustomizationSettingsStyleCustomBackgroundDescription": "Dùng hình nền tùy chỉnh thay cho hình mặc định.",
 
-    "VideoBackgroundPreviewUnavailableHeader": "Video Background Preview is Unavailable",
-    "VideoBackgroundPreviewUnavailableDescription": "You cannot preview your video background in OOBE but do not worry! Your video background will be applied once you are completing OOBE.",
+    "VideoBackgroundPreviewUnavailableHeader": "Xem trước video không khả dụng",
+    "VideoBackgroundPreviewUnavailableDescription": "Bạn không thể xem trước video trong OOBE nhưng cũng đừng lo lắng! Video của bạn sẽ được áp dụng sau khi OOBE đã hoàn thành.",
 
     "LoadingInitializationTitle": "Đang khởi tạo lần chạy đầu tiên của trình khởi chạy",
     "LoadingCDNCheckboxCheckLatency": "(Đang kiểm tra độ trễ...)",

--- a/Hi3Helper.Core/packages.lock.json
+++ b/Hi3Helper.Core/packages.lock.json
@@ -2,12 +2,6 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
-      "Microsoft.NET.ILLink.Tasks": {
-        "type": "Direct",
-        "requested": "[8.0.4, )",
-        "resolved": "8.0.4",
-        "contentHash": "PZb5nfQ+U19nhnmnR9T1jw+LTmozhuG2eeuzuW5A7DqxD/UXW2ucjmNJqnqOuh8rdPzM3MQXoF8AfFCedJdCUw=="
-      },
       "Google.Protobuf": {
         "type": "Transitive",
         "resolved": "3.26.1",
@@ -29,7 +23,6 @@
       "hi3helper.http": {
         "type": "Project"
       }
-    },
-    "net8.0/win-x64": {}
+    }
   }
 }

--- a/InnoSetupHelper/packages.lock.json
+++ b/InnoSetupHelper/packages.lock.json
@@ -2,12 +2,6 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
-      "Microsoft.NET.ILLink.Tasks": {
-        "type": "Direct",
-        "requested": "[8.0.4, )",
-        "resolved": "8.0.4",
-        "contentHash": "PZb5nfQ+U19nhnmnR9T1jw+LTmozhuG2eeuzuW5A7DqxD/UXW2ucjmNJqnqOuh8rdPzM3MQXoF8AfFCedJdCUw=="
-      },
       "System.IO.Hashing": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -37,7 +31,6 @@
       "hi3helper.http": {
         "type": "Project"
       }
-    },
-    "net8.0/win-x64": {}
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 
 <p align="center">
+  <img width="512px" height="auto" src="https://cdn.discordapp.com/attachments/1116150301649543230/1234954798088982538/CollapseLauncherIdolType.png?ex=66388b88&is=66373a08&hm=d467954d1ef0c9d26ba0ac29e6bb19cff0c382a5fe252a6abd0125fca7ad38af"/><br/>
+  <i>I know, it's not a good one. But at least we made it lol</i>
+  <i>~ neon-nyan</i>
   <img src="https://raw.githubusercontent.com/neon-nyan/CollapseLauncher-Page/main/images/NewBannerv2_color.webp"/>
 </p>
 


### PR DESCRIPTION
# What's new? - 1.80.3
- **[Fix]** [WORKAROUND] Use legacy parser for SR repair/cache update, by @bagusnl 
  - This due to emergency fix that caused by protobuf incorrectly parsing the data when using static parser.
  - This also fixes SR repair/cache function for v2.2.0
- **[New]** Add way to skip Star Rail audio patch, by @bagusnl 
  - _**NOT RECOMMENDED, ONLY USE FOR DEBUG OR WHEN INSTRUCTED**_
  - Add empty file named `@NoAudioPatch` in the game data to skip Collapse adding, download, and patching audio patch during update.
- **[Fix]** Crashes when Repair/Cache update went too fast, by @bagusnl 
  - Clamp TimeSpan in ProgressBase to not get out of bound
- **[Fix]** Fixed text alignment on "Check Update" button in Settings, by @neon-nyan 
- **[Imp]** Adjusted Windows button style, by @neon-nyan 
- **[Imp]** Extend maximum download thread to 16, by @neon-nyan 
- **[Fix]** Fixed multithreading issue(s) with Install, Repair, and Cache mechanisms, by @neon-nyan 
- **[Imp]** Updated NuGet dependencies, by @bagusnl 
- **[Imp]** Localize Discord RPC details, by @bagusnl 
- **[Fix]** Delta patch for Honkai: Star Rail crashing, by @bagusnl 





Template:
**[New]**
**[Imp]**
**[Fix]**
**[Loc]**
**[Doc]**