### PR TITLE
Preview 1.80.15 Release

### DIFF
--- a/CollapseLauncher/Classes/CachesManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/Check.cs
@@ -46,7 +46,7 @@ namespace CollapseLauncher
                 }, async (asset, localToken) =>
                 {
                     await CheckAsset(asset, returnAsset, localToken);
-                }).ConfigureAwait(false);
+                });
             }
             catch (AggregateException ex)
             {

--- a/CollapseLauncher/Classes/CachesManagement/StarRail/Check.cs
+++ b/CollapseLauncher/Classes/CachesManagement/StarRail/Check.cs
@@ -60,7 +60,7 @@ namespace CollapseLauncher
                             await CheckAsset(asset, returnAsset, baseIFixPathPersistent, baseIFixPathStreaming, threadToken);
                             break;
                     }
-                }).ConfigureAwait(false);
+                });
             }
             catch (AggregateException ex)
             {

--- a/CollapseLauncher/Classes/DiscordPresence/DiscordPresenceManager.cs
+++ b/CollapseLauncher/Classes/DiscordPresence/DiscordPresenceManager.cs
@@ -185,14 +185,6 @@
             {
                 if (GetAppConfigValue("EnableDiscordRPC").ToBool())
                 {
-                    // Only change activity for Idle or Play status the second time we call SetActivity
-                    if ((activity == ActivityType.Idle || activity == ActivityType.Play) &&
-                        _lastAttemptedActivityType != activity)
-                    {
-                        _lastAttemptedActivityType = activity;
-                        return;
-                    }
-
                     _lastAttemptedActivityType = activity;
                     _activityType              = activity;
 

--- a/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
+++ b/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
@@ -394,6 +394,7 @@ namespace CollapseLauncher
     #region ChangeTitleDragArea
     public enum DragAreaTemplate
     {
+        None,
         Full,
         Default
     }

--- a/CollapseLauncher/Classes/FileDialogCOM/FileDialogNative.cs
+++ b/CollapseLauncher/Classes/FileDialogCOM/FileDialogNative.cs
@@ -25,19 +25,19 @@ namespace CollapseLauncher.FileDialogCOM
         public static void InitHandlerPointer(IntPtr handle) => parentHandler = handle;
 
         public static async ValueTask<string> GetFilePicker(Dictionary<string, string> FileTypeFilter = null, string title = null) =>
-            (string)await GetPickerOpenTask<string>(string.Empty, FileTypeFilter, title).ConfigureAwait(false);
+            (string)await GetPickerOpenTask<string>(string.Empty, FileTypeFilter, title);
 
         public static async ValueTask<string[]> GetMultiFilePicker(Dictionary<string, string> FileTypeFilter = null, string title = null) =>
-            (string[])await GetPickerOpenTask<string[]>(Array.Empty<string>(), FileTypeFilter, title, true).ConfigureAwait(false);
+            (string[])await GetPickerOpenTask<string[]>(Array.Empty<string>(), FileTypeFilter, title, true);
 
         public static async ValueTask<string> GetFolderPicker(string title = null) =>
-            (string)await GetPickerOpenTask<string>(string.Empty, null, title, false, true).ConfigureAwait(false);
+            (string)await GetPickerOpenTask<string>(string.Empty, null, title, false, true);
 
         public static async ValueTask<string[]> GetMultiFolderPicker(string title = null) =>
-            (string[])await GetPickerOpenTask<string[]>(Array.Empty<string>(), null, title, true, true).ConfigureAwait(false);
+            (string[])await GetPickerOpenTask<string[]>(Array.Empty<string>(), null, title, true, true);
 
         public static async ValueTask<string> GetFileSavePicker(Dictionary<string, string> FileTypeFilter = null, string title = null) =>
-            await GetPickerSaveTask<string>(string.Empty, FileTypeFilter, title).ConfigureAwait(false);
+            await GetPickerSaveTask<string>(string.Empty, FileTypeFilter, title);
 
         private static ValueTask<object> GetPickerOpenTask<T>(object defaultValue, Dictionary<string, string> FileTypeFilter = null,
             string title = null, bool isMultiple = false, bool isFolder = false)

--- a/CollapseLauncher/Classes/FileMigrationProcess/FileMigrationProcess.cs
+++ b/CollapseLauncher/Classes/FileMigrationProcess/FileMigrationProcess.cs
@@ -157,7 +157,7 @@ namespace CollapseLauncher
                         FileInfo outputFileInfo = new FileInfo(outputTargetPath);
                         await MoveWriteFile(uiRef, inputFileInfo, outputFileInfo, cancellationToken);
                     }
-                }).ConfigureAwait(false);
+                });
 
             inputPathInfo.Delete(true);
             return outputDirPath;

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/SettingsBase.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/SettingsBase.cs
@@ -20,7 +20,7 @@ namespace CollapseLauncher.GameSettings.Base
 
         internal static string? RegistryPath
         {
-            get => _registryPath ??= string.IsNullOrEmpty(_gameVersionManager?.GamePreset?.InternalGameNameInConfig) ?
+            get => _registryPath = string.IsNullOrEmpty(_gameVersionManager?.GamePreset?.InternalGameNameInConfig) ?
                 null :
                 Path.Combine($"Software\\{_gameVersionManager.VendorTypeProp.VendorType}", _gameVersionManager.GamePreset.InternalGameNameInConfig);
         }
@@ -28,11 +28,9 @@ namespace CollapseLauncher.GameSettings.Base
         internal static RegistryKey? RegistryRoot
         {
             get
-            {
+             {
                 // If the registry path is null, then return null
                 if (RegistryPath == null) return null;
-
-                if (_registryRoot != null) return _registryRoot;
 
                 // Try to open the registry path
                 _registryRoot = Registry.CurrentUser.OpenSubKey(RegistryPath, true);

--- a/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
+++ b/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
@@ -61,7 +61,7 @@ namespace CollapseLauncher.Helper.Background
         private   delegate ValueTask          AssignDefaultAction<in T>(T element) where T : class;
         internal  delegate void               ThrowExceptionAction(Exception element);
         internal  static   ActionBlock<Task>? SharedActionBlockQueue = new ActionBlock<Task>(async (action) => {
-            await action.ConfigureAwait(false);
+            await action;
         },
         new ExecutionDataflowBlockOptions
         {

--- a/CollapseLauncher/Classes/Helper/Background/ColorPaletteUtility.cs
+++ b/CollapseLauncher/Classes/Helper/Background/ColorPaletteUtility.cs
@@ -216,7 +216,7 @@ namespace CollapseLauncher.Helper.Background
                                                                  ColorThief.GetColor(bitmapInput.Buffer,
                                                                      bitmapInput.Channel, bitmapInput.Width,
                                                                      bitmapInput.Height, 1))
-                                                        .ConfigureAwait(false);
+                                                        ;
 
                 WColor wColor        = DrawingColorToColor(averageColor);
                 WColor adjustedColor = wColor.SetSaturation(1.5);

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
@@ -31,7 +31,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                     await FallbackCDNUtil.DownloadAsJSONType<HoYoPlayLauncherResources>(PresetConfig?.LauncherResourceURL, InternalAppJSONContext.Default, innerToken);
 
             HoYoPlayLauncherResources? hypResourceResponse = await hypResourceResponseCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token);
 
             HoYoPlayLauncherResources? hypPluginResource = null;
             HoYoPlayLauncherResources? hypSdkResource = null;
@@ -42,7 +42,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                         await FallbackCDNUtil.DownloadAsJSONType<HoYoPlayLauncherResources>(PresetConfig?.LauncherPluginURL, InternalAppJSONContext.Default, innerToken);
 
                 hypPluginResource = await hypPluginResourceCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                  ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                  ExecutionTimeoutAttempt, onTimeoutRoutine, token);
             }
 
             if (!string.IsNullOrEmpty(PresetConfig?.LauncherGameChannelSDKURL))
@@ -52,7 +52,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                         await FallbackCDNUtil.DownloadAsJSONType<HoYoPlayLauncherResources>(PresetConfig?.LauncherGameChannelSDKURL, InternalAppJSONContext.Default, innerToken);
 
                 hypSdkResource = await hypSdkResourceCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                               ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                               ExecutionTimeoutAttempt, onTimeoutRoutine, token);
             }
 
             RegionResourceLatest sophonResourceCurrentPackage = new RegionResourceLatest();
@@ -326,9 +326,9 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                     await FallbackCDNUtil.DownloadAsJSONType<HoYoPlayLauncherNews>(launcherNewsUrl, InternalAppJSONContext.Default, innerToken);
 
             HoYoPlayLauncherNews? hypLauncherBackground = await hypLauncherBackgroundCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token);
             HoYoPlayLauncherNews? hypLauncherNews = await hypLauncherNewsCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token);
 
             // Merge background image
             if (hypLauncherBackground?.Data?.GameInfoList != null && hypLauncherNews?.Data != null)
@@ -465,7 +465,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                     await FallbackCDNUtil.DownloadAsJSONType<HoYoPlayLauncherGameInfo>(launcherGameInfoUrl, InternalAppJSONContext.Default, innerToken);
 
             HoYoPlayLauncherGameInfo? hypLauncherGameInfo = await hypLauncherGameInfoCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token);
 
             HoYoPlayGameInfoField? sophonLauncherGameInfoRoot = new HoYoPlayGameInfoField();
             if (hypLauncherGameInfo != null)

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -92,7 +92,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
                     await FallbackCDNUtil.DownloadAsJSONType<RegionResourceProp>(PresetConfig?.LauncherResourceURL, InternalAppJSONContext.Default, innerToken);
 
             LauncherGameResource = await launcherGameResourceCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token);
 
             if (LauncherGameResource == null)
             {
@@ -106,7 +106,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
                         await FallbackCDNUtil.DownloadAsJSONType<RegionResourceProp>(string.Format(PresetConfig?.LauncherPluginURL!, GetDeviceId(PresetConfig!)), InternalAppJSONContext.Default, innerToken);
 
                 RegionResourceProp? pluginProp = await launcherPluginPropCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                               ExecutionTimeoutAttempt, onTimeoutRoutine, token).ConfigureAwait(false);
+                                                               ExecutionTimeoutAttempt, onTimeoutRoutine, token);
 
                 if (pluginProp != null && LauncherGameResource.data != null)
                 {

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -2782,6 +2782,8 @@ namespace CollapseLauncher.InstallManager.Base
                     case ContentDialogResult.Secondary:
                         ResetDownload(packageList);
                         break;
+                    case ContentDialogResult.None:
+                        throw new OperationCanceledException("Cancelling progress");
                 }
             }
         }

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1105,12 +1105,17 @@ namespace CollapseLauncher.InstallManager.Base
                 // Assign extractor
                 string packageExtension = Path.GetExtension(asset!.PathOutput).ToLower();
 #if USENEWZIPDECOMPRESS
-                InstallPackageExtractorDelegate installTaskDelegate = packageExtension switch
+                InstallPackageExtractorDelegate installTaskDelegate;
+                if ((asset!.PathOutput.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
+                  || asset!.PathOutput.EndsWith(".zip.001", StringComparison.OrdinalIgnoreCase))
+                  && !_isAllowExtractCorruptZip)
                 {
-                    ".zip" => _isAllowExtractCorruptZip ? ExtractUsing7zip : ExtractUsingNativeZip,
-                    ".zip.001" => _isAllowExtractCorruptZip ? ExtractUsing7zip : ExtractUsingNativeZip,
-                    _ => ExtractUsing7zip
-                };
+                    installTaskDelegate = ExtractUsingNativeZip;
+                }
+                else
+                {
+                    installTaskDelegate = ExtractUsing7zip;
+                }
 #else
                 InstallPackageExtractorDelegate installTaskDelegate = ExtractUsing7zip;
 #endif

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -2905,7 +2905,7 @@ namespace CollapseLauncher.InstallManager.Base
             {
                 string errStr = $"Free Space on {driveInfo.Name} is not sufficient! " +
                                 $"(Free space: {ConverterTool.SummarizeSizeSimple(diskFreeSpace)}, Req. Space: {ConverterTool.SummarizeSizeSimple(remainedDownloadUncompressed)} (Total: {ConverterTool.SummarizeSizeSimple(requiredSpaceUncompressed)}), " +
-                                $"Existing Package Size: {existingPackageSizeGb}, Drive: {driveInfo.Name})";
+                                $"Existing Package Size (Compressed): {currentDownloadedCompressed} (Uncompressed): {currentDownloadedUncompressed}, Drive: {driveInfo.Name})";
                 LogWriteLine(errStr, LogType.Error, true);
                 await Dialog_InsufficientDriveSpace(Content, diskFreeSpace, remainedDownloadUncompressed, driveInfo.Name);
                 throw new TaskCanceledException(errStr);

--- a/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
@@ -16,7 +16,7 @@ namespace CollapseLauncher.InstallManager.Zenless
         #region Override Methods - UninstallGame
         protected override UninstallGameProperty AssignUninstallFolders() => new UninstallGameProperty()
         {
-            gameDataFolderName = "ZZZ_Data",
+            gameDataFolderName = "ZenlessZoneZero_Data",
             foldersToDelete = new string[] { "APMCrashReporter" },
             filesToDelete = new string[] { "mhypbase.dll", "HoYoKProtect.sys", "GameAssembly.dll", "pkg_version", "config.ini", "^ZZZ.*", "^Unity.*" },
             foldersToKeepInData = new string[] { "ScreenShots" }

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -855,7 +855,7 @@ namespace CollapseLauncher.Interfaces
                 using (FileStream patchfs = new FileStream(patchOutputFile, FileMode.Open, FileAccess.Read, FileShare.None, _bufferBigLength))
                 {
                     // Verify the patch file and if it doesn't match, then redownload it
-                    byte[] patchCRC = await CheckHashAsync(patchfs, MD5.Create(), token, false).ConfigureAwait(false);
+                    byte[] patchCRC = await CheckHashAsync(patchfs, MD5.Create(), token, false);
                     if (!IsArrayMatch(patchCRC, patchHash.Span))
                     {
                         // Revert back the total size
@@ -878,7 +878,7 @@ namespace CollapseLauncher.Interfaces
                 // Subscribe patching progress and start applying patch
                 patchUtil.ProgressChanged += RepairTypeActionPatching_ProgressChanged;
                 patchUtil.Initialize(inputFile, patchOutputFile, outputFile);
-                await Task.Run(() => patchUtil.Apply(token)).ConfigureAwait(false);
+                await Task.Run(() => patchUtil.Apply(token));
 
                 // Delete old block
                 File.Delete(inputFile);

--- a/CollapseLauncher/Classes/RegionManagement/BridgedNetworkStream.cs
+++ b/CollapseLauncher/Classes/RegionManagement/BridgedNetworkStream.cs
@@ -49,7 +49,7 @@ namespace CollapseLauncher
             int totalRead = 0;
             while (totalRead < buffer.Length)
             {
-                int read = await ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
+                int read = await ReadAsync(buffer.Slice(totalRead), cancellationToken);
                 if (read == 0) return;
 
                 totalRead += read;

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Check.cs
@@ -46,7 +46,7 @@ namespace CollapseLauncher
                 // and iterate assetIndex and check it using different method for each type and run it in parallel
                 await Parallel.ForEachAsync(assetIndex, new ParallelOptions { MaxDegreeOfParallelism = _threadCount, CancellationToken = token }, async (asset, threadToken) =>
                 {
-                    await CheckAssetAllType(asset, brokenAssetIndex, threadToken).ConfigureAwait(false);
+                    await CheckAssetAllType(asset, brokenAssetIndex, threadToken);
                 });
             }
             catch (AggregateException ex)

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
@@ -188,7 +188,7 @@ namespace CollapseLauncher
             try
             {
                 // Get the Dispatcher Query
-                QueryProperty queryProperty = await GetDispatcherQuery(_httpClient, token).ConfigureAwait(false);
+                QueryProperty queryProperty = await GetDispatcherQuery(_httpClient, token);
 
                 // Initialize persistent folder path and check for the folder existence
                 string basePersistentPath = $"{_execPrefix}_Data\\Persistent";

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Repair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Repair.cs
@@ -44,7 +44,7 @@ namespace CollapseLauncher
 #endif
                     )
                 {
-                    await RepairAssetTypeGeneric(asset, _httpClient, token).ConfigureAwait(false);
+                    await RepairAssetTypeGeneric(asset, _httpClient, token);
                 }
 
                 return true;

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Repair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Repair.cs
@@ -47,13 +47,13 @@ namespace CollapseLauncher
                     )
                 {
                     // Assign a task depends on the asset type
-                    ConfiguredTaskAwaitable assetTask = (asset.FT switch
+                    Task assetTask = (asset.FT switch
                     {
                         FileType.Blocks => RepairAssetTypeBlocks(asset, _httpClient, token),
                         FileType.Audio => RepairOrPatchTypeAudio(asset, _httpClient, token),
                         FileType.Video => RepairAssetTypeVideo(asset, _httpClient, token),
                         _ => RepairAssetTypeGeneric(asset, _httpClient, token)
-                    }).ConfigureAwait(false);
+                    });
 
                     // Await the task
                     await assetTask;

--- a/CollapseLauncher/Classes/RepairManagement/StarRail/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/StarRail/Check.cs
@@ -99,7 +99,7 @@ namespace CollapseLauncher
                             await CheckAssetType(asset, brokenAssetIndex, threadToken);
                             break;
                     }
-                }).ConfigureAwait(false);
+                });
             }
             catch (AggregateException ex)
             {

--- a/CollapseLauncher/Classes/RepairManagement/StarRail/Repair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/StarRail/Repair.cs
@@ -46,13 +46,13 @@ namespace CollapseLauncher
                     )
                 {
                     // Assign a task depends on the asset type
-                    ConfiguredTaskAwaitable assetTask = (asset.FT switch
+                    Task assetTask = (asset.FT switch
                     {
                         FileType.Blocks => RepairAssetTypeGeneric(asset, _httpClient, token),
                         FileType.Audio => RepairAssetTypeGeneric(asset, _httpClient, token),
                         FileType.Video => RepairAssetTypeGeneric(asset, _httpClient, token),
                         _ => RepairAssetTypeGeneric(asset, _httpClient, token)
-                    }).ConfigureAwait(false);
+                    });
 
                     // Await the task
                     await assetTask;

--- a/CollapseLauncher/Classes/RepairManagement/StarRail/StarRailRepair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/StarRail/StarRailRepair.cs
@@ -64,7 +64,7 @@ namespace CollapseLauncher
         public async Task<bool> StartCheckRoutine(bool useFastCheck)
         {
             _useFastMethod = useFastCheck;
-            return await TryRunExamineThrow(CheckRoutine()).ConfigureAwait(false);
+            return await TryRunExamineThrow(CheckRoutine());
         }
 
         public async Task StartRepairRoutine(bool showInteractivePrompt = false, Action actionIfInteractiveCancel = null)
@@ -76,7 +76,7 @@ namespace CollapseLauncher
                 await SpawnRepairDialog(_assetIndex, actionIfInteractiveCancel);
             }
 
-            _ = await TryRunExamineThrow(RepairRoutine()).ConfigureAwait(false);
+            _ = await TryRunExamineThrow(RepairRoutine());
         }
 
         private async Task<bool> CheckRoutine()

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -15,7 +15,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.80.14</Version>
+        <Version>1.80.15</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
@@ -129,7 +129,9 @@
                                       ItemsSource="{x:Bind p:LauncherMetadataHelper.LauncherGameNameCollection, Mode=OneWay}"
                                       PlaceholderText="{x:Bind helper:Locale.Lang._GameClientTitles['Honkai Impact 3rd']}"
                                       SelectionChanged="SetGameCategoryChange"
-                                      Style="{ThemeResource AcrylicComboBoxStyle}" />
+                                      Style="{ThemeResource AcrylicComboBoxStyle}"
+                                      DropDownOpened="GameComboBox_OnDropDownOpened"
+                                      DropDownClosed="GameComboBox_OnDropDownClosed" />
                             <ComboBox x:Name="ComboBoxGameRegion"
                                       Grid.Column="1"
                                       MinWidth="148"
@@ -137,7 +139,9 @@
                                       CornerRadius="0,15,15,0"
                                       PlaceholderText="{x:Bind helper:Locale.Lang._GameClientRegions['Southeast Asia']}"
                                       SelectionChanged="EnableRegionChangeButton"
-                                      Style="{ThemeResource AcrylicComboBoxStyle}" />
+                                      Style="{ThemeResource AcrylicComboBoxStyle}"
+                                      DropDownOpened="GameComboBox_OnDropDownOpened"
+                                      DropDownClosed="GameComboBox_OnDropDownClosed" />
                         </Grid>
                         <Grid x:Name="ChangeGameBtnGridShadow"
                               Grid.Column="1"

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -330,9 +330,9 @@ namespace CollapseLauncher
 
         private void MainPageGrid_SizeChanged(object sender, SizeChangedEventArgs e) => ChangeTitleDragArea.Change(DragAreaTemplate.Default);
 
-        private async void ChangeTitleDragAreaInvoker_TitleBarEvent(object sender, ChangeTitleDragAreaProperty e)
+        private void ChangeTitleDragAreaInvoker_TitleBarEvent(object sender, ChangeTitleDragAreaProperty e)
         {
-            await Task.Delay(250);
+            UpdateLayout();
 
             InputNonClientPointerSource nonClientInputSrc = InputNonClientPointerSource.GetForWindowId(WindowUtility.CurrentWindowId.Value);
             WindowUtility.EnableWindowNonClientArea();
@@ -340,6 +340,12 @@ namespace CollapseLauncher
 
             switch (e.Template)
             {
+                case DragAreaTemplate.None:
+                    nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, new RectInt32[]
+                    {
+                        GetElementPos((WindowUtility.CurrentWindow as MainWindow)?.AppTitleBar)
+                    });
+                    break;
                 case DragAreaTemplate.Full:
                     nonClientInputSrc.ClearRegionRects(NonClientRegionKind.Passthrough);
                     break;
@@ -1053,6 +1059,16 @@ namespace CollapseLauncher
 
             if (!IsShowRegionChangeWarning && IsInstantRegionChange && !DisableInstantRegionChange && !IsFirstStartup)
                 ChangeRegionInstant();
+        }
+
+        private void GameComboBox_OnDropDownOpened(object sender, object e)
+        {
+            ChangeTitleDragArea.Change(DragAreaTemplate.None);
+        }
+
+        private void GameComboBox_OnDropDownClosed(object sender, object e)
+        {
+            ChangeTitleDragArea.Change(DragAreaTemplate.Default);
         }
         #endregion
 

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
@@ -161,7 +161,7 @@
                         x:FieldModifier="internal" />
         <Grid x:Name="TitleBarFrameGrid"
               Grid.Row="0">
-            <Grid x:Name="AppTitleBar">
+            <Grid x:Name="AppTitleBar" x:FieldModifier="internal">
                 <Button x:Name="MinimizeButton"
                         Width="40"
                         Height="40"

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -218,9 +218,6 @@ namespace CollapseLauncher
         private void MainFrameChangerInvoker_WindowFrameEvent(object sender, MainFrameProperties e)
         {
             rootFrame.Navigate(e.FrameTo, null, e.Transition);
-
-            // Recalculate non-client area size
-            WindowUtility.EnableWindowNonClientArea();
         }
 
         private void MainFrameChangerInvoker_WindowFrameGoBackEvent(object sender, EventArgs e)

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -218,6 +218,9 @@ namespace CollapseLauncher
         private void MainFrameChangerInvoker_WindowFrameEvent(object sender, MainFrameProperties e)
         {
             rootFrame.Navigate(e.FrameTo, null, e.Transition);
+
+            // Recalculate non-client area size
+            WindowUtility.EnableWindowNonClientArea();
         }
 
         private void MainFrameChangerInvoker_WindowFrameGoBackEvent(object sender, EventArgs e)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -757,7 +757,7 @@ namespace CollapseLauncher.Dialogs
                                       SummarizeSizeSimple(partialLength),
                                       SummarizeSizeSimple(contentLength)),
                         Content,
-                        null,
+                        Lang._Misc.Cancel,
                         Lang._Misc.YesResume,
                         Lang._Misc.NoStartFromBeginning,
                         ContentDialogButton.Primary,

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
@@ -1387,7 +1387,8 @@
                                         HorizontalAlignment="Stretch"
                                         HorizontalContentAlignment="Left"
                                         Click="StopGameButton_Click"
-                                        CornerRadius="14">
+                                        CornerRadius="14"
+                                        IsEnabled="False">
                                     <Button.Content>
                                         <Grid Margin="4,0">
                                             <Grid.ColumnDefinitions>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -946,6 +946,10 @@ namespace CollapseLauncher.Pages
 
                 PlaytimeIdleStack.Visibility = Visibility.Visible;
                 PlaytimeRunningStack.Visibility = Visibility.Collapsed;
+                
+            #if !DISABLEDISCORD
+                AppDiscordPresence?.SetActivity(ActivityType.Idle);
+            #endif
             }
             catch (TaskCanceledException)
             {

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -575,7 +575,7 @@
                     <Hyperlink NavigateUri="https://github.com/CollapseLauncher/Collapse/blob/main/LICENSE"
                                UnderlineStyle="None">
                         <Run FontWeight="Bold"
-                             Text="MIT License" />
+                             Text="{x:Bind helper:Locale.Lang._SettingsPage.LicenseType}" />
                     </Hyperlink>
                     <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.About_Copyright4}" />
                 </TextBlock>

--- a/Hi3Helper.Core/Classes/Data/Tools/GenshinDispatchHelper/GenshinDispatchHelper.cs
+++ b/Hi3Helper.Core/Classes/Data/Tools/GenshinDispatchHelper/GenshinDispatchHelper.cs
@@ -48,7 +48,7 @@ namespace Hi3Helper.Data
                 Console.WriteLine(dFormat);
                 Logger.WriteLog(dFormat, LogType.Default);
 #endif
-                await this._httpClient!.Download(DispatchBaseURL, s, null, null, cancelToken).ConfigureAwait(false);
+                await this._httpClient!.Download(DispatchBaseURL, s, null, null, cancelToken);
                 s.Position = 0;
                 DispatcherDataInfo = (YSDispatchInfo)JsonSerializer.Deserialize(s, typeof(YSDispatchInfo), CoreLibraryJSONContext.Default);
             }
@@ -83,7 +83,7 @@ namespace Hi3Helper.Data
 
             ParseGameResPkgProp(ref returnValProp);
             ParseDesignDataURL(ref returnValProp);
-            await ParseAudioAssetsURL(returnValProp).ConfigureAwait(false);
+            await ParseAudioAssetsURL(returnValProp);
         }
 
         private void ParseDesignDataURL(ref QueryProperty ValProp)
@@ -136,7 +136,7 @@ namespace Hi3Helper.Data
         {
             using (MemoryStream response = new MemoryStream())
             {
-                await this._httpClient!.Download(ConverterTool.CombineURLFromString(ValProp!.ClientGameResURL, "/StandaloneWindows64/base_revision"), response, null, null, cancelToken).ConfigureAwait(false);
+                await this._httpClient!.Download(ConverterTool.CombineURLFromString(ValProp!.ClientGameResURL, "/StandaloneWindows64/base_revision"), response, null, null, cancelToken);
                 string[] responseData = Encoding.UTF8.GetString(response.ToArray()).Split(' ');
 
                 ValProp.ClientAudioAssetsURL = string.Format("{0}/output_{1}_{2}/client",

--- a/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
@@ -78,7 +78,7 @@
                 public string About_Copyright2                      { get; set; } = LangFallback?._SettingsPage.About_Copyright2;
                 public string About_Copyright3                      { get; set; } = LangFallback?._SettingsPage.About_Copyright3;
                 public string About_Copyright4                      { get; set; } = LangFallback?._SettingsPage.About_Copyright4;
-                public string MITLicense                            { get; set; } = LangFallback?._SettingsPage.MITLicense;
+                public string LicenseType                           { get; set; } = LangFallback?._SettingsPage.LicenseType;
                 public string Disclaimer                            { get; set; } = LangFallback?._SettingsPage.Disclaimer;
                 public string Disclaimer1                           { get; set; } = LangFallback?._SettingsPage.Disclaimer1;
                 public string Disclaimer2                           { get; set; } = LangFallback?._SettingsPage.Disclaimer2;

--- a/Hi3Helper.Core/Lang/es_419.json
+++ b/Hi3Helper.Core/Lang/es_419.json
@@ -133,6 +133,9 @@
     "PauseCancelBtn": "Pausar/Cancelar",
     "DownloadBtn": "Descargar el Juego",
 
+    "GameStatusPlaceholderComingSoonBtn": "Próximamente",
+    "GameStatusPlaceholderPreRegisterBtn": "¡Pre-regístrate ahora!",
+
     "GameSettingsBtn": "Ajustes Rápidos",
     "GameSettings_Panel1": "Configuración Rápida",
     "GameSettings_Panel1OpenGameFolder": "Abrir Carpeta del Juego",
@@ -607,6 +610,8 @@
     "DiscordRP_Default": "Sin actividad",
     "DiscordRP_Ad": "- Con Collapse Launcher",
     "DiscordRP_Region": "Región:",
+
+    "DownloadModeLabelSophon": "Modo Sophon",
 
     "Taskbar_PopupHelp1": "Haz clic para llevar Collapse al primer plano.",
     "Taskbar_PopupHelp2": "Hacer doble clic para alternar la visibilidad de las ventanas",

--- a/Hi3Helper.Core/Lang/ja_JP.json
+++ b/Hi3Helper.Core/Lang/ja_JP.json
@@ -133,6 +133,9 @@
     "PauseCancelBtn": "一時停止/キャンセル",
     "DownloadBtn": "ダウンロード",
 
+    "GameStatusPlaceholderComingSoonBtn": "乞うご期待",
+    "GameStatusPlaceholderPreRegisterBtn": "今すぐ事前登録！",
+
     "GameSettingsBtn": "クイック設定",
     "GameSettings_Panel1": "クイック設定",
     "GameSettings_Panel1OpenGameFolder": "ゲームフォルダーを開く",
@@ -607,6 +610,8 @@
     "DiscordRP_Default": "放置",
     "DiscordRP_Ad": "- Collapse Launcherから起動",
     "DiscordRP_Region": "サーバー:",
+
+    "DownloadModeLabelSophon": "Sophonモード",
 
     "Taskbar_PopupHelp1": "クリックでCollapseを最前面で開く",
     "Taskbar_PopupHelp2": "ダブルクリックでウィンドウの表示/非表示を切り替え",

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -133,6 +133,9 @@
     "PauseCancelBtn": "暂停/取消",
     "DownloadBtn": "下载游戏",
 
+    "GameStatusPlaceholderComingSoonBtn": "即将推出",
+    "GameStatusPlaceholderPreRegisterBtn": "立即预注册！",
+
     "GameSettingsBtn": "快速设置",
     "GameSettings_Panel1": "快速设置",
     "GameSettings_Panel1OpenGameFolder": "打开游戏文件夹",
@@ -607,6 +610,8 @@
     "DiscordRP_Default": "没有活动",
     "DiscordRP_Ad": "- 使用 Collapse 启动器",
     "DiscordRP_Region": "区服：",
+
+    "DownloadModeLabelSophon": "Sophon 模式",
 
     "Taskbar_PopupHelp1": "单击将 Collapse 置顶",
     "Taskbar_PopupHelp2": "双击切换窗口可见性",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [![Build-Canary](https://github.com/neon-nyan/Collapse/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/neon-nyan/Collapse/actions/workflows/build.yml)
 [![Qodana](https://github.com/CollapseLauncher/Collapse/actions/workflows/qodana-scan.yml/badge.svg)](https://github.com/CollapseLauncher/Collapse/actions/workflows/qodana-scan.yml)
-[![Sync to Bitbucket](https://github.com/neon-nyan/CollapseLauncher-ReleaseRepo/actions/workflows/sync-to-bitbucket.yml/badge.svg)](https://github.com/neon-nyan/CollapseLauncher-ReleaseRepo/actions/workflows/sync-to-bitbucket.yml)
+[![Sync to GitLab](https://github.com/CollapseLauncher/CollapseLauncher-ReleaseRepo/actions/workflows/sync-to-gitlab.yml/badge.svg)](https://github.com/CollapseLauncher/CollapseLauncher-ReleaseRepo/actions/workflows/sync-to-gitlab.yml)
 [![Upload to R2](https://github.com/neon-nyan/CollapseLauncher-ReleaseRepo/actions/workflows/upload-to-r2.yml/badge.svg)](https://github.com/neon-nyan/CollapseLauncher-ReleaseRepo/actions/workflows/upload-to-r2.yml)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FCollapseLauncher%2FCollapse.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2FCollapseLauncher%2FCollapse?ref=badge_shield&issueType=license)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FCollapseLauncher%2FCollapse.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2FCollapseLauncher%2FCollapse?ref=badge_shield&issueType=security)

--- a/README.md
+++ b/README.md
@@ -199,6 +199,27 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
       <td>:white_check_mark:</td>
       <td>N/A</td>
     </tr>
+   <tr>
+      <td rowspan="2">Zenless Zone Zero</td>
+      <td>Global</td>
+      <td>:white_check_mark:</td>
+      <td>:white_check_mark:</td>
+      <td>:white_check_mark:</td>
+      <td>N/A</td>
+      <td>N/A</td>
+      <td>N/A</td>
+      <td>N/A</td>
+    </tr>
+    <tr>
+      <td>Mainland China</td>
+      <td>:white_check_mark:</td>
+      <td>:white_check_mark:</td>
+      <td>:white_check_mark:</td>
+      <td>N/A</td>
+      <td>N/A</td>
+      <td>N/A</td>
+      <td>N/A</td>
+    </tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 > > Please keep in mind that the Game Conversion feature is currently only available for Honkai Impact: 3rd. Other miHoYo/Cognosphere Pte. Ltd. games are currently not planned for game conversion. 
 
 # Download Ready-To-Use Builds
-[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.14/CL-1.80.14-stable_Installer.exe)
-> **Note**: The version for this build is `1.80.14` (Released on: June 30th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.15/CL-1.80.15-stable_Installer.exe)
+> **Note**: The version for this build is `1.80.15` (Released on: July 9th, 2024).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.14-pre/CL-1.80.14-preview_Installer.exe)
-> **Note**: The version for this build is `1.80.14` (Released on: June 30th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.15-pre/CL-1.80.15-preview_Installer.exe)
+> **Note**: The version for this build is `1.80.15` (Released on: July 9th, 2024).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 

--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 > > Please keep in mind that the Game Conversion feature is currently only available for Honkai Impact: 3rd. Other miHoYo/Cognosphere Pte. Ltd. games are currently not planned for game conversion. 
 
 # Download Ready-To-Use Builds
-[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.13/CL-1.80.13-stable_Installer.exe)
-> **Note**: The version for this build is `1.80.13` (Released on: June 26th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.14/CL-1.80.14-stable_Installer.exe)
+> **Note**: The version for this build is `1.80.14` (Released on: June 30th, 2024).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.13-pre/CL-1.80.13-preview_Installer.exe)
-> **Note**: The version for this build is `1.80.13` (Released on: June 26th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.14-pre/CL-1.80.14-preview_Installer.exe)
+> **Note**: The version for this build is `1.80.14` (Released on: June 30th, 2024).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 


### PR DESCRIPTION
# What's New? - 1.80.15
- **[Fix]** Crashing/Not responding issue caused by `ConfigureAwait`, by @neon-nyan 
- **[Fix]** Discord RPC weird behaviors, by @bagusnl & @neon-nyan 
  - RPC wont update between idle/play status
  - RPC stuck between game changes 
- **[Fix]** Game Settings "reset" between game changes, by @bagusnl 
  - This is caused by recent rewrite did not take into account refreshing `RegistryRoot` which is used by all GameSettings backend to load values from registry.
  - Now `RegistryRoot` is always retrieve the latest value instead of caching it.
- **[Fix]** `MIT License` string in Settings page not localized, by @bagusnl 
- **[Imp]** Allow user to Cancel when asked to either resume or redownload an ongoing download, by @neon-nyan 
- **[Fix]** Zip extraction not using multithread, by @neon-nyan 
- **[Imp]** Use Uncompressed Size when calculating disk space requirements, by @neon-nyan 
- **[Fix]** "Stop Game" button always enabled even when game is not running, by @neon-nyan 
- **[Fix]** Game selector ComboBox fixes, by @shatyuka 
  - Fixed being unable to change game/region after a metadata update
  - Fixed ComboBox not using acrylic theme
- **[Fix]** Zenless Zone Zero uninstall error, by @NSPC911 

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
