### PR TITLE
Fix typo in feature_request.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -44,7 +44,7 @@ body:
       attributes:
         label: Describe alternatives you've considered
         description: A clear and concise description of any alternative solutions or features you've considered.
-        placeholder: What are the alternatives you've considered? Sometimes, the Collapse team can't always implement everything the way you envisonned it, so what are some compromises, changes you're willing to make to the current proposal?
+        placeholder: What are the alternatives you've considered? Sometimes, the Collapse team can't always implement everything the way you envisioned it, so what are some compromises, changes you're willing to make to the current proposal?
       validations:
         required: true
 


### PR DESCRIPTION
# Main Goal
To fix a small typo I saw while creating a feature request issue!

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0 (hopefully not by this simple fix)