### PR TITLE
[Urgent] Stable 1.80.19 Hotfix Release

### DIFF
--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1137,19 +1137,17 @@ namespace CollapseLauncher.InstallManager.Base
 
         private long GetAssetIndexTotalUncompressSize(List<GameInstallPackage> assetIndex)
         {
-            long returnSize = 0;
             ArgumentNullException.ThrowIfNull(assetIndex);
 
-            foreach (GameInstallPackage asset in assetIndex)
-            {
-                using (Stream stream = GetSingleOrSegmentedDownloadStream(asset))
-                    using (ArchiveFile archiveFile = new ArchiveFile(stream!))
-                    {
-                        returnSize += archiveFile.Entries.Sum(x => (long)x!.Size);
-                    }
-            }
-
+            long returnSize = assetIndex.Sum(GetSingleOrSegmentedUncompressedSize);
             return returnSize;
+        }
+
+        private long GetSingleOrSegmentedUncompressedSize(GameInstallPackage asset)
+        {
+            using Stream      stream      = GetSingleOrSegmentedDownloadStream(asset);
+            using ArchiveFile archiveFile = new ArchiveFile(stream!);
+            return archiveFile.Entries.Sum(x => (long)x!.Size);
         }
 
         private Stream GetSingleOrSegmentedDownloadStream(GameInstallPackage asset)
@@ -1212,6 +1210,9 @@ namespace CollapseLauncher.InstallManager.Base
                 _status!.IsProgressPerFileIndetermined = false;
                 _status!.IsProgressAllIndetermined = false;
                 UpdateStatus();
+
+                _progressPerFileSizeCurrent = 0;
+                _progressPerFileSizeTotal = GetSingleOrSegmentedUncompressedSize(asset);
 
                 // Assign extractor
                 string packageExtension = Path.GetExtension(asset!.PathOutput).ToLower();

--- a/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 // ReSharper disable GrammarMistakeInComment
 // ReSharper disable CommentTypo
@@ -80,6 +81,26 @@ namespace CollapseLauncher.InstallManager.Zenless
         {
             ZenlessSettings = zenlessSettings;
         }
+
+        #region Override Methods - StartPackageInstallationInner
+        protected override async Task StartPackageInstallationInner(List<GameInstallPackage>? gamePackage = null,
+                                                                    bool isOnlyInstallPackage = false,
+                                                                    bool doNotDeleteZipExplicit = false)
+        {
+            // Run the base installation process
+            await base.StartPackageInstallationInner(gamePackage, isOnlyInstallPackage, doNotDeleteZipExplicit);
+
+            // Then start on processing hdifffiles list and deletefiles list
+            await ApplyHdiffListPatch();
+            ApplyDeleteFileAction();
+
+            // Update the audio lang list if not in isOnlyInstallPackage mode
+            if (!isOnlyInstallPackage)
+            {
+                WriteAudioLangList(_assetIndex);
+            }
+        }
+        #endregion
 
         #region Override Methods - Audio Lang List
         protected override void WriteAudioLangList(List<GameInstallPackage> gamePackage)

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -15,7 +15,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.80.18</Version>
+        <Version>1.80.19</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>


### PR DESCRIPTION
# What's New? - 1.80.19
- **[New]** ZZZ Pre-download Support, by @neon-nyan 
- **[New]** Bilibili Region Support for ZZZ, by @bagusnl & @neon-nyan  
- **[Imp]** Bring back the old file download behavior to store chunk files as sequential ``.001`` files, by @neon-nyan
  This change however, is backward compatible if you still have the hash-based (``.xxxxx``) extension chunks.
- **[Fix]** Random "File is being used by another process" Errors when Downloading, by @neon-nyan 
- **[Fix]** Potentially skipping HDiff patching and old files removal routine while applying ZZZ Update, by @neon-nyan 
- **[Fix]** ``Hi3Helper.Http`` submodule causing size miscalculation while downloading files, by @neon-nyan 

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>