### PR TITLE
Stable 1.80.18 Hotfix Release

### DIFF
--- a/CollapseLauncher/Classes/GamePropertyVault.cs
+++ b/CollapseLauncher/Classes/GamePropertyVault.cs
@@ -60,7 +60,7 @@ namespace CollapseLauncher.Statics
                         _GameSettings = new ZenlessSettings(_GameVersion);
                         _GameCache    = null;
                         _GameRepair   = null;
-                        _GameInstall  = new ZenlessInstall(UIElementParent, _GameVersion);
+                        _GameInstall  = new ZenlessInstall(UIElementParent, _GameVersion, _GameSettings as ZenlessSettings);
                         break;
                     default:
                         throw new NotSupportedException($"[GamePresetProperty.Ctor] Game type: {GamePreset.GameType} ({GamePreset.ProfileName} - {GamePreset.ZoneName}) is not supported!");

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -2704,12 +2704,18 @@ namespace CollapseLauncher.InstallManager.Base
                     string langStr = await sw.ReadLineAsync();
                     string localeCode = GetLanguageLocaleCodeByLanguageString(langStr);
 
-                    // Try get the voice over resource
-                    if (TryGetVoiceOverResourceByLocaleCode(packs, localeCode, out RegionResourceVersion outRes))
+                // Try get the voice over resource
+                if (TryGetVoiceOverResourceByLocaleCode(packs, localeCode, out RegionResourceVersion outRes))
+                {
+                    // Check if the existing package is already exist or not.
+                    GameInstallPackage outResDup =
+                        packageList.FirstOrDefault(x => x.LanguageID != null &&
+                                                   x.LanguageID.Equals(outRes.language,
+                                                                    StringComparison.OrdinalIgnoreCase));
+                    if (outResDup != null)
                     {
-                        // Check if the existing package is already exist or not.
-                        RegionResourceVersion outResDup = packs.FirstOrDefault(x => x.language != null && x.language.Equals(outRes.language, StringComparison.OrdinalIgnoreCase));
-                        if (outResDup != null) continue;
+                        continue;
+                    }
 
                         GameInstallPackage package = new GameInstallPackage(outRes, _gamePath, assetVersion) { LanguageID = localeCode, PackageType = GameInstallPackageType.Audio };
                         packageList.Add(package);

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -2946,7 +2946,7 @@ namespace CollapseLauncher.InstallManager.Base
             }
 
             // Delete the file of the chunk file too
-            _httpClient.DeleteMultisessionFiles(FileOutput, Thread);
+            Http.DeleteMultisessionFiles(FileOutput, Thread);
         }
 
         private long GetExistingDownloadPackageSize(List<GameInstallPackage> packageList)
@@ -2962,7 +2962,7 @@ namespace CollapseLauncher.InstallManager.Base
                     long totalSegmentDownloaded = 0;
                     for (int j = 0; j < packageList[i].Segments.Count; j++)
                     {
-                        long segmentDownloaded = _httpClient.CalculateExistingMultisessionFilesWithExpctdSize(packageList[i].Segments[j].PathOutput, _downloadThreadCount, packageList[i].Segments[j].Size);
+                        long segmentDownloaded = Http.CalculateExistingMultisessionFilesWithExpctdSize(packageList[i].Segments[j].PathOutput, _downloadThreadCount, packageList[i].Segments[j].Size);
                         totalSize += segmentDownloaded;
                         totalSegmentDownloaded += segmentDownloaded;
                         packageList[i].Segments[j].SizeDownloaded = segmentDownloaded;
@@ -2971,7 +2971,7 @@ namespace CollapseLauncher.InstallManager.Base
                     continue;
                 }
 
-                packageList[i].SizeDownloaded = _httpClient.CalculateExistingMultisessionFilesWithExpctdSize(packageList[i].PathOutput, _downloadThreadCount, packageList[i].Size);
+                packageList[i].SizeDownloaded = Http.CalculateExistingMultisessionFilesWithExpctdSize(packageList[i].PathOutput, _downloadThreadCount, packageList[i].Size);
                 totalSize += packageList[i].SizeDownloaded;
             }
 

--- a/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
@@ -2,16 +2,164 @@ using CollapseLauncher.GameVersioning;
 using CollapseLauncher.InstallManager.Base;
 using CollapseLauncher.Interfaces;
 using Microsoft.UI.Xaml;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
+// ReSharper disable GrammarMistakeInComment
+// ReSharper disable CommentTypo
+// ReSharper disable StringLiteralTypo
+// ReSharper disable CheckNamespace
+// ReSharper disable ArrangeObjectCreationWhenTypeEvident
+// ReSharper disable EmptyRegion
+// ReSharper disable InconsistentNaming
+// ReSharper disable ConvertToPrimaryConstructor
+
+#nullable enable
 namespace CollapseLauncher.InstallManager.Zenless
 {
     internal class ZenlessInstall : InstallManagerBase<GameTypeZenlessVersion>
     {
-        #region Override Properties
+        #region Private Properties
+        private ZenlessSettings? ZenlessSettings { get; set; }
         #endregion
 
-        public ZenlessInstall(UIElement parentUI, IGameVersionCheck GameVersionManager)
-            : base(parentUI, GameVersionManager) { }
+        #region Override Properties
+        protected override int _gameVoiceLanguageID
+        {
+            get => ZenlessSettings?.GeneralData?.DeviceLanguageVoiceType switch
+            {
+                LanguageVoice.zh_cn => 0,
+                LanguageVoice.en_us => 1,
+                LanguageVoice.ja_jp => 2,
+                LanguageVoice.ko_kr => 3,
+                LanguageVoice.Unset => 2,  // Default to ja_jp
+                _ => throw new NotSupportedException("Type of the language voice type is not valid!")
+            };
+        }
+
+        protected override string? _gameAudioLangListPath
+        {
+            get
+            {
+                // If the persistent folder is not exist, then return null
+                if (!Directory.Exists(_gameDataPersistentPath))
+                    return null;
+
+                // Get the audio lang path index
+                string audioLangPath = _gameAudioLangListPathStatic;
+                return File.Exists(audioLangPath) ? audioLangPath : null;
+            }
+        }
+
+        private            string? _gameAudioLangListPathAlternate
+        {
+            get
+            {
+                // If the persistent folder is not exist, then return null
+                if (!Directory.Exists(_gameDataPersistentPath))
+                    return null;
+
+                // Get the audio lang path index
+                string audioLangPath = _gameAudioLangListPathAlternateStatic;
+                return File.Exists(audioLangPath) ? audioLangPath : null;
+            }
+        }
+
+        protected override string _gameAudioLangListPathStatic =>
+            Path.Combine(_gameDataPersistentPath, "audio_lang_launcher");
+        private            string _gameAudioLangListPathAlternateStatic =>
+            Path.Combine(_gameDataPersistentPath, "audio_lang");
+        #endregion
+
+        public ZenlessInstall(UIElement parentUI, IGameVersionCheck GameVersionManager, ZenlessSettings zenlessSettings)
+            : base(parentUI, GameVersionManager)
+        {
+            ZenlessSettings = zenlessSettings;
+        }
+
+        #region Override Methods - Audio Lang List
+        protected override void WriteAudioLangList(List<GameInstallPackage> gamePackage)
+        {
+            // Run the writing method from the base first
+            base.WriteAudioLangList(gamePackage);
+
+            // Then create the one from the alternate one
+            // Read all the existing list
+            List<string> langList = File.Exists(_gameAudioLangListPathAlternateStatic)
+                ? File.ReadAllLines(_gameAudioLangListPathAlternateStatic).ToList()
+                : [];
+
+            // Try lookup if there is a new language list, then add it to the list
+            foreach (GameInstallPackage package in
+                     _assetIndex.Where(x => x.PackageType == GameInstallPackageType.Audio))
+            {
+                string langString = GetLanguageStringByLocaleCodeAlternate(package.LanguageID);
+                if (!langList.Contains(langString, StringComparer.OrdinalIgnoreCase))
+                {
+                    langList.Add(langString);
+                }
+            }
+
+            // Create the audio lang list file
+            using StreamWriter sw = new StreamWriter(_gameAudioLangListPathAlternateStatic,
+                                                     new FileStreamOptions
+                                                     { Mode = FileMode.Create, Access = FileAccess.Write });
+            // Iterate the package list
+            foreach (string langString in langList)
+            {
+                // Write the language string as per ID
+                sw.WriteLine(langString);
+            }
+        }
+
+        protected override void WriteAudioLangListSophon(List<string> sophonVOList)
+        {
+            // Run the writing method from the base first
+            base.WriteAudioLangListSophon(sophonVOList);
+
+            // Then create the one from the alternate one
+            // Read all the existing list
+            List<string> langList = File.Exists(_gameAudioLangListPathAlternateStatic)
+                ? File.ReadAllLines(_gameAudioLangListPathAlternateStatic).ToList()
+                : [];
+
+            // Try lookup if there is a new language list, then add it to the list
+            for (int index = 0; index < sophonVOList.Count; index++)
+            {
+                var packageLocaleCodeString = sophonVOList[index];
+                string langString = GetLanguageStringByLocaleCodeAlternate(packageLocaleCodeString);
+                if (!langList.Contains(langString, StringComparer.OrdinalIgnoreCase))
+                {
+                    langList.Add(langString);
+                }
+            }
+
+            // Create the audio lang list file
+            using var sw = new StreamWriter(_gameAudioLangListPathAlternateStatic,
+                                            new FileStreamOptions
+                                            { Mode = FileMode.Create, Access = FileAccess.Write });
+            // Iterate the package list
+            foreach (var voIds in langList)
+            // Write the language string as per ID
+            {
+                sw.WriteLine(voIds);
+            }
+        }
+
+        private string GetLanguageStringByLocaleCodeAlternate(string localeCode)
+        {
+            return localeCode switch
+            {
+                "zh-cn" => "Cn",
+                "en-us" => "En",
+                "ja-jp" => "Jp",
+                "ko-kr" => "Kr",
+                _ => throw new KeyNotFoundException($"Alternate locale code: {localeCode} is not supported!")
+            };
+        }
+        #endregion
 
         #region Override Methods - UninstallGame
         protected override UninstallGameProperty AssignUninstallFolders() => new UninstallGameProperty()
@@ -24,3 +172,4 @@ namespace CollapseLauncher.InstallManager.Zenless
         #endregion
     }
 }
+#nullable restore

--- a/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
@@ -1,3 +1,5 @@
+using CollapseLauncher.GameSettings.Zenless;
+using CollapseLauncher.GameSettings.Zenless.Enums;
 using CollapseLauncher.GameVersioning;
 using CollapseLauncher.InstallManager.Base;
 using CollapseLauncher.Interfaces;

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -15,7 +15,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.80.17</Version>
+        <Version>1.80.18</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>


### PR DESCRIPTION
# What's New? - 1.80.18
- **[New]** ZZZ Pre-download Support, by @neon-nyan 
- **[New]** Bilibili Region Support for ZZZ, by @bagusnl & @neon-nyan  
- **[Imp]** Bring back the old file download behavior to store chunk files as sequential ``.001`` files, by @neon-nyan
  This change however, is backward compatible if you still have the hash-based (``.xxxxx``) extension chunks.
- **[Fix]** Random "File is being used by another process" Errors when Downloading, by @neon-nyan 

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>