### PR TITLE
[Urgent] Preview 1.81.3 Hotfix Release

### DIFF
--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1355,17 +1355,17 @@ namespace CollapseLauncher.InstallManager.Base
 
         private long GetAssetIndexTotalUncompressSize(List<GameInstallPackage> assetIndex)
         {
-            long returnSize = 0;
             ArgumentNullException.ThrowIfNull(assetIndex);
 
-            foreach (GameInstallPackage asset in assetIndex)
-            {
-                using Stream      stream      = GetSingleOrSegmentedDownloadStream(asset);
-                using ArchiveFile archiveFile = new ArchiveFile(stream!);
-                returnSize += archiveFile.Entries.Sum(x => (long)x!.Size);
-            }
-
+            long returnSize = assetIndex.Sum(GetSingleOrSegmentedUncompressedSize);
             return returnSize;
+        }
+
+        private long GetSingleOrSegmentedUncompressedSize(GameInstallPackage asset)
+        {
+            using Stream      stream      = GetSingleOrSegmentedDownloadStream(asset);
+            using ArchiveFile archiveFile = new ArchiveFile(stream!);
+            return archiveFile.Entries.Sum(x => (long)x!.Size);
         }
 
         private Stream GetSingleOrSegmentedDownloadStream(GameInstallPackage asset)
@@ -1453,6 +1453,9 @@ namespace CollapseLauncher.InstallManager.Base
                 _status!.IsProgressPerFileIndetermined = false;
                 _status!.IsProgressAllIndetermined     = false;
                 UpdateStatus();
+
+                _progressPerFileSizeCurrent = 0;
+                _progressPerFileSizeTotal = GetSingleOrSegmentedUncompressedSize(asset);
 
                 // Assign extractor
             #if USENEWZIPDECOMPRESS

--- a/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Zenless/ZenlessInstall.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 // ReSharper disable GrammarMistakeInComment
 // ReSharper disable CommentTypo
@@ -79,6 +80,26 @@ namespace CollapseLauncher.InstallManager.Zenless
         {
             ZenlessSettings = zenlessSettings;
         }
+
+        #region Override Methods - StartPackageInstallationInner
+        protected override async Task StartPackageInstallationInner(List<GameInstallPackage>? gamePackage = null,
+                                                                    bool isOnlyInstallPackage = false,
+                                                                    bool doNotDeleteZipExplicit = false)
+        {
+            // Run the base installation process
+            await base.StartPackageInstallationInner(gamePackage, isOnlyInstallPackage, doNotDeleteZipExplicit);
+
+            // Then start on processing hdifffiles list and deletefiles list
+            await ApplyHdiffListPatch();
+            ApplyDeleteFileAction();
+
+            // Update the audio lang list if not in isOnlyInstallPackage mode
+            if (!isOnlyInstallPackage)
+            {
+                WriteAudioLangList(_assetIndex);
+            }
+        }
+        #endregion
 
         #region Override Methods - Audio Lang List
         protected override void WriteAudioLangList(List<GameInstallPackage> gamePackage)

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <!-- General Properties -->
         <OutputType>WinExe</OutputType>
@@ -15,7 +15,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.81.2</Version>
+        <Version>1.81.3</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>

--- a/Hi3Helper.Core/Lang/es_419.json
+++ b/Hi3Helper.Core/Lang/es_419.json
@@ -181,18 +181,18 @@
     "Exception_DownloadTimeout2": "¡Verifica la estabilidad de tu conexión! Si la velocidad de tu internet es lenta, disminuye el numero de Hilos de Descarga.",
     "Exception_DownloadTimeout3": "**ADVERTENCIA** ¡Cambiar el numero de hilos reiniciaran la descarga desde 0 y tendrás que eliminar manualmente las partes de archivos ya descargados!",
 
-    "GameStateInvalid_Title": "Game Data Directory/Executable Name/Config.ini/App.Info file is Invalid!",
-    "GameStateInvalid_Subtitle1": "Collapse Launcher has detected that the game file properties are invalid for region:\r\n",
-    "GameStateInvalid_Subtitle2": "It's recommended to perform a fix in order the launcher to detect the game properly",
-    "GameStateInvalid_Subtitle3": "Click \"",
-    "GameStateInvalid_Subtitle4": "\" to fix the game properties or click \"",
-    "GameStateInvalid_Subtitle5": "\" to cancel the operation.",
+    "GameStateInvalid_Title": "¡Directorio de Datos de Juego/Nombre del Ejecutable/Config.ini/App.Info es inválido!",
+    "GameStateInvalid_Subtitle1": "Collapse detectó que las propiedades de archivo del juego son inválidas para la región:\r\n",
+    "GameStateInvalid_Subtitle2": "Es recomendado hacer una reparación para que el launcher detecte el juego correctamente",
+    "GameStateInvalid_Subtitle3": "Haz clic en \"",
+    "GameStateInvalid_Subtitle4": "\" para reparar las propiedades o clic en \"",
+    "GameStateInvalid_Subtitle5": "\" para cancelar la operación.",
 
-    "GameStateInvalidFixed_Title": "Game File Properties have been Succesfully Fixed!",
-    "GameStateInvalidFixed_Subtitle1": "Game file properties have been fixed for region:",
-    "GameStateInvalidFixed_Subtitle2": "Please perform a \"",
-    "GameStateInvalidFixed_Subtitle3": "\" in the \"",
-    "GameStateInvalidFixed_Subtitle4": "\" menu in order to make sure all the files are verified."
+    "GameStateInvalidFixed_Title": "¡Se han corregido con éxito los archivos de juego!",
+    "GameStateInvalidFixed_Subtitle1": "Se han corregido las propiedades para la región:",
+    "GameStateInvalidFixed_Subtitle2": "Por Favor, realiza un \"",
+    "GameStateInvalidFixed_Subtitle3": "\" en el menú de \"",
+    "GameStateInvalidFixed_Subtitle4": "\" para asegurar que todos los archivos están verificados."
   },
 
   "_GameRepairPage": {
@@ -481,7 +481,7 @@
     "Update_NewVer2": "Actualización disponible!",
     "Update_LatestVer": "Estás usando la última versión.",
     "Update_SeeChangelog": "Ver los Últimos Cambios (Ingles)",
-    "Update_ChangelogTitle": "Latest Changes",
+    "Update_ChangelogTitle": "Últimos Cambios",
 
     "AppFiles": "Gestión de Archivos",
     "AppFiles_OpenDataFolderBtn": "Abrir Carpeta de Datos de la Aplicación",
@@ -545,40 +545,40 @@
     "Waifu2X_Error_Loader": "ERROR: Fallo al inicializar el Vulkan Loader. Asegúrate de que tienes una GPU compatible con Vulkan y su respetivo Driver instalado.",
     "Waifu2X_Error_Output": "ERROR: Fallo en la comprobación de Waifu2X, se obtuvo una imagen vacía de salida.",
 
-    "NetworkSettings_Title": "Network Settings",
-    "NetworkSettings_Proxy_Title": "Proxy Settings",
+    "NetworkSettings_Title": "Ajustes de Red",
+    "NetworkSettings_Proxy_Title": "Ajustes de Proxy",
 
-    "NetworkSettings_Proxy_Hostname": "Proxy Hostname",
-    "NetworkSettings_Proxy_HostnameHelp1": "Represents the URL of the Proxy to use.",
-    "NetworkSettings_Proxy_HostnameHelp2": "Collapse can only support",
-    "NetworkSettings_Proxy_HostnameHelp3": "HTTP/HTTPS and SOCKS4/4a/5",
-    "NetworkSettings_Proxy_HostnameHelp4": "type of proxy at the moment.",
+    "NetworkSettings_Proxy_Hostname": "Hostname de Proxy",
+    "NetworkSettings_Proxy_HostnameHelp1": "Representa la URL del Proxy a utilizar.",
+    "NetworkSettings_Proxy_HostnameHelp2": "Collapse solo soporta proxy de tipo ",
+    "NetworkSettings_Proxy_HostnameHelp3": "HTTP/HTTPS y SOCKS4/4a/5",
+    "NetworkSettings_Proxy_HostnameHelp4": "por el momento.",
 
-    "NetworkSettings_ProxyWarn_UrlInvalid": "The URL entered is not valid!",
-    "NetworkSettings_ProxyWarn_NotSupported": "The proxy scheme is not supported! Collapse only supports http://, https://, socks4://, socks4a:// and socks5://",
+    "NetworkSettings_ProxyWarn_UrlInvalid": "¡La URL ingresada no es valida!",
+    "NetworkSettings_ProxyWarn_NotSupported": "¡El formato de Proxy no es soportado! Collapse solo soporta http://, https://, socks4://, socks4a:// y socks5://",
 
-    "NetworkSettings_Proxy_Username": "Proxy Username",
-    "NetworkSettings_Proxy_UsernamePlaceholder": "Enter Proxy Username",
-    "NetworkSettings_Proxy_UsernameHelp1": "Default:",
-    "NetworkSettings_Proxy_UsernameHelp2": "[Empty]",
-    "NetworkSettings_Proxy_UsernameHelp3": "Leave this field empty if your proxy doesn't require authentication.",
+    "NetworkSettings_Proxy_Username": "Nombre de Usuario de Proxy",
+    "NetworkSettings_Proxy_UsernamePlaceholder": "Ingresar Nombre de Usuario",
+    "NetworkSettings_Proxy_UsernameHelp1": "Por Defecto:",
+    "NetworkSettings_Proxy_UsernameHelp2": "[Vacío]",
+    "NetworkSettings_Proxy_UsernameHelp3": "Si tu proxy no requiere autenticación, deja el campo vacío.",
 
-    "NetworkSettings_Proxy_Password": "Proxy Password",
-    "NetworkSettings_Proxy_PasswordPlaceholder": "Enter Proxy Password",
-    "NetworkSettings_Proxy_PasswordHelp1": "Default:",
-    "NetworkSettings_Proxy_PasswordHelp2": "[Empty]",
-    "NetworkSettings_Proxy_PasswordHelp3": "Leave this field empty if your proxy doesn't require authentication.",
+    "NetworkSettings_Proxy_Password": "Contraseña de Proxy",
+    "NetworkSettings_Proxy_PasswordPlaceholder": "Ingresar Contraseña de Proxy",
+    "NetworkSettings_Proxy_PasswordHelp1": "Por Defecto:",
+    "NetworkSettings_Proxy_PasswordHelp2": "[Vacío]",
+    "NetworkSettings_Proxy_PasswordHelp3": "Si tu proxy no requiere autenticación, deja el campo vacío.",
 
-    "NetworkSettings_ProxyTest_Button": "Test Proxy Connectivity",
-    "NetworkSettings_ProxyTest_ButtonChecking": "Checking Connectivity...",
-    "NetworkSettings_ProxyTest_ButtonSuccess": "Proxy Connectivity Test is Successful!",
-    "NetworkSettings_ProxyTest_ButtonFailed": "Test Failed! Proxy is not Reachable",
+    "NetworkSettings_ProxyTest_Button": "Probar Conectividad del Proxy",
+    "NetworkSettings_ProxyTest_ButtonChecking": "Comprobando Conectividad...",
+    "NetworkSettings_ProxyTest_ButtonSuccess": "¡Prueba de Conectividad fue exitosa!",
+    "NetworkSettings_ProxyTest_ButtonFailed": "¡Prueba fallida! No se puede alcanzar el proxy",
 
-    "NetworkSettings_Http_Title": ".NET HTTP Client Settings",
-    "NetworkSettings_Http_Redirect": "Allow HTTP Redirection",
-    "NetworkSettings_Http_SimulateCookies": "Allow Simulate HTTP Cookies",
-    "NetworkSettings_Http_UntrustedHttps": "Allow Untrusted HTTPS Certificate",
-    "NetworkSettings_Http_Timeout": "HTTP Client Timeout (in Seconds)"
+    "NetworkSettings_Http_Title": "Ajustes Cliente .NET HTTP",
+    "NetworkSettings_Http_Redirect": "Permitir Redirección HTTP",
+    "NetworkSettings_Http_SimulateCookies": "Permitir Simular HTTP Cookies",
+    "NetworkSettings_Http_UntrustedHttps": "Permitir Certificados HTTPS que no son de confianza",
+    "NetworkSettings_Http_Timeout": "Tiempo de espera del cliente HTTP (en segundos)"
   },
 
   "_Misc": {
@@ -884,8 +884,8 @@
     "DownloadSettingsTitle": "Descargando Configuración",
     "DownloadSettingsOption1": "Iniciar el juego después de instalar ",
     
-    "OpenInExternalBrowser": "Open in External Browser",
-    "CloseOverlay": "Close Overlay"
+    "OpenInExternalBrowser": "Abrir en Navegador Web Externo",
+    "CloseOverlay": "Cerrar Superposición (Overlay)"
   },
 
   "_FileMigrationProcess": {

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 > > Please keep in mind that the Game Conversion feature is currently only available for Honkai Impact: 3rd. Other miHoYo/Cognosphere Pte. Ltd. games are currently not planned for game conversion. 
 
 # Download Ready-To-Use Builds
-[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.17/CL-1.80.17-stable_Installer.exe)
-> **Note**: The version for this build is `1.80.17` (Released on: July 31st, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.18/CL-1.80.18-stable_Installer.exe)
+> **Note**: The version for this build is `1.80.18` (Released on: August 12th, 2024).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.81.1-pre/CL-1.81.1-preview_Installer.exe)
-> **Note**: The version for this build is `1.81.1` (Released on: July 31st, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.81.2-pre/CL-1.81.2-preview_Installer.exe)
+> **Note**: The version for this build is `1.81.2` (Released on: August 12th, 2024).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 


### PR DESCRIPTION
# What's New? - 1.81.3
- **[New]** ZZZ Pre-download Support, by @neon-nyan 
- **[New]** Bilibili Region Support for ZZZ, by @bagusnl & @neon-nyan  
- **[New]** Burst Download Mode, by @neon-nyan 
  - This will make download process of multiple files faster by downloading them in parallel.
  - NOT recommended for those with slower internet, thus disabled by default.
  - As its a very experimental settings, if you want to try, edit the Collapse config file:
  - `%AppData%\..\CollapseLauncher\config.ini`, add/modify `IsBurstDownloadModeEnabled` key to "True".
- **[Fix]** Use the Custom Resolution Enforcer for ALL Games, by @bagusnl 
  - Practically when you use Custom Res, forces all game to obey the resolution by changing its Window property.
- **[Fix]** Black Bar on top of Image Carousel, by @shatyuka 
- **[Fix]** Reimplement Migrate from Steam Feature for Hi3, by @neon-nyan 
- **[Fix]** Random "File is being used by another process" Errors when Downloading, by @neon-nyan 
- **[Imp]** Bring back the old file download behavior to store chunk files as sequential ``.001`` files, by @neon-nyan
  This change however, is backward compatible if you still have the hash-based (``.xxxxx``) extension chunks.
- **[Fix]** Potentially skipping HDiff patching and old files removal routine while applying ZZZ Update, by @neon-nyan 
- **[Fix]** ``Hi3Helper.Http`` submodule causing size miscalculation while downloading files, by @neon-nyan 
- **[Loc]** Localization Sync from Transifex, by Localizers <3

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
