### PR TITLE
[New Mainline Release] 1.80.9 Preview

### DIFF
--- a/CollapseLauncher.sln
+++ b/CollapseLauncher.sln
@@ -20,8 +20,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InnoSetupHelper", "InnoSetu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiscordRPC", "Hi3Helper.SharpDiscordRPC\DiscordRPC\DiscordRPC.csproj", "{2004AA88-FFC3-4186-B11A-3E4C577A3D25}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hi3Helper.Sophon.Test", "Hi3Helper.Sophon.Test\Hi3Helper.Sophon.Test.csproj", "{5E97C5A8-EE96-4F47-8CA7-BF4455D12A34}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hi3Helper.Sophon", "Hi3Helper.Sophon\Hi3Helper.Sophon.csproj", "{3F87DCD0-39B7-4F8C-8F34-A0FC7C6E65A0}"
 EndProject
 Global
@@ -84,10 +82,6 @@ Global
 		{2004AA88-FFC3-4186-B11A-3E4C577A3D25}.Publish|x64.Build.0 = Release|x64
 		{2004AA88-FFC3-4186-B11A-3E4C577A3D25}.Release|x64.ActiveCfg = Release|x64
 		{2004AA88-FFC3-4186-B11A-3E4C577A3D25}.Release|x64.Build.0 = Release|x64
-		{5E97C5A8-EE96-4F47-8CA7-BF4455D12A34}.Debug|x64.ActiveCfg = Debug|x64
-		{5E97C5A8-EE96-4F47-8CA7-BF4455D12A34}.Debug|x64.Build.0 = Debug|x64
-		{5E97C5A8-EE96-4F47-8CA7-BF4455D12A34}.Publish|x64.ActiveCfg = Release|x64
-		{5E97C5A8-EE96-4F47-8CA7-BF4455D12A34}.Release|x64.ActiveCfg = Release|x64
 		{3F87DCD0-39B7-4F8C-8F34-A0FC7C6E65A0}.Debug|x64.ActiveCfg = Debug|x64
 		{3F87DCD0-39B7-4F8C-8F34-A0FC7C6E65A0}.Debug|x64.Build.0 = Debug|x64
 		{3F87DCD0-39B7-4F8C-8F34-A0FC7C6E65A0}.Publish|x64.ActiveCfg = Release|x64

--- a/CollapseLauncher/Classes/CoCreateInstance.cs
+++ b/CollapseLauncher/Classes/CoCreateInstance.cs
@@ -145,6 +145,7 @@ namespace CollapseLauncher
         }
 
         [DllImport("OLE32.dll", EntryPoint = "CoCreateInstance", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static unsafe extern HRESULT CoCreateInstanceInvoke(ref Guid rclsid, [MarshalAs(UnmanagedType.IUnknown)] object pUnkOuter, CLSCTX dwClsContext, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppObj);
     }
 }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -260,7 +260,9 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// This holds value for controllers input that has been customized.
         /// </summary>
         public List<string> _overrideControllerMapKeyList { get; set; }
-
+        
+        // unused field
+        public List<string> rewiredMapMigrateRecord { get; set; }
 
         /// <summary>
         /// This holds controller mapping override for controller ID in _overrideControllerMapKeyList.

--- a/CollapseLauncher/Classes/Helper/Image/Waifu2X.cs
+++ b/CollapseLauncher/Classes/Helper/Image/Waifu2X.cs
@@ -10,10 +10,10 @@ namespace CollapseLauncher.Helper.Image
     {
         public const string DllName = "Lib\\waifu2x-ncnn-vulkan";
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern int ncnn_get_default_gpu_index();
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern IntPtr ncnn_get_gpu_name(int gpuId);
 
         public static int DefaultGpuIndex => ncnn_get_default_gpu_index();
@@ -30,31 +30,32 @@ namespace CollapseLauncher.Helper.Image
         public const string DllName = "Lib\\waifu2x-ncnn-vulkan";
 
         #region DllImports
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern IntPtr waifu2x_create(int gpuId = 0, bool ttaMode = false, int numThreads = 0);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern void waifu2x_destroy(IntPtr context);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern unsafe int waifu2x_load(IntPtr context, byte* param, byte* model);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern unsafe int waifu2x_process(IntPtr context, int w, int h, int c, byte* inData, byte* outData);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern unsafe int waifu2x_process_cpu(IntPtr context, int w, int h, int c, byte* inData, byte* outData);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern void waifu2x_set_param(IntPtr context, Param param, int value);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern int waifu2x_get_param(IntPtr context, Param param);
 
-        [DllImport(DllName)]
+        [DllImport(DllName, ExactSpelling = true)]
         private static extern Waifu2XStatus waifu2x_self_test(IntPtr context);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern long GetPackagesByPackageFamily(string packageFamilyName, ref uint count, [Out] IntPtr packageFullNames, ref uint bufferLength, [Out] IntPtr buffer);
         #endregion
 

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -158,12 +158,9 @@
                     if (InnerLauncherConfig.m_isWindows11)
                     {
                         // We have no title bar
-                        const int SM_CYCAPTION      = 4;
-                        const int SM_CYSIZEFRAME    = 33;
-                        const int SM_CXPADDEDBORDER = 92;
-                        var titleBarHeight = InvokeProp.GetSystemMetrics(SM_CYSIZEFRAME) +
-                                             InvokeProp.GetSystemMetrics(SM_CYCAPTION) +
-                                             InvokeProp.GetSystemMetrics(SM_CXPADDEDBORDER);
+                        var titleBarHeight = InvokeProp.GetSystemMetrics(InvokeProp.SystemMetric.SM_CYSIZEFRAME) +
+                                             InvokeProp.GetSystemMetrics(InvokeProp.SystemMetric.SM_CYCAPTION) +
+                                             InvokeProp.GetSystemMetrics(InvokeProp.SystemMetric.SM_CXPADDEDBORDER);
                         value.Height -= titleBarHeight;
 
                         CurrentAppWindow.ResizeClient(new SizeInt32

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -153,16 +153,38 @@
                         return;
                     }
 
-                    CurrentAppWindow.ResizeClient(new SizeInt32
+                    if (InnerLauncherConfig.m_isWindows11)
                     {
-                        Width  = (int)value.Width,
-                        Height = (int)value.Height
-                    });
-                    CurrentAppWindow.Move(new PointInt32
+                        // We have no title bar
+                        const int SM_CYCAPTION      = 4;
+                        const int SM_CYSIZEFRAME    = 33;
+                        const int SM_CXPADDEDBORDER = 92;
+                        var titleBarHeight = InvokeProp.GetSystemMetrics(SM_CYSIZEFRAME) +
+                                             InvokeProp.GetSystemMetrics(SM_CYCAPTION) +
+                                             InvokeProp.GetSystemMetrics(SM_CXPADDEDBORDER);
+                        value.Height -= titleBarHeight;
+
+                        CurrentAppWindow.ResizeClient(new SizeInt32
+                        {
+                            Width  = (int) value.Width,
+                            Height = (int) value.Height
+                        });
+                        CurrentAppWindow.Move(new PointInt32
+                        {
+                            X = (int) value.X,
+                            Y = (int) value.Y
+                        });
+                    }
+                    else
                     {
-                        X = (int)value.X,
-                        Y = (int)value.Y
-                    });
+                        CurrentAppWindow.MoveAndResize(new RectInt32()
+                        {
+                            Width  = (int) value.Width,
+                            Height = (int) value.Height,
+                            X      = (int) value.X,
+                            Y      = (int) value.Y
+                        });
+                    }
                 }
             }
 
@@ -248,7 +270,7 @@
                 // Apply fix for mouse event
                 ApplyWindowTitlebarContextFix();
 
-                // Apply fix for Window border on Windows 11
+                // Apply fix for Window border on Windows 10
                 ApplyWindowBorderFix();
 
                 // Initialize FileDialogHandler
@@ -397,7 +419,7 @@
                     }
                     case WM_NCCALCSIZE:
                     {
-                        if (!InnerLauncherConfig.m_isWindows11 && wParam == 1)
+                        if (!InnerLauncherConfig.m_isWindows11 && wParam != 0)
                         {
                             return 0;
                         }
@@ -564,14 +586,6 @@
                     return;
                 }
 
-                // We have no title bar
-                const int SM_CYCAPTION      = 4;
-                const int SM_CYSIZEFRAME    = 33;
-                const int SM_CXPADDEDBORDER = 92;
-                var titleBarHeight = InvokeProp.GetSystemMetrics(SM_CYSIZEFRAME) +
-                                     InvokeProp.GetSystemMetrics(SM_CYCAPTION) +
-                                     InvokeProp.GetSystemMetrics(SM_CXPADDEDBORDER);
-
                 // Get the scale factor and calculate the size and offset
                 double scaleFactor      = CurrentWindowMonitorScaleFactor;
                 int    lastWindowWidth  = (int)(width * scaleFactor);
@@ -583,7 +597,7 @@
 
                 // Use CurrentWindowPosition to change the size and position
                 CurrentWindowPosition = new Rect
-                    { Height = lastWindowHeight - titleBarHeight, Width = lastWindowWidth, X = xOff, Y = yOff };
+                    { Height = lastWindowHeight, Width = lastWindowWidth, X = xOff, Y = yOff };
             }
 
             internal static void WindowMinimize()

--- a/CollapseLauncher/Classes/InstallManagement/StarRail/StarRailInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/StarRail/StarRailInstall.cs
@@ -4,6 +4,7 @@ using CollapseLauncher.Interfaces;
 using Hi3Helper;
 using Hi3Helper.Shared.ClassStruct;
 using Microsoft.UI.Xaml;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -217,6 +218,19 @@ namespace CollapseLauncher.InstallManager.StarRail
             filesToDelete = new[] { "ACE-BASE.sys", "GameAssembly.dll", "pkg_version", "config.ini", "^StarRail.*", "^Unity.*" },
             foldersToKeepInData = new[] { "ScreenShots" }
         };
+        #endregion
+
+        #region Override Methods - Sophon
+        protected override string GetLangIdToSophonVOLangName(int id)
+            => id switch
+            {
+                0 => "zh-cn",
+                1 => "zh-cn",
+                2 => "en-us",
+                3 => "ja-jp",
+                4 => "ko-kr",
+                _ => throw new NotSupportedException($"This lang id: {id} is not supported")
+            };
         #endregion
     }
 }

--- a/CollapseLauncher/Classes/RegistryMonitor/RegistryMonitor.cs
+++ b/CollapseLauncher/Classes/RegistryMonitor/RegistryMonitor.cs
@@ -24,16 +24,19 @@ namespace RegistryUtils
     {
         #region P/Invoke
 
-        [DllImport("advapi32.dll", SetLastError = true)]
+        [DllImport("advapi32.dll", EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern int RegOpenKeyEx(IntPtr hKey, string subKey, uint options, int samDesired,
                                                out IntPtr phkResult);
 
-        [DllImport("advapi32.dll", SetLastError = true)]
+        [DllImport("advapi32.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern int RegNotifyChangeKeyValue(IntPtr hKey, bool bWatchSubtree,
                                                           RegChangeNotifyFilter dwNotifyFilter, IntPtr hEvent,
                                                           bool fAsynchronous);
 
-        [DllImport("advapi32.dll", SetLastError = true)]
+        [DllImport("advapi32.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern int RegCloseKey(IntPtr hKey);
 
         private const int KEY_QUERY_VALUE = 0x0001;

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -42,6 +42,12 @@ namespace CollapseLauncher
                 // Iterate assetIndex and check it using different method for each type and run it in parallel
                 await Parallel.ForEachAsync(assetIndex, new ParallelOptions { MaxDegreeOfParallelism = _threadCount, CancellationToken = token }, async (asset, threadToken) =>
                 {
+                    if (asset.IsUsed)
+                    {
+                        return;
+                    }
+                    asset.IsUsed = true;
+
                     // Assign a task depends on the asset type
                     switch (asset.FT)
                     {
@@ -58,7 +64,7 @@ namespace CollapseLauncher
                             await CheckAssetTypeGeneric(asset, brokenAssetIndex, threadToken);
                             break;
                     }
-                }).ConfigureAwait(false);
+                });
             }
             catch (AggregateException ex)
             {
@@ -176,7 +182,7 @@ namespace CollapseLauncher
             }
 
             // Open and read fileInfo as FileStream 
-            using (FileStream filefs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, _bufferBigLength))
+            await using (FileStream filefs = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 // If pass the check above, then do MD5 Hash calculation
                 localCRC = await CheckHashAsync(filefs, MD5.Create(), token);
@@ -272,7 +278,7 @@ namespace CollapseLauncher
             }
 
             // Open and read fileInfo as FileStream 
-            using (FileStream filefs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, _bufferBigLength))
+            await using (FileStream filefs = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 // If pass the check above, then do CRC calculation
                 byte[] localCRC = await CheckHashAsync(filefs, MD5.Create(), token);

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -182,7 +182,7 @@ namespace CollapseLauncher
             }
 
             // Open and read fileInfo as FileStream 
-            await using (FileStream filefs = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
+            await using (FileStream filefs = await NaivelyOpenFileStreamAsync(file, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 // If pass the check above, then do MD5 Hash calculation
                 localCRC = await CheckHashAsync(filefs, MD5.Create(), token);
@@ -278,7 +278,7 @@ namespace CollapseLauncher
             }
 
             // Open and read fileInfo as FileStream 
-            await using (FileStream filefs = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
+            await using (FileStream filefs = await NaivelyOpenFileStreamAsync(file, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 // If pass the check above, then do CRC calculation
                 byte[] localCRC = await CheckHashAsync(filefs, MD5.Create(), token);
@@ -395,7 +395,7 @@ namespace CollapseLauncher
             if ((fileOld?.Exists ?? false) && !file.Exists)
             {
                 // Open and read fileInfo as FileStream 
-                using (FileStream fileOldfs = new FileStream(filePathOld, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, _bufferBigLength))
+                await using (FileStream fileOldfs = await NaivelyOpenFileStreamAsync(fileOld, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     // If pass the check above, then do CRC calculation
                     byte[] localOldCRC = await CheckHashAsync(fileOldfs, MD5.Create(), token, false);
@@ -478,7 +478,7 @@ namespace CollapseLauncher
             }
 
             // Open and read fileInfo as FileStream 
-            using (FileStream filefs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, _bufferBigLength))
+            await using (FileStream filefs = await NaivelyOpenFileStreamAsync(file, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 // If pass the check above, then do CRC calculation
                 // Additional: the total file size progress is disabled and will be incremented after this

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
@@ -107,15 +107,15 @@ namespace CollapseLauncher
                     // Get the Senadina File Identifier Dictionary and its file references
                     senadinaFileIdentifier = await GetSenadinaIdentifierDictionary(httpClient, _mainMetaRepoUrl, token);
                     audioManifestSenadinaFileIdentifier = await GetSenadinaIdentifierKind(httpClient, senadinaFileIdentifier,
-                                                                                          SenadinaKind.chiptunesCurrent, versionArray, _mainMetaRepoUrl, token);
+                                                                                          SenadinaKind.chiptunesCurrent, versionArray, _mainMetaRepoUrl, false, token);
                     blocksPlatformManifestSenadinaFileIdentifier = await GetSenadinaIdentifierKind(httpClient, senadinaFileIdentifier,
-                                                                                               SenadinaKind.platformBase, versionArray, _mainMetaRepoUrl, token);
+                                                                                               SenadinaKind.platformBase, versionArray, _mainMetaRepoUrl, false, token);
                     blocksBaseManifestSenadinaFileIdentifier = await GetSenadinaIdentifierKind(httpClient, senadinaFileIdentifier,
-                                                                                               SenadinaKind.bricksBase, versionArray, _mainMetaRepoUrl, token);
+                                                                                               SenadinaKind.bricksBase, versionArray, _mainMetaRepoUrl, false, token);
                     blocksCurrentManifestSenadinaFileIdentifier = await GetSenadinaIdentifierKind(httpClient, senadinaFileIdentifier,
-                                                                                                  SenadinaKind.bricksCurrent, versionArray, _mainMetaRepoUrl, token);
+                                                                                                  SenadinaKind.bricksCurrent, versionArray, _mainMetaRepoUrl, false, token);
                     patchConfigManifestSenadinaFileIdentifier = await GetSenadinaIdentifierKind(httpClient, senadinaFileIdentifier,
-                                                                                                SenadinaKind.wandCurrent, versionArray, _mainMetaRepoUrl, token);
+                                                                                                SenadinaKind.wandCurrent, versionArray, _mainMetaRepoUrl, true, token);
                 }
 
                 if (!_isOnlyRecoverMain)
@@ -183,7 +183,7 @@ namespace CollapseLauncher
 #endif
         }
 
-        private async Task<SenadinaFileIdentifier?> GetSenadinaIdentifierKind(HttpClient client, Dictionary<string, SenadinaFileIdentifier>? dict, SenadinaKind kind, int[] gameVersion, string mainUrl, CancellationToken token)
+        private async Task<SenadinaFileIdentifier?> GetSenadinaIdentifierKind(HttpClient client, Dictionary<string, SenadinaFileIdentifier>? dict, SenadinaKind kind, int[] gameVersion, string mainUrl, bool skipThrow, CancellationToken token)
         {
             ArgumentNullException.ThrowIfNull(dict);
             
@@ -194,6 +194,7 @@ namespace CollapseLauncher
             if (!dict.ContainsKey(origFileRelativePath))
             {
                 LogWriteLine($"Key reference to the pustaka file: {hashedRelativePath} is not found for game version: {string.Join('.', gameVersion)}. Please contact us on our Discord Server to report this issue.", LogType.Error, true);
+                if (skipThrow) return null;
                 throw new
                     FileNotFoundException("Assets reference for repair is not found. " +
                                           "Please contact us in GitHub issues or Discord to let us know about this issue.");

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -1228,8 +1228,8 @@ namespace CollapseLauncher
                 paneToggleButtonGrid.PointerExited  += NavView_PanePointerEntered;
             }
 
-            var backIcon = NavigationViewControl.FindDescendant("NavigationViewBackButton")?.FindDescendant<AnimatedIcon>();
-            backIcon?.ApplyDropShadow(Colors.Gray, 20);
+            // var backIcon = NavigationViewControl.FindDescendant("NavigationViewBackButton")?.FindDescendant<AnimatedIcon>();
+            // backIcon?.ApplyDropShadow(Colors.Gray, 20);
 
             var toggleIcon = NavigationViewControl.FindDescendant("TogglePaneButton")?.FindDescendant<AnimatedIcon>();
             toggleIcon?.ApplyDropShadow(Colors.Gray, 20);

--- a/CollapseLauncher/XAMLs/MainApp/TrayIcon.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/TrayIcon.xaml.cs
@@ -124,7 +124,7 @@ namespace CollapseLauncher
             if (LauncherConfig.GetAppConfigValue("EnableConsole").ToBool())
             {
                 IntPtr consoleWindowHandle = GetConsoleWindow();
-                if (m_consoleHandle == IntPtr.Zero) return;
+                if (LoggerConsole.ConsoleHandle == IntPtr.Zero) return;
                 if (IsWindowVisible(consoleWindowHandle) && !forceShow)
                 {
                     LoggerConsole.DisposeConsole();

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -161,12 +161,6 @@
           "Microsoft.WindowsAppSDK": "1.5.240227000"
         }
       },
-      "Microsoft.NET.ILLink.Tasks": {
-        "type": "Direct",
-        "requested": "[8.0.5, )",
-        "resolved": "8.0.5",
-        "contentHash": "4ISW1Ndgz86FkIbu5rVlMqhhtojdy5rUlxC/N+9kPh9qbYcvHiCvYbHKzAPVIx9OPYIjT9trXt7JI42Y5Ukq6A=="
-      },
       "Microsoft.NETCore.Platforms": {
         "type": "Direct",
         "requested": "[8.0.0-preview.7.23375.6, )",
@@ -223,6 +217,15 @@
         "requested": "[2.0.0, )",
         "resolved": "2.0.0",
         "contentHash": "OZP9ACtcxaJeyidhulsLFAG1OLq5OOozXeORg5Ol3pUCHb0Abz6EqQI6Sz38oJESP3dtz1lTNg8DHauVhbp7BA=="
+      },
+      "SharpCompress": {
+        "type": "Direct",
+        "requested": "[0.37.2, )",
+        "resolved": "0.37.2",
+        "contentHash": "cFBpTct57aubLQXkdqMmgP8GGTFRh7fnRWP53lgE/EYUpDZJ27SSvTkdjB4OYQRZ20SJFpzczUquKLbt/9xkhw==",
+        "dependencies": {
+          "ZstdSharp.Port": "0.8.0"
+        }
       },
       "SharpHDiffPatch.Core": {
         "type": "Direct",

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -365,8 +365,8 @@
       },
       "Google.Protobuf": {
         "type": "Transitive",
-        "resolved": "3.27.0",
-        "contentHash": "tEaKpc+SP7I3gYW9AHozESyKkrCg8Xe7huI3Q3iUt5t8Dn29r2k1u8jyrGrD16maj/0UsQBM0MDViWEj0iynOA=="
+        "resolved": "3.27.1",
+        "contentHash": "7IVz9TzhYCZ8qY0rPhXUnyJSXYdshUqmmxmTI763XmDDSJJFnyfKH43FFcMJu/CZgBcE98xlFztrKwhzcRkiPg=="
       },
       "H.GeneratedIcons.System.Drawing": {
         "type": "Transitive",
@@ -386,8 +386,8 @@
       },
       "Hi3Helper.ZstdNet": {
         "type": "Transitive",
-        "resolved": "1.5.3",
-        "contentHash": "QIaWZmCvxzDng6cXrrh2uJp9BcNOQQNqnVt729vcDvSlWhhE5+QioqZupskLrW9zIuvvxayBr+Ei6KpwYBeMNw=="
+        "resolved": "1.6.2",
+        "contentHash": "8fx2KaLe9SAAODCNY0qXHIFNbloELXIIPUPGquxjIBj6YIznhTAynzH3RJeOQSFrtkdH37BwEFY2YAw4fW9ghQ=="
       },
       "Microsoft.CSharp": {
         "type": "Transitive",

--- a/Hi3Helper.Core/Classes/Data/InvokeProp.cs
+++ b/Hi3Helper.Core/Classes/Data/InvokeProp.cs
@@ -19,8 +19,11 @@ namespace Hi3Helper
         // https://pinvoke.net/default.aspx/Enums.SystemMetric
         public enum SystemMetric
         {
-            SM_CXSCREEN = 0,
-            SM_CYSCREEN = 1
+            SM_CXSCREEN       = 0,
+            SM_CYSCREEN       = 1,
+            SM_CYCAPTION      = 4,
+            SM_CYSIZEFRAME    = 33,
+            SM_CXPADDEDBORDER = 92,
         }
 
         // Reference:
@@ -33,14 +36,6 @@ namespace Hi3Helper
             SWP_NOZORDER     = 4,
             SWP_FRAMECHANGED = 0x20,
             SWP_SHOWWINDOW   = 0x40,
-        }
-
-        public enum SpecialWindowHandles
-        {
-            HWND_TOP = 0,
-            HWND_BOTTOM = 1,
-            HWND_TOPMOST = -1,
-            HWND_NOTOPMOST = -2
         }
 
         [Flags]
@@ -92,63 +87,52 @@ namespace Hi3Helper
         #endregion
 
         #region Kernel32
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", ExactSpelling = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr GetConsoleWindow();
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        public static extern IntPtr GetStdHandle(int nStdHandle);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool SetStdHandle(int nStdHandle, IntPtr hHandle);
 
-        [DllImport("kernel32.dll")]
-        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        public static extern uint GetLastError();
-
-        [DllImport("Kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool AllocConsole();
 
-        [DllImport("Kernel32.dll")]
-        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        public static extern bool FreeConsole();
-
-        [DllImport("Kernel32.dll")]
+        [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess, uint dwShareMode, uint lpSecurityAttributes, uint dwCreationDisposition, uint dwFlagsAndAttributes, uint hTemplateFile);
         
-        [DllImport("KERNEL32.dll", ExactSpelling = true, SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr GlobalAlloc(GLOBAL_ALLOC_FLAGS uFlags, nuint uBytes);
         
-        [DllImport("KERNEL32.dll", ExactSpelling = true, SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr GlobalFree(IntPtr hMem);
 
-        [DllImport("KERNEL32.dll", ExactSpelling = true, SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr GlobalLock(IntPtr hMem);
 
-        [DllImport("KERNEL32.dll", ExactSpelling = true, SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GlobalUnlock(IntPtr hMem);
         
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool SetConsoleCtrlHandler(HandlerRoutine handlerRoutine, bool add);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern ExecutionState SetThreadExecutionState(ExecutionState esFlags);
 
         #endregion
@@ -165,88 +149,73 @@ namespace Hi3Helper
             public uint   flags;
         }
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        public static extern int GetSystemMetrics(int nIndex);
+        public static extern int GetSystemMetrics(SystemMetric nIndex);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
 
-        [DllImport("user32.dll", SetLastError = true)]
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, SetWindowPosFlags uFlags);
 
-        [DllImport("user32.dll")]
-        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        public static extern int GetDpiForWindow(IntPtr hWnd);
-        
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        [DllImport("user32.dll", EntryPoint = "SendMessageW", ExactSpelling = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, UIntPtr wParam, IntPtr lParam);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        public static extern IntPtr GetActiveWindow();
-
-        [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
-        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool OpenClipboard(IntPtr hWndNewOwner);
 
-        [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CloseClipboard();
 
-        [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr SetClipboardData(uint uFormat, IntPtr data);
 
-        [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool EmptyClipboard();
         
-        [DllImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool IsWindowVisible(IntPtr hWnd);
 
-        [DllImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
-        
-        [DllImport("user32.dll")]
-        public static extern bool GetWindowRect(IntPtr hwnd, ref WindowRect rectangle);
 
-        [DllImport("user32.dll")]
-        public static extern uint GetWindowLong(IntPtr hwnd, int index);
-
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr GetForegroundWindow();
 
-        [DllImport("user32.dll")]
-        public static extern uint SetWindowLong(IntPtr hwnd, int index, uint value);
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        public static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
-        [DllImport("user32.dll")]
-        public static extern IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr value);
-
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", EntryPoint = "FindWindowExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern bool DestroyWindow(IntPtr hwnd);
 
-        [DllImport("user32.dll")]
-        public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hwnd, uint msg, UIntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll", EntryPoint = "CallWindowProcW", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
         #endregion
 
         #region Shcore
-        [DllImport("Shcore.dll", SetLastError = true)]
+        [DllImport("Shcore.dll", ExactSpelling = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern int GetDpiForMonitor(IntPtr hmonitor, Monitor_DPI_Type dpiType, out uint dpiX, out uint dpiY);
         #endregion
@@ -275,7 +244,8 @@ namespace Hi3Helper
             internal void* Buffer;
         }
 
-        [DllImport("ntdll.dll")]
+        [DllImport("ntdll.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private unsafe static extern uint NtQuerySystemInformation(int SystemInformationClass, byte* SystemInformation, uint SystemInformationLength, out uint ReturnLength);
 
         private static byte[] NtQueryCachedBuffer = new byte[4 << 20];
@@ -432,16 +402,6 @@ namespace Hi3Helper
             }
         }
 
-        public struct WindowRect
-        {
-            // ReSharper disable UnusedAutoPropertyAccessor.Global
-            public int Left { get; set; }
-            public int Top { get; set; }
-            public int Right { get; set; }
-            public int Bottom { get; set; }
-            // ReSharper restore UnusedAutoPropertyAccessor.Global
-        }
-        
         public static IntPtr GetProcessWindowHandle(string ProcName) => Process.GetProcessesByName(Path.GetFileNameWithoutExtension(ProcName), ".")[0].MainWindowHandle;
 
         public class InvokePresence
@@ -458,7 +418,8 @@ namespace Hi3Helper
         }
 
         #region shell32
-        [DllImport("shell32.dll", SetLastError = true)]
+        [DllImport("shell32.dll", EntryPoint = "ExtractIconExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern uint ExtractIconEx(string lpszFile, int nIconIndex, IntPtr[] phiconLarge, IntPtr[] phiconSmall, uint nIcons);
 
         public static void SetWindowIcon(IntPtr hWnd, IntPtr hIconLarge, IntPtr hIconSmall)
@@ -535,17 +496,20 @@ namespace Hi3Helper
             public int cyBottomHeight;
         }
 
-        [DllImport("dwmapi.dll")]
+        [DllImport("dwmapi.dll", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern uint DwmExtendFrameIntoClientArea(IntPtr hWnd, ref MARGINS pMarInset);
         #endregion
 
         #region uxtheme
-        [DllImport("uxtheme.dll", EntryPoint = "#132")]
+        [DllImport("uxtheme.dll", EntryPoint = "#132", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         [return:MarshalAs(UnmanagedType.I1)]
         public static extern bool ShouldAppsUseDarkMode();
 
         // Note: Can only use "Default" and "AllowDark" to support Windows 10 1809
-        [DllImport("uxtheme.dll", EntryPoint = "#135")]
+        [DllImport("uxtheme.dll", EntryPoint = "#135", ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern PreferredAppMode SetPreferredAppMode(PreferredAppMode preferredAppMode);
         #endregion
     }

--- a/Hi3Helper.Core/Classes/Data/InvokeProp.cs
+++ b/Hi3Helper.Core/Classes/Data/InvokeProp.cs
@@ -48,8 +48,6 @@ namespace Hi3Helper
             GPTR = 0x00000040,
         }
 
-        public static IntPtr m_consoleHandle;
-
         public enum HandleEnum
         {
             SW_HIDE = 0,

--- a/Hi3Helper.Core/Classes/Data/InvokeProp.cs
+++ b/Hi3Helper.Core/Classes/Data/InvokeProp.cs
@@ -154,6 +154,16 @@ namespace Hi3Helper
         #endregion
 
         #region User32
+        public struct WINDOWPOS
+        {
+            public IntPtr hwnd;
+            public IntPtr hwndInsertAfter;
+            public int    x;
+            public int    y;
+            public int    cx;
+            public int    cy;
+            public uint   flags;
+        }
 
         [DllImport("user32.dll")]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/Hi3Helper.Core/Classes/Data/ScreenData.cs
+++ b/Hi3Helper.Core/Classes/Data/ScreenData.cs
@@ -31,8 +31,8 @@ namespace Hi3Helper.Screen
 
         public static Size GetScreenSize() => new Size
         {
-            Width = GetSystemMetrics((int)SystemMetric.SM_CXSCREEN),
-            Height = GetSystemMetrics((int)SystemMetric.SM_CYSCREEN)
+            Width = GetSystemMetrics(SystemMetric.SM_CXSCREEN),
+            Height = GetSystemMetrics(SystemMetric.SM_CYSCREEN)
         };
     }
 }

--- a/Hi3Helper.Core/Classes/Logger/LoggerBase.cs
+++ b/Hi3Helper.Core/Classes/Logger/LoggerBase.cs
@@ -78,7 +78,7 @@ namespace Hi3Helper
         {
             // Always seek to the end of the file.
             _logWriter?.BaseStream.Seek(0, SeekOrigin.End);
-            _logWriter?.WriteLine(GetLine(line, type, false));
+            _logWriter?.WriteLine(GetLine(line, type, false, true));
         }
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 #endregion
@@ -89,26 +89,29 @@ namespace Hi3Helper
         /// </summary>
         /// <param name="line">Line for the log you want to return</param>
         /// <param name="type">Type of the log. The type will be added in the return</param>
-        /// <param name="isForDisplaying">To indicate if the return will be used for writing into log or just displaying</param>
-        /// <returns>Decorated line with timestamp if isForDisplaying is false or colored if isForDisplaying is true</returns>
-        protected string GetLine(string line, LogType type, bool isForDisplaying)
+        /// <param name="coloredType">Whether to colorize the type string, typically used for displaying</param>
+        /// <param name="withTimeStamp">Whether to append a timestamp after log type</param>
+        /// <returns>Decorated line with colored type or timestamp according to the parameters</returns>
+        protected string GetLine(string line, LogType type, bool coloredType, bool withTimeStamp)
         {
             lock (_stringBuilder)
             {
                 // Clear the _stringBuilder
                 _stringBuilder.Clear();
 
-                // If it's used for display only, then append color string + label.
-                // Else, append label + timestamp
-                if (isForDisplaying)
+                // Colorize the log type
+                if (coloredType)
                 {
                     _stringBuilder.Append(GetColorizedString(type) + GetLabelString(type) + "\u001b[0m");
                 }
                 else
                 {
                     _stringBuilder.Append(GetLabelString(type));
+                }
 
-                    // Append timestamp for write log
+                // Append timestamp
+                if (withTimeStamp)
+                {
                     if (type != LogType.NoTag)
                     {
                         _stringBuilder.Append($" [{GetCurrentTime("HH:mm:ss.fff")}]");

--- a/Hi3Helper.Core/Classes/Logger/Type/LoggerConsole.cs
+++ b/Hi3Helper.Core/Classes/Logger/Type/LoggerConsole.cs
@@ -46,7 +46,7 @@ namespace Hi3Helper
             }
 
             // Decorate the line
-            line = GetLine(line, type, _virtualTerminal);
+            line = GetLine(line, type, _virtualTerminal, false);
 
             // Write using new async write line output and use .Error for error type
             if (type == LogType.Error) await Console.Error.WriteLineAsync(line);
@@ -72,7 +72,7 @@ namespace Hi3Helper
                 return;
             }
 
-            line = GetLine(line, type, true);
+            line = GetLine(line, type, _virtualTerminal, false);
             Console.Write(line);
 
             if (writeToLog) WriteLog(line, type);

--- a/Hi3Helper.Core/Classes/Logger/Type/LoggerConsole.cs
+++ b/Hi3Helper.Core/Classes/Logger/Type/LoggerConsole.cs
@@ -10,6 +10,9 @@ namespace Hi3Helper
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter")]
     public class LoggerConsole : LoggerBase, ILog
     {
+        public static IntPtr ConsoleHandle;
+        private static bool _virtualTerminal;
+
         public LoggerConsole(string folderPath, Encoding encoding) : base(folderPath, encoding)
 #if !APPLYUPDATE
             => AllocateConsole();
@@ -43,7 +46,7 @@ namespace Hi3Helper
             }
 
             // Decorate the line
-            line = GetLine(line, type, true);
+            line = GetLine(line, type, _virtualTerminal);
 
             // Write using new async write line output and use .Error for error type
             if (type == LogType.Error) await Console.Error.WriteLineAsync(line);
@@ -80,7 +83,7 @@ namespace Hi3Helper
         #region StaticMethods
         public static void DisposeConsole()
         {
-            if (m_consoleHandle != IntPtr.Zero)
+            if (ConsoleHandle != IntPtr.Zero)
             {
                 IntPtr consoleWindow = GetConsoleWindow();
                 ShowWindow(consoleWindow, 0);
@@ -89,7 +92,7 @@ namespace Hi3Helper
 
         public static void AllocateConsole()
         {
-            if (m_consoleHandle != IntPtr.Zero)
+            if (ConsoleHandle != IntPtr.Zero)
             {
                 IntPtr consoleWindow = GetConsoleWindow();
                 ShowWindow(consoleWindow, 5);
@@ -105,10 +108,10 @@ namespace Hi3Helper
             const uint GENERIC_WRITE = 0x40000000;
             const uint FILE_SHARE_WRITE = 2;
             const uint OPEN_EXISTING = 3;
-            m_consoleHandle = CreateFile("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+            ConsoleHandle = CreateFile("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
 
             const int STD_OUTPUT_HANDLE = -11;
-            SetStdHandle(STD_OUTPUT_HANDLE, m_consoleHandle);
+            SetStdHandle(STD_OUTPUT_HANDLE, ConsoleHandle);
 
             Console.OutputEncoding = Encoding.UTF8;
 
@@ -118,16 +121,16 @@ namespace Hi3Helper
             if (instanceCount > 1) instanceIndicator = $" - #{instanceCount}";
             Console.Title = $"Collapse Console{instanceIndicator}";
 
-            if (!GetConsoleMode(m_consoleHandle, out uint mode))
+            if (GetConsoleMode(ConsoleHandle, out uint mode))
             {
-                throw new ContextMarshalException($"Failed to get console mode with error code: {Marshal.GetLastPInvokeError()}");
-            }
-
-            const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4;
-            const uint DISABLE_NEWLINE_AUTO_RETURN = 8;
-            if (!SetConsoleMode(m_consoleHandle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN))
-            {
-                throw new ContextMarshalException($"Failed to set console mode with error code: {Marshal.GetLastPInvokeError()}");
+                const uint ENABLE_PROCESSED_OUTPUT            = 1;
+                const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4;
+                const uint DISABLE_NEWLINE_AUTO_RETURN        = 8;
+                mode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
+                if (SetConsoleMode(ConsoleHandle, mode))
+                {
+                    _virtualTerminal = true;
+                }
             }
 
             SetWindowIcon(GetConsoleWindow(), AppIconLarge, AppIconSmall);

--- a/Hi3Helper.Core/Classes/Shared/ClassStruct/Class/GameDataStructure.cs
+++ b/Hi3Helper.Core/Classes/Shared/ClassStruct/Class/GameDataStructure.cs
@@ -11,6 +11,7 @@ namespace Hi3Helper.Shared.ClassStruct
     public enum FileType : byte { Generic, Blocks, Audio, Video, Unused }
     public class FilePropertiesRemote : IAssetIndexSummary
     {
+        public bool IsUsed { get; set; }
         private string _crc;
         private byte[] _crcArray;
 

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -374,7 +374,7 @@
     "Debug_IncludeGameLogs": "保存游戏日志到 Collapse（可能含有敏感数据）",
     "Debug_MultipleInstance": "允许开启多个 Collapse",
 
-    "ChangeRegionWarning_Toggle": "显示区域更改警告",
+    "ChangeRegionWarning_Toggle": "显示区服更改警告",
     "ChangeRegionInstant_Toggle": "选择后立即更改区服",
     "ChangeRegionWarning_Warning": "*您需要重新启动应用程序以使此设置生效。",
 
@@ -561,6 +561,7 @@
     "Idle": "闲置",
     "Change": "更改",
     "Cancelled": "已取消",
+    "FinishingUp": "即将完成",
     "Extracting": "提取中",
     "Converting": "转换中",
     "Patching": "修补中",

--- a/Hi3Helper.Sophon.Test/Hi3Helper.Sophon.Test.csproj
+++ b/Hi3Helper.Sophon.Test/Hi3Helper.Sophon.Test.csproj
@@ -1,17 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Platforms>x64</Platforms>
-    <EntryPointExe>Hi3Helper.Sophon.Test.Main</EntryPointExe>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net462</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Platforms>x64</Platforms>
+        <EntryPointExe>Hi3Helper.Sophon.Test.Main</EntryPointExe>
+		<DefineConstants>DEMODIFF</DefineConstants>
+		<LangVersion>preview</LangVersion>
     </PropertyGroup>
-    
-    <ItemGroup>
-    <ProjectReference Include="..\Hi3Helper.Sophon\Hi3Helper.Sophon.csproj" />
-    </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">
         <DebugType>portable</DebugType>
     </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Threading.Tasks" Version="*" />
+		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="*" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="*" Condition="$(DefineConstants.Contains('NET462'))" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Hi3Helper.Sophon\Hi3Helper.Sophon.Universal.csproj" />
+	</ItemGroup>
 </Project>

--- a/Hi3Helper.Sophon.Test/Hi3Helper.Sophon.Test/Hi3Helper.Sophon.Test.sln
+++ b/Hi3Helper.Sophon.Test/Hi3Helper.Sophon.Test/Hi3Helper.Sophon.Test.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.34929.205
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hi3Helper.Sophon.Universal", "..\..\Hi3Helper.Sophon\Hi3Helper.Sophon.Universal.csproj", "{58B8538F-C2F2-47AD-A8C1-966040B7C976}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hi3Helper.Sophon.Test", "..\Hi3Helper.Sophon.Test.csproj", "{43CEB3FE-530B-4CE4-833A-40A4720104E0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{58B8538F-C2F2-47AD-A8C1-966040B7C976}.Debug|x64.ActiveCfg = Debug|x64
+		{58B8538F-C2F2-47AD-A8C1-966040B7C976}.Debug|x64.Build.0 = Debug|x64
+		{58B8538F-C2F2-47AD-A8C1-966040B7C976}.Release|x64.ActiveCfg = Release|x64
+		{58B8538F-C2F2-47AD-A8C1-966040B7C976}.Release|x64.Build.0 = Release|x64
+		{43CEB3FE-530B-4CE4-833A-40A4720104E0}.Debug|x64.ActiveCfg = Debug|x64
+		{43CEB3FE-530B-4CE4-833A-40A4720104E0}.Debug|x64.Build.0 = Debug|x64
+		{43CEB3FE-530B-4CE4-833A-40A4720104E0}.Release|x64.ActiveCfg = Release|x64
+		{43CEB3FE-530B-4CE4-833A-40A4720104E0}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A5298644-AC74-413B-876B-881C03B58503}
+	EndGlobalSection
+EndGlobal

--- a/Hi3Helper.Sophon.Test/Program.cs
+++ b/Hi3Helper.Sophon.Test/Program.cs
@@ -2,8 +2,10 @@
 using Hi3Helper.Sophon.Infos;
 using Hi3Helper.Sophon.Structs;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -20,15 +22,20 @@ namespace Hi3Helper.Sophon.Test
         private static int UsageHelp()
         {
             string executableName = Process.GetCurrentProcess().ProcessName;
+#if !DEMODIFF
             Console.WriteLine($"{executableName} [Sophon Branch Url] [Matching field name (usually, you can set \"game\" as the value)] [Download Output Path] [OPTIONAL: Amount of threads to be used (Default: {Environment.ProcessorCount})] [OPTIONAL: Amount of max. connection used for Http Client (Default: 128)]");
+#else
+            Console.WriteLine($"{executableName} [Preload/Update] [Sophon Branch Url From] [Sophon Branch Url To] [Matching field name (usually, you can set \"game\" as the value)] [Old Directory Path] [New Directory Path] [OPTIONAL: Amount of threads to be used (Default: {Environment.ProcessorCount})] [OPTIONAL: Amount of max. connection used for Http Client (Default: 128)]");
+#endif
             return 1;
         }
 
-        public static async Task<int> Main(params string[] args)
+            public static async Task<int> Main(params string[] args)
         {
             int threads = Environment.ProcessorCount;
             int maxHttpHandle = 128;
 
+#if !DEMODIFF
             if (args.Length < 3)
                 return UsageHelp();
 
@@ -39,27 +46,60 @@ namespace Hi3Helper.Sophon.Test
                 Console.WriteLine($"HTTP Client maximum connection has been set to: {maxHttpHandle} handles!");
 
             string outputDir = args[2];
+#else
+            bool isPreloadMode = false;
 
-            Logger.LogHandler += Logger_LogHandler;
+            if (args.Length < 6)
+                return UsageHelp();
+
+            if (!((isPreloadMode = args[0].Equals("Preload", StringComparison.OrdinalIgnoreCase)) || args[0].Equals("Update", StringComparison.OrdinalIgnoreCase)))
+                return UsageHelp();
+
+            if (args.Length > 6 && int.TryParse(args[6], out threads))
+                Console.WriteLine($"Thread count has been set to: {threads} for downloading!");
+
+            if (args.Length > 7 && int.TryParse(args[7], out maxHttpHandle))
+                Console.WriteLine($"HTTP Client maximum connection has been set to: {maxHttpHandle} handles!");
+
+            string outputDir = args[4];
+#endif
+
+        // Logger.LogHandler += Logger_LogHandler;
 
         StartDownload:
             using (CancellationTokenSource tokenSource = new CancellationTokenSource())
             {
-                CancelMessage = "Press \"C\" key to stop or \"R\" key to restart the download";
+                CancelMessage = "[\"C\"] Stop or [\"R\"] Restart";
                 using (HttpClientHandler httpHandler = new HttpClientHandler
                 {
                     MaxConnectionsPerServer = maxHttpHandle
                 })
                 using (HttpClient httpClient = new HttpClient(httpHandler)
                 {
-                    // DefaultRequestVersion = HttpVersion.Version30,
-                    // DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower
+#if NET6_0_OR_GREATER
+                    DefaultRequestVersion = HttpVersion.Version30,
+                    DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower
+#endif
                 })
                 {
+#if !DEMODIFF
                     SophonChunkManifestInfoPair manifestPair = await SophonManifest.CreateSophonChunkManifestInfoPair(httpClient, args[0], args[1], tokenSource.Token);
 
                     SophonChunksInfo sophonChunksInfo = manifestPair.ChunksInfo;
                     SophonManifestInfo sophonManifestInfo = manifestPair.ManifestInfo;
+#else
+                    string outputNewDir = args[5];
+
+                    SophonChunkManifestInfoPair manifestPairFrom = await SophonManifest.CreateSophonChunkManifestInfoPair(httpClient, args[1], args[3], tokenSource.Token);
+
+                    SophonChunksInfo sophonChunksInfoFrom = manifestPairFrom.ChunksInfo;
+                    SophonManifestInfo sophonManifestInfoFrom = manifestPairFrom.ManifestInfo;
+
+                    SophonChunkManifestInfoPair manifestPairTo = await SophonManifest.CreateSophonChunkManifestInfoPair(httpClient, args[2], args[3], tokenSource.Token);
+
+                    SophonChunksInfo sophonChunksInfoTo = manifestPairTo.ChunksInfo;
+                    SophonManifestInfo sophonManifestInfoTo = manifestPairTo.ManifestInfo;
+#endif
 
                     long currentRead = 0;
                     Task.Run(() => AppExitKeyTrigger(tokenSource));
@@ -75,15 +115,39 @@ namespace Hi3Helper.Sophon.Test
 
                     try
                     {
+                        string chunkOutPath = Path.Combine(outputDir, "chunk_collapse");
+                        if (!Directory.Exists(chunkOutPath))
+                            Directory.CreateDirectory(chunkOutPath);
+
+                        if (!Directory.Exists(outputNewDir))
+                            Directory.CreateDirectory(outputNewDir);
+#if !DEMODIFF
                         string totalSizeUnit = SummarizeSizeSimple(sophonChunksInfo.TotalSize);
+                        string totalSizeDiffUnit = "0 B";
+#else
+                        long totalSizeDiff = await SophonUpdate.GetCalculatedDiffSizeAsync(httpClient, manifestPairFrom, manifestPairTo, false, tokenSource.Token);
+                        string totalSizeDiffUnit = SummarizeSizeSimple(totalSizeDiff);
+                        string totalSizeUnit = SummarizeSizeSimple(manifestPairTo.ChunksInfo.TotalSize);
+#endif
+
+                        foreach (string fileTemp in Directory.EnumerateFiles(outputDir, "*_tempUpdate", SearchOption.AllDirectories))
+                        {
+                            File.Delete(fileTemp);
+                        }
 
                         IsRetry = false;
 #if NET6_0_OR_GREATER
-                        await Parallel.ForEachAsync(SophonManifest.EnumerateAsync(
+                        await Parallel.ForEachAsync(
+#if !DEMODIFF
+                            SophonManifest.EnumerateAsync(
                             httpClient,
                             sophonManifestInfo,
                             sophonChunksInfo,
-                            tokenSource.Token),
+                            tokenSource.Token)
+#else
+                            SophonUpdate.EnumerateUpdateAsync(httpClient, manifestPairFrom, manifestPairTo)
+#endif
+                            ,
                             parallelOptions,
                             async (asset, token) =>
                             {
@@ -96,8 +160,7 @@ namespace Hi3Helper.Sophon.Test
                                 if (!string.IsNullOrEmpty(outputAssetDir) && !Directory.Exists(outputAssetDir))
                                     Directory.CreateDirectory(outputAssetDir);
 
-                                // using FileStream fileStream = new FileStream(outputAssetPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
-
+#if !DEMODIFF
                                 await asset.WriteToStreamAsync(
                                     httpClient,
                                     // fileStream,
@@ -108,20 +171,64 @@ namespace Hi3Helper.Sophon.Test
                                         Interlocked.Add(ref currentRead, read);
                                         string sizeUnit = SummarizeSizeSimple(currentRead);
                                         string speedUnit = SummarizeSizeSimple(currentRead / stopwatch.Elapsed.TotalSeconds);
-                                        Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} -> {currentRead} ({speedUnit}/s)    \r");
+                                        Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} ({totalSizeDiffUnit} diff) -> {currentRead} ({speedUnit}/s)    \r");
                                     },
                                     (asset) =>
                                     {
                                         Console.WriteLine($"Downloaded: {asset.AssetName}");
                                     }
                                     );
+#else
+                                if (isPreloadMode)
+                                {
+                                    await asset.DownloadDiffChunksAsync(
+                                        httpClient,
+                                        chunkOutPath,
+                                        parallelOptions,
+                                        (read) =>
+                                        {
+                                            Interlocked.Add(ref currentRead, read);
+                                            string sizeUnit = SummarizeSizeSimple(currentRead);
+                                            string speedUnit = SummarizeSizeSimple(currentRead / stopwatch.Elapsed.TotalSeconds);
+                                            Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} ({totalSizeDiffUnit} diff) -> {currentRead} ({speedUnit}/s)    \r");
+                                        }
+                                        );
+                                }
+                                else
+                                {
+                                    await asset.WriteUpdateAsync(
+                                        httpClient,
+                                        outputDir,
+                                        outputNewDir,
+                                        chunkOutPath,
+                                        parallelOptions,
+                                        (read) =>
+                                        {
+                                            Interlocked.Add(ref currentRead, read);
+                                            string sizeUnit = SummarizeSizeSimple(currentRead);
+                                            string speedUnit = SummarizeSizeSimple(currentRead / stopwatch.Elapsed.TotalSeconds);
+                                            Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} ({totalSizeDiffUnit} diff) -> {currentRead} ({speedUnit}/s)    \r");
+                                        },
+                                        (asset) =>
+                                        {
+                                            Console.WriteLine($"Downloaded: {asset.AssetName}");
+                                        }
+                                        );
+                                }
+#endif
                             });
 #else
-                        foreach (SophonAsset asset in await SophonManifest.GetAssetListAsync(
+                        await foreach (SophonAsset asset in
+#if !DEMODIFF
+                        await SophonManifest.GetAssetListAsync(
                             httpClient,
                             sophonManifestInfo,
                             sophonChunksInfo,
-                            tokenSource.Token))
+                            tokenSource.Token)
+#else
+                            SophonUpdate.EnumerateUpdateAsync(httpClient, manifestPairFrom, manifestPairTo).WithCancellation(tokenSource.Token)
+#endif
+                            )
                         {
                             if (asset.IsDirectory)
                                 continue;
@@ -134,6 +241,7 @@ namespace Hi3Helper.Sophon.Test
 
                             // using FileStream fileStream = new FileStream(outputAssetPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
 
+#if !DEMODIFF
                             await asset.WriteToStreamAsync(
                                 httpClient,
                                 // fileStream,
@@ -144,16 +252,54 @@ namespace Hi3Helper.Sophon.Test
                                     Interlocked.Add(ref currentRead, read);
                                     string sizeUnit = SummarizeSizeSimple(currentRead);
                                     string speedUnit = SummarizeSizeSimple(currentRead / stopwatch.Elapsed.TotalSeconds);
-                                    Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} -> {currentRead} ({speedUnit}/s)    \r");
+                                    Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} ({totalSizeDiffUnit} diff) -> {currentRead} ({speedUnit}/s)    \r");
                                 },
                                 (assetDone) =>
                                 {
-                                    Console.WriteLine($"Downloaded: {assetDone.AssetName}");
+                                    Console.WriteLine($"Downloaded: {asset.AssetName}");
                                 }
                                 );
+#else
+                            if (isPreloadMode)
+                            {
+                                await asset.DownloadDiffChunksAsync(
+                                    httpClient,
+                                    chunkOutPath,
+                                    parallelOptions,
+                                    (read) =>
+                                    {
+                                        Interlocked.Add(ref currentRead, read);
+                                        string sizeUnit = SummarizeSizeSimple(currentRead);
+                                        string speedUnit = SummarizeSizeSimple(currentRead / stopwatch.Elapsed.TotalSeconds);
+                                        Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} ({totalSizeDiffUnit} diff) -> {currentRead} ({speedUnit}/s)    \r");
+                                    }
+                                    );
+                            }
+                            else
+                            {
+                                await asset.WriteUpdateAsync(
+                                    httpClient,
+                                    outputDir,
+                                    outputNewDir,
+                                    chunkOutPath,
+                                    parallelOptions,
+                                    (read) =>
+                                    {
+                                        Interlocked.Add(ref currentRead, read);
+                                        string sizeUnit = SummarizeSizeSimple(currentRead);
+                                        string speedUnit = SummarizeSizeSimple(currentRead / stopwatch.Elapsed.TotalSeconds);
+                                        Console.Write($"{CancelMessage} | {sizeUnit}/{totalSizeUnit} ({totalSizeDiffUnit} diff) -> {currentRead} ({speedUnit}/s)    \r");
+                                    },
+                                    (asset) =>
+                                    {
+                                        Console.WriteLine($"Downloaded: {asset.AssetName}");
+                                    }
+                                    );
+                            }
+#endif
                         }
 #endif
-                    }
+                        }
                     catch (OperationCanceledException)
                     {
                         Console.WriteLine("Download has been cancelled!");

--- a/Hi3Helper.Sophon.Test/Properties/launchSettings.json
+++ b/Hi3Helper.Sophon.Test/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    },
+    "Hi3Helper.Sophon.Test - Download": {
+      "commandName": "Project",
+      "commandLineArgs": "\"https://sg-public-api.hoyoverse.com/downloader/sophon_chunk/api/getBuild?branch=main&package_id=ScSYQBFhu9&password=bDL4JUHL625x&plat_app=ddxf6vlr1reo\" \"game\" \"C:\\myGit\\testSophos\" 1"
+    },
+    "Hi3Helper.Sophon.Test - Preload Chunks": {
+      "commandName": "Project",
+      "commandLineArgs": "Preload \"https://sg-public-api.hoyoverse.com/downloader/sophon_chunk/api/getBuild?branch=main&package_id=ScSYQBFhu9&password=bDL4JUHL625x&plat_app=ddxf6vlr1reo&tag=4.6.0\" \"https://sg-public-api.hoyoverse.com/downloader/sophon_chunk/api/getBuild?branch=main&package_id=ScSYQBFhu9&password=bDL4JUHL625x&plat_app=ddxf6vlr1reo\" \"game\" \"C:\\myGit\\testSophos\" \"C:\\myGit\\newTestSophos\""
+    },
+    "Hi3Helper.Sophon.Test - Update": {
+      "commandName": "Project",
+      "commandLineArgs": "Update \"https://sg-public-api.hoyoverse.com/downloader/sophon_chunk/api/getBuild?branch=main&package_id=ScSYQBFhu9&password=bDL4JUHL625x&plat_app=ddxf6vlr1reo&tag=4.6.0\" \"https://sg-public-api.hoyoverse.com/downloader/sophon_chunk/api/getBuild?branch=main&package_id=ScSYQBFhu9&password=bDL4JUHL625x&plat_app=ddxf6vlr1reo\" \"game\" \"C:\\myGit\\testSophos\" \"C:\\myGit\\newTestSophos\""
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img width="512px" height="auto" src="https://raw.githubusercontent.com/CollapseLauncher/Collapse/main/Docs/Imgs/CollapseLauncherIdolType.png"/><br/>
   <i>I know, it's not a good one. But at least we made it lol</i>
   <i>~ neon-nyan</i>
-  <img src="https://raw.githubusercontent.com/neon-nyan/CollapseLauncher-Page/main/images/NewBannerv2_color.webp"/>
+  <img src="https://raw.githubusercontent.com/CollapseLauncher/.github/main/profile/NewBannerv2_Banner_color_20240615.webp"/>
 </p>
 
 ##### GI Nahida Background Credit: [Rafa on Pixiv](https://www.pixiv.net/en/users/3970196)


### PR DESCRIPTION
## PR Status : 
- Overall Status : DONE
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No

### Changelog
-  **[Fix]**: Skip pustaka file if not present, by @neon-nyan 
- **[Imp]**: Add new GI 4.7 field, by @bagusnl 
- **[Fix]**: Used file being called twice, for Hi3, by @neon-nyan 
- **[Fix]**: Stop Windows from opening files sometimes for no reason, by @neon-nyan 
   - "File is being used by another process" should be resolved, by @neon-nyan 
- **[Fix]**: Windows 10 client size should be normal now, by @shatyuka 
- **[Fix]**: Remove 1px border offset on Windows 10, by @shatyuka 
- **[Fix]**: Add missing attribute, `SetLastError` to interop calls, by @shatyuka 
- **[New]**: Move `Hi3Helper.Sophon.Test` to its own solution, by @neon-nyan 
- **[Fix]**: Sometimes the console would just crash when in legacy, by @shatyuka 
- **[New]** Add Sophon-based download and preload capabilities for games that support it, by @neon-nyan 

