### PR TITLE
Preview 1.82.1 Release

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
@@ -6,11 +6,51 @@ using System;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
 
 #nullable enable
 namespace CollapseLauncher.GameSettings.Zenless;
 internal class GeneralData : MagicNodeBaseValues<GeneralData>
 {
+    #region Disposer
+    public void Dispose() => DisposeAsync().GetAwaiter().GetResult();
+    
+    public async Task DisposeAsync()
+    {
+        _systemSettingDataMap = null;
+        _keyboardBindingMap = null;
+        _mouseBindingMap = null;
+        _gamepadBindingMap = null;
+        _graphicsPresData = null;
+        _resolutionIndexData = null;
+        _vSyncData = null;
+        _renderResolutionData = null;
+        _shadowQualityData = null;
+        _antiAliasingData = null;
+        _volFogQualityData = null;
+        _bloomData = null;
+        _reflQualityData = null;
+        _fxQualityData = null;
+        _colorFilterData = null;
+        _charQualityData = null;
+        _distortionData = null;
+        _shadingQualityData = null;
+        _envQualityData = null;
+        _envGlobalIllumination = null;
+        _vMotionBlur = null;
+        _fpsData = null;
+        _hpcaData = null;
+        _mainVolData = null;
+        _musicVolData = null;
+        _dialogVolData = null;
+        _sfxVolData = null;
+        _playDevData = null;
+        _muteAudOnMinimizeData = null;
+
+        await Task.CompletedTask;
+    }
+
+    #endregion
     #region Node Based Properties
     private JsonNode? _systemSettingDataMap;
     private JsonNode? _keyboardBindingMap;
@@ -474,6 +514,20 @@ internal class GeneralData : MagicNodeBaseValues<GeneralData>
         get => (_fpsData ??= SystemSettingDataMap
            .AsSystemSettingLocalData("110", FpsOption.Hi60)).GetDataEnum<FpsOption>();
         set => _fpsData?.SetDataEnum(value);
+    }
+    
+    // Key 13162 High-Precision Character Animation
+    private SystemSettingLocalData<bool>? _hpcaData;
+
+    /// <summary>
+    /// Sets in-game settings for High-Precision Character Animation. <br/>
+    /// Whatever that is ¯\_(ツ)_/¯
+    /// </summary>
+    [JsonIgnore]
+    public bool HiPrecisionCharaAnim
+    {
+        get => (_hpcaData ??= SystemSettingDataMap.AsSystemSettingLocalData("13162", true)).GetData();
+        set => _hpcaData?.SetData(value);
     }
 
     #endregion

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
@@ -10,12 +10,12 @@ using System.Threading.Tasks;
 
 #nullable enable
 namespace CollapseLauncher.GameSettings.Zenless;
-internal class GeneralData : MagicNodeBaseValues<GeneralData>
+
+internal class GeneralData : MagicNodeBaseValues<GeneralData>, IDisposable
 {
     #region Disposer
-    public void Dispose() => DisposeAsync().GetAwaiter().GetResult();
-    
-    public async Task DisposeAsync()
+
+    ~GeneralData()
     {
         _systemSettingDataMap = null;
         _keyboardBindingMap = null;
@@ -47,8 +47,10 @@ internal class GeneralData : MagicNodeBaseValues<GeneralData>
         _playDevData = null;
         _muteAudOnMinimizeData = null;
 
-        await Task.CompletedTask;
+        GC.Collect();
     }
+
+    public void Dispose() => GC.SuppressFinalize(this);
 
     #endregion
     #region Node Based Properties

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Settings.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Settings.cs
@@ -58,6 +58,7 @@ namespace CollapseLauncher.GameSettings.Zenless
 
         public override void ReloadSettings()
         {
+            GeneralData.Dispose();
             InitializeSettings();
         }
 

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1560,37 +1560,52 @@ namespace CollapseLauncher.InstallManager.Base
 
                     try
                     {
-                        string argument = "";
+                        string arguments = "";
                         string executableName;
-                        int indexOfArgument = asset.RunCommand.IndexOf(".exe ", StringComparison.OrdinalIgnoreCase) + 5;
-                        if (indexOfArgument < 5 && !asset.RunCommand.EndsWith(".exe"))
-                        {
-                            indexOfArgument = asset.RunCommand.IndexOf(' ');
-                        }
-                        else
-                        {
-                            indexOfArgument = -1;
-                        }
+                        // int indexOfArgument = asset.RunCommand.IndexOf(".exe ", StringComparison.OrdinalIgnoreCase) + 5;
+                        // if (indexOfArgument < 5 && !asset.RunCommand.EndsWith(".exe"))
+                        // {
+                        //     indexOfArgument = asset.RunCommand.IndexOf(' ');
+                        // }
+                        // else
+                        // {
+                        //     indexOfArgument = -1;
+                        // }
+                        //
+                        // if (indexOfArgument >= 0)
+                        // {
+                        //     argument = asset.RunCommand.Substring(indexOfArgument);
+                        //     executableName =
+                        //         ConverterTool.NormalizePath(asset.RunCommand.Substring(0, indexOfArgument)
+                        //                                          .TrimEnd(' '));
+                        // }
+                        // else
+                        // {
+                        //     executableName = asset.RunCommand;
+                        // }
 
-                        if (indexOfArgument >= 0)
+                        var firstSpaceIndex = asset.RunCommand.IndexOf(' ');
+                        if (firstSpaceIndex != -1)
                         {
-                            argument = asset.RunCommand.Substring(indexOfArgument);
-                            executableName =
-                                ConverterTool.NormalizePath(asset.RunCommand.Substring(0, indexOfArgument)
-                                                                 .TrimEnd(' '));
+                            // Split into executable and arguments
+                            executableName = asset.RunCommand.Substring(0, firstSpaceIndex);
+                            arguments = asset.RunCommand.Substring(firstSpaceIndex + 1);
                         }
                         else
                         {
+                            // No arguments, only executable
                             executableName = asset.RunCommand;
+                            arguments = string.Empty;
                         }
-
+                        
+                        
                         string executablePath = ConverterTool.NormalizePath(Path.Combine(_gamePath, executableName));
                         Process commandProcess = new Process
                         {
                             StartInfo = new ProcessStartInfo
                             {
                                 FileName        = executablePath,
-                                Arguments       = argument,
+                                Arguments       = arguments,
                                 UseShellExecute = true,
                                 WorkingDirectory = Path.GetDirectoryName(executablePath)
                             }
@@ -1603,7 +1618,7 @@ namespace CollapseLauncher.InstallManager.Base
                         }
                         else
                         {
-                            LogWriteLine($"Starting plugin process {executablePath} with argument {argument}");
+                            LogWriteLine($"Starting plugin process {executablePath} with argument {arguments}");
                             await commandProcess.WaitForExitAsync();
                         }
                     }

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1584,14 +1584,15 @@ namespace CollapseLauncher.InstallManager.Base
                             executableName = asset.RunCommand;
                         }
 
-                        string executablePath = Path.Combine(_gamePath, executableName);
+                        string executablePath = ConverterTool.NormalizePath(Path.Combine(_gamePath, executableName));
                         Process commandProcess = new Process
                         {
                             StartInfo = new ProcessStartInfo
                             {
                                 FileName        = executablePath,
                                 Arguments       = argument,
-                                UseShellExecute = true
+                                UseShellExecute = true,
+                                WorkingDirectory = Path.GetDirectoryName(executablePath)
                             }
                         };
 
@@ -1602,6 +1603,7 @@ namespace CollapseLauncher.InstallManager.Base
                         }
                         else
                         {
+                            LogWriteLine($"Starting plugin process {executablePath} with argument {argument}");
                             await commandProcess.WaitForExitAsync();
                         }
                     }

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -16,7 +16,6 @@
 using CollapseLauncher.CustomControls;
 using CollapseLauncher.Dialogs;
 using CollapseLauncher.Extension;
-using CollapseLauncher.FileDialogCOM;
 using CollapseLauncher.Helper;
 using CollapseLauncher.Helper.Metadata;
 using CollapseLauncher.Interfaces;
@@ -63,6 +62,7 @@ using ZipArchiveEntry = SharpCompress.Archives.Zip.ZipArchiveEntry;
 using SophonLogger = Hi3Helper.Sophon.Helper.Logger;
 using SophonManifest = Hi3Helper.Sophon.SophonManifest;
 using CollapseLauncher.Classes.FileDialogCOM;
+using CollapseLauncher.DiscordPresence;
 
 // ReSharper disable ForCanBeConvertedToForeach
 // ReSharper disable SwitchStatementHandlesSomeKnownEnumValuesWithDefault
@@ -3858,12 +3858,18 @@ namespace CollapseLauncher.InstallManager.Base
                     _status.IsRunning   = true;
                     _status.IsCompleted = false;
                     _status.IsCanceled  = false;
+                    #if !DISABLEDISCORD
+                    InnerLauncherConfig.AppDiscordPresence?.SetActivity(ActivityType.Update);
+                    #endif
                     break;
                 case CompletenessStatus.Completed:
                     IsRunning           = false;
                     _status.IsRunning   = false;
                     _status.IsCompleted = true;
                     _status.IsCanceled  = false;
+                    #if !DISABLEDISCORD
+                    InnerLauncherConfig.AppDiscordPresence?.SetActivity(ActivityType.Idle);
+                    #endif
                     // HACK: Fix the progress not achieving 100% while completed
                     _progress.ProgressAllPercentage     = 100f;
                     _progress.ProgressPerFilePercentage = 100f;
@@ -3873,12 +3879,18 @@ namespace CollapseLauncher.InstallManager.Base
                     _status.IsRunning   = false;
                     _status.IsCompleted = false;
                     _status.IsCanceled  = true;
+                    #if !DISABLEDISCORD
+                    InnerLauncherConfig.AppDiscordPresence?.SetActivity(ActivityType.Idle);
+                    #endif
                     break;
                 case CompletenessStatus.Idle:
                     IsRunning           = false;
                     _status.IsRunning   = false;
                     _status.IsCompleted = false;
                     _status.IsCanceled  = false;
+                    #if !DISABLEDISCORD
+                    InnerLauncherConfig.AppDiscordPresence?.SetActivity(ActivityType.Idle);
+                    #endif
                     break;
             }
 

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1100,7 +1100,7 @@ namespace CollapseLauncher.InstallManager.Base
                 }
 
                 // Get the remote chunk size
-                _progressPerFileSizeTotal   = sophonUpdateAssetList.GetCalculatedDiffSize();
+                _progressPerFileSizeTotal   = sophonUpdateAssetList.GetCalculatedDiffSize(!isPreloadMode);
                 _progressPerFileSizeCurrent = 0;
 
                 // Get the remote total size and current total size

--- a/CollapseLauncher/Classes/RepairManagement/StarRail/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/StarRail/Check.cs
@@ -220,7 +220,9 @@ namespace CollapseLauncher
 
             // Check if the file exist on both persistent and streaming path for non-patch file, then mark the
             // persistent path as redundant (unused)
-            if (IsPersistentExist && IsStreamingExist && !asset.IsPatchApplicable)
+            bool isNonPatchHasRedundantPersistent = !asset.IsPatchApplicable && IsPersistentExist && IsStreamingExist && fileInfoStreaming.Length == asset.S;
+
+            if (isNonPatchHasRedundantPersistent)
             {
                 // Add the count and asset. Mark the type as "RepairAssetType.Unused"
                 _progressAllCountFound++;
@@ -236,14 +238,18 @@ namespace CollapseLauncher
                     )
                 ));
 
-                // Fix the asset detected as a used file even though it's actually unused
-                asset.FT = FileType.Unused;
-                targetAssetIndex.Add(asset);
+                // Create a new instance as unused one
+                FilePropertiesRemote unusedAsset = new FilePropertiesRemote
+                {
+                    N = fileInfoPersistent.FullName,
+                    FT = FileType.Unused,
+                    RN = asset.RN,
+                    CRC = asset.CRC,
+                    S = asset.S
+                };
+                targetAssetIndex.Add(unusedAsset);
 
-                // Set the file to be used from Persistent one
-                UsePersistent = true;
-
-                LogWriteLine($"File [T: {asset.FT}]: {asset.N} is redundant (exist both on persistent and streaming)", LogType.Warning, true);
+                LogWriteLine($"File [T: {asset.FT}]: {unusedAsset.N} is redundant (exist both on persistent and streaming)", LogType.Warning, true);
             }
 
             // If the file has Hash Mark or is persistent, then create the hash mark file

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -31,7 +31,7 @@
         <DebugType>portable</DebugType>
         <GitVersion>false</GitVersion>
         <!-- AoT Configs -->
-		<PublishAot>true</PublishAot>
+		<PublishAot>false</PublishAot>
         <!-- WinUI Properties -->
         <UseWinUI>true</UseWinUI>
         <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -140,7 +140,7 @@
 		-->
         <PackageReference Include="Clowd.Squirrel" Version="2.11.1" Condition="!$(DefineConstants.Contains('USEVELOPACK'))" />
         <PackageReference Include="Libsql.Client" Version="0.5.0" />
-		<PackageReference Include="Velopack" Version="0.0.626" Condition="$(DefineConstants.Contains('USEVELOPACK'))" />
+		<PackageReference Include="Velopack" Version="0.0.869" Condition="$(DefineConstants.Contains('USEVELOPACK'))" />
 
         <PackageReference Include="CommunityToolkit.Common" Version="8.4.0-preview1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0-preview1" />
@@ -157,7 +157,7 @@
         -->
         <PackageReference Include="FFmpegInteropX" Version="*-*" Condition="$(DefineConstants.Contains('USEFFMPEGFORVIDEOBG'))" />
         
-        <PackageReference Include="GitInfo" Version="3.3.5" PrivateAssets="all" />
+        <PackageReference Include="GitInfo" Version="3.5.0" PrivateAssets="all" />
         <PackageReference Include="HtmlAgilityPack" Version="1.11.70" />
         <PackageReference Include="Markdig.Signed" Version="0.38.0" />
         <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.0" />

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -2000,38 +2000,56 @@ namespace CollapseLauncher
             }.Start();
         }
 
-        private void OpenGameFolder_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        private async void OpenGameFolder_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            if (!IsGameInstalled()) return;
-
-            string GameFolder = NormalizePath(GameDirPath);
-            LogWriteLine($"Opening Game Folder:\r\n\t{GameFolder}");
-            new Process()
+            try
             {
-                StartInfo = new ProcessStartInfo()
-                {
-                    UseShellExecute = true,
-                    FileName = "explorer.exe",
-                    Arguments = GameFolder
-                }
-            }.Start();
+                if (!IsGameInstalled()) return;
+
+                string GameFolder = NormalizePath(GameDirPath);
+                LogWriteLine($"Opening Game Folder:\r\n\t{GameFolder}");
+                await Task.Run(() =>
+                    new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            UseShellExecute = true,
+                            FileName = "explorer.exe",
+                            Arguments = GameFolder
+                        }
+                    }.Start());
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Failed when trying to open game folder!\r\n{ex}", LogType.Error, true);
+                ErrorSender.SendException(ex);
+            }
         }
 
-        private void OpenGameCacheFolder_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        private async void OpenGameCacheFolder_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            if (!IsGameInstalled()) return;
-
-            string GameFolder = CurrentGameProperty._GameVersion.GameDirAppDataPath;
-            LogWriteLine($"Opening Game Folder:\r\n\t{GameFolder}");
-            new Process()
+            try
             {
-                StartInfo = new ProcessStartInfo()
-                {
-                    UseShellExecute = true,
-                    FileName = "explorer.exe",
-                    Arguments = GameFolder
-                }
-            }.Start();
+                if (!IsGameInstalled()) return;
+
+                string GameFolder = CurrentGameProperty._GameVersion.GameDirAppDataPath;
+                LogWriteLine($"Opening Game Folder:\r\n\t{GameFolder}");
+                await Task.Run(() =>
+                    new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            UseShellExecute = true,
+                            FileName = "explorer.exe",
+                            Arguments = GameFolder
+                        }
+                    }.Start());
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Failed when trying to open game cache folder!\r\n{ex}", LogType.Error, true);
+                ErrorSender.SendException(ex);
+            }
         }
 
         private void ForceCloseGame_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/CachesPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/CachesPage.xaml
@@ -11,7 +11,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       CacheMode="BitmapCache"
       Loaded="InitializeLoaded"
-      NavigationCacheMode="Enabled"
+      NavigationCacheMode="Disabled"
       Unloaded="Page_Unloaded"
       mc:Ignorable="d">
     <Grid>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/GenshinGameSettingsPage.xaml
@@ -14,7 +14,7 @@
       xmlns:xaml="using:Microsoft.Graphics.Canvas.UI.Xaml"
       CacheMode="BitmapCache"
       Loaded="InitializeSettings"
-      NavigationCacheMode="Enabled"
+      NavigationCacheMode="Disabled"
       Unloaded="OnUnload"
       mc:Ignorable="d">
     <Page.Resources>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/HonkaiGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/HonkaiGameSettingsPage.xaml
@@ -10,7 +10,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       CacheMode="BitmapCache"
       Loaded="InitializeSettings"
-      NavigationCacheMode="Enabled"
+      NavigationCacheMode="Disabled"
       Unloaded="OnUnload"
       mc:Ignorable="d">
     <Page.Resources>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/StarRailGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/StarRailGameSettingsPage.xaml
@@ -11,7 +11,7 @@
       xmlns:static="using:CollapseLauncher.GameSettings.StarRail"
       CacheMode="BitmapCache"
       Loaded="InitializeSettings"
-      NavigationCacheMode="Enabled"
+      NavigationCacheMode="Disabled"
       Unloaded="OnUnload"
       mc:Ignorable="d">
     <Page.Resources>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.Ext.cs
@@ -48,6 +48,7 @@ namespace CollapseLauncher.Pages
                     BloomToggle.IsChecked                    = true;
                     DistortionToggle.IsChecked               = true;
                     MotionBlurToggle.IsChecked               = true;
+                    HPCAToggle.IsChecked                     = true;
                     break;
                 case GraphicsPresetOption.Medium:
                     VSyncToggle.IsChecked                    = true;
@@ -64,6 +65,7 @@ namespace CollapseLauncher.Pages
                     BloomToggle.IsChecked                    = true;
                     DistortionToggle.IsChecked               = true;
                     MotionBlurToggle.IsChecked               = true;
+                    HPCAToggle.IsChecked                     = false;
                     break;
                 case GraphicsPresetOption.Low:
                     VSyncToggle.IsChecked                    = true;
@@ -80,6 +82,7 @@ namespace CollapseLauncher.Pages
                     BloomToggle.IsChecked                    = true;
                     DistortionToggle.IsChecked               = true;
                     MotionBlurToggle.IsChecked               = true;
+                    HPCAToggle.IsChecked                     = false;
                     break;
             }
 
@@ -545,6 +548,13 @@ namespace CollapseLauncher.Pages
         {
             get => (int)Settings.GeneralData.Fps;
             set => Settings.GeneralData.Fps = (FpsOption)value;
+        }
+
+        /// <inheritdoc cref="CollapseLauncher.GameSettings.Zenless.GeneralData.HiPrecisionCharaAnim"/>
+        public bool Graphics_HiPreCharaAnim
+        {
+            get => Settings.GeneralData.HiPrecisionCharaAnim;
+            set => Settings.GeneralData.HiPrecisionCharaAnim = value;
         }
         #endregion
 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
@@ -500,6 +500,7 @@
                                     <ColumnDefinition />
                                     <ColumnDefinition />
                                     <ColumnDefinition />
+                                    <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
                                 <StackPanel Grid.Column="0"
                                             VerticalAlignment="Center">
@@ -534,6 +535,19 @@
                                               IsChecked="{x:Bind Graphics_MotionBlur, Mode=TwoWay}"
                                               Unchecked="EnforceCustomPreset_Checkbox">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_MotionBlur}"
+                                                   TextWrapping="Wrap" />
+                                    </CheckBox>
+                                </StackPanel>
+                                <StackPanel Grid.Column="3"
+                                            VerticalAlignment="Center">
+                                    <!-- ReSharper disable once InconsistentNaming -->
+                                    <CheckBox x:Name="HPCAToggle"
+                                              HorizontalAlignment="Left"
+                                              VerticalAlignment="Center"
+                                              Checked="EnforceCustomPreset_Checkbox"
+                                              IsChecked="{x:Bind Graphics_HiPreCharaAnim, Mode=TwoWay}"
+                                              Unchecked="EnforceCustomPreset_Checkbox">
+                                        <TextBlock Text="{x:Bind helper:Locale.Lang._ZenlessGameSettingsPage.Graphics_HighPrecisionCharacterAnimation}"
                                                    TextWrapping="Wrap" />
                                     </CheckBox>
                                 </StackPanel>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
@@ -13,7 +13,7 @@
       xmlns:static="using:CollapseLauncher.GameSettings.Zenless"
       CacheMode="BitmapCache"
       Loaded="InitializeSettings"
-      NavigationCacheMode="Enabled"
+      NavigationCacheMode="Disabled"
       Unloaded="OnUnload"
       mc:Ignorable="d">
     <Page.Resources>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -2199,37 +2199,56 @@ namespace CollapseLauncher.Pages
         #endregion
 
         #region Open Button Method
-        private void OpenGameFolderButton_Click(object sender, RoutedEventArgs e)
+        private async void OpenGameFolderButton_Click(object sender, RoutedEventArgs e)
         {
-            string GameFolder = NormalizePath(GameDirPath);
-            LogWriteLine($"Opening Game Folder:\r\n\t{GameFolder}");
-            new Process()
+            try
             {
-                StartInfo = new ProcessStartInfo()
-                {
-                    UseShellExecute = true,
-                    FileName = "explorer.exe",
-                    Arguments = GameFolder
-                }
-            }.Start();
+                string gameFolder = NormalizePath(GameDirPath);
+                LogWriteLine($"Opening Game Folder:\r\n\t{gameFolder}");
+
+                await Task.Run(() =>
+                    new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            UseShellExecute = true,
+                            FileName = "explorer.exe",
+                            Arguments = gameFolder
+                        }
+                    }.Start());
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Failed when trying to open game folder!\r\n{ex}", LogType.Error, true);
+                ErrorSender.SendException(ex);
+            }
         }
 
-        private void OpenCacheFolderButton_Click(object sender, RoutedEventArgs e)
+        private async void OpenCacheFolderButton_Click(object sender, RoutedEventArgs e)
         {
-            string GameFolder = CurrentGameProperty._GameVersion.GameDirAppDataPath;
-            LogWriteLine($"Opening Game Folder:\r\n\t{GameFolder}");
-            new Process()
+            string cacheFolder = CurrentGameProperty._GameVersion.GameDirAppDataPath;
+            LogWriteLine($"Opening Game Folder:\r\n\t{cacheFolder}");
+            try
             {
-                StartInfo = new ProcessStartInfo()
-                {
-                    UseShellExecute = true,
-                    FileName = "explorer.exe",
-                    Arguments = GameFolder
-                }
-            }.Start();
+                await Task.Run(() =>
+                    new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            UseShellExecute = true,
+                            FileName = "explorer.exe",
+                            Arguments = cacheFolder
+                        }
+                    }.Start());
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Failed when trying to open game cache folder!\r\n{ex}", LogType.Error, true);
+                ErrorSender.SendException(ex);
+            }
         }
 
-        private void OpenScreenshotFolderButton_Click(object sender, RoutedEventArgs e)
+        private async void OpenScreenshotFolderButton_Click(object sender, RoutedEventArgs e)
         {
             string ScreenshotFolder = Path.Combine(NormalizePath(GameDirPath), CurrentGameProperty._GameVersion.GamePreset.GameType switch
             {
@@ -2242,15 +2261,24 @@ namespace CollapseLauncher.Pages
             if (!Directory.Exists(ScreenshotFolder))
                 Directory.CreateDirectory(ScreenshotFolder);
 
-            new Process()
+            try
             {
-                StartInfo = new ProcessStartInfo()
-                {
-                    UseShellExecute = true,
-                    FileName = "explorer.exe",
-                    Arguments = ScreenshotFolder
-                }
-            }.Start();
+                await Task.Run(() => 
+                    new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            UseShellExecute = true,
+                            FileName = "explorer.exe",
+                            Arguments = ScreenshotFolder
+                        }
+                    }.Start());
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Failed when trying to open game screenshot folder!\r\n{ex}", LogType.Error, true);
+                ErrorSender.SendException(ex);
+            }
         }
 
         private async void CleanupFilesButton_Click(object sender, RoutedEventArgs e)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/RepairPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/RepairPage.xaml
@@ -14,7 +14,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       CacheMode="BitmapCache"
       Loaded="InitializeLoaded"
-      NavigationCacheMode="Enabled"
+      NavigationCacheMode="Disabled"
       Unloaded="Page_Unloaded"
       mc:Ignorable="d">
     <Grid>

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -111,12 +111,6 @@
         "resolved": "0.38.0",
         "contentHash": "zfi6kNm5QJnsCGm5a0hMG2qw8juYbOfsS4c1OuTcqkbYQUCdkam6d6Nt7nPIrbV4D+U7sHChidSQlg+ViiMPuw=="
       },
-      "Microsoft.DotNet.ILCompiler": {
-        "type": "Direct",
-        "requested": "[9.0.0-rc.2.24473.5, )",
-        "resolved": "9.0.0-rc.2.24473.5",
-        "contentHash": "+4KH+fbuWXX+I1nM+iP84N0nnorwxY3N8SrNLDNdWdblCPcWXSZnnst/IS+NEHTavnoTErwFNwk7IP8rPrNAQA=="
-      },
       "Microsoft.Graphics.Win2D": {
         "type": "Direct",
         "requested": "[1.3.0, )",
@@ -479,15 +473,6 @@
         "requested": "[0.5.0, )",
         "resolved": "0.5.0",
         "contentHash": "5Tw6O9sBDAN1aV+kpOSVvqvFk6Ahk6bYz0TTx3808Dp40M45gKTtzTzI9SS1VeAkljE6BAOeKaykpPnG36oOgw=="
-      },
-      "Microsoft.DotNet.ILCompiler": {
-        "type": "Direct",
-        "requested": "[9.0.0-rc.2.24473.5, )",
-        "resolved": "9.0.0-rc.2.24473.5",
-        "contentHash": "+4KH+fbuWXX+I1nM+iP84N0nnorwxY3N8SrNLDNdWdblCPcWXSZnnst/IS+NEHTavnoTErwFNwk7IP8rPrNAQA==",
-        "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "9.0.0-rc.2.24473.5"
-        }
       },
       "Microsoft.Graphics.Win2D": {
         "type": "Direct",

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -86,11 +86,11 @@
       },
       "GitInfo": {
         "type": "Direct",
-        "requested": "[3.3.5, )",
-        "resolved": "3.3.5",
-        "contentHash": "xt8tAMq42KompgmZI5fpko9IY9cuGqjvNFCc+B6iZeoCHlqcbuGZz33SFD+jTsPZTFfrxqTXvywm/s8DcFcEIg==",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "w7pFvv7PutCdK126BSq9O+wXfiyXQ68c2BeZnd9AHAbkV+IlTCF47LCZHNCqNchWMEv+GBbWGHCcGzZT411tIw==",
         "dependencies": {
-          "ThisAssembly.Constants": "1.4.1"
+          "ThisAssembly.Constants": "2.0.6"
         }
       },
       "HtmlAgilityPack": {
@@ -262,12 +262,12 @@
       },
       "Velopack": {
         "type": "Direct",
-        "requested": "[0.0.626, )",
-        "resolved": "0.0.626",
-        "contentHash": "el6qqNyJM3GA11j6SFZgcQJ/AFg7ocQQSu+Tk/+OIzejZlROGLK+RDWPb4tcp9E9ug9aT4HV0m35zISMSC++/Q==",
+        "requested": "[0.0.869, )",
+        "resolved": "0.0.869",
+        "contentHash": "oGk+2xphxXDm2rsj4z5JTOnfE7CydgEmsbadubkJOUAbLcaAnuLZQF+3EgVZEiuEFLgtdtl7BBhZ8GrDs41l1g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "NuGet.Versioning": "6.10.1"
+          "NuGet.Versioning": "6.11.1"
         }
       },
       "CommunityToolkit.WinUI.Animations": {
@@ -335,8 +335,8 @@
       },
       "NuGet.Versioning": {
         "type": "Transitive",
-        "resolved": "6.10.1",
-        "contentHash": "tovHZ3OlMVmsTdhv2z5nwnnhoA1ryhfJMyVQ9/+iv6d3h78fp230XaGy3K/iVcLwB50DdfNfIsitW97KSOWDFg=="
+        "resolved": "6.11.1",
+        "contentHash": "YNn3BB71F+guJW42TbAhGcMh3gpyqFMZcPVD9pm5vcvGivTALtRely/VCPWQQ6JQ5PfwIrjPaJMO7VnqyeK3rg=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -358,8 +358,8 @@
       },
       "ThisAssembly.Constants": {
         "type": "Transitive",
-        "resolved": "1.4.1",
-        "contentHash": "sV0CDYlC6YSIkYbdwd4+jRinLb888Dac71pmNhF2Ll6UXY1J+1oVt3EfmX6euXEKz2RLdfV+4GyZctfEA0NSqA==",
+        "resolved": "2.0.6",
+        "contentHash": "XF1RWxkEx+xvSRZOpkLF0rrclMsjKYkO+j7UoCk+ebSzKcxoIye7Na4HvkmIJogNoB+vZqSz7df5McxgzZHtbg==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Threading.Tasks.Extensions": "4.5.4"

--- a/Hi3Helper.Core/Lang/Locale/LangZenlessGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangZenlessGameSettingsPage.cs
@@ -28,6 +28,9 @@ namespace Hi3Helper
                 public string Graphics_Distortion { get; set; } =
                     LangFallback?._ZenlessGameSettingsPage.Graphics_Distortion;
 
+                public string Graphics_HighPrecisionCharacterAnimation { get; set; } =
+                    LangFallback?._ZenlessGameSettingsPage.Graphics_HighPrecisionCharacterAnimation;
+
                 public string Audio_PlaybackDev { get; set; } =
                     LangFallback?._ZenlessGameSettingsPage.Audio_PlaybackDev;
                 

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -1506,6 +1506,7 @@
     "Graphics_EffectsQ": "Effects Quality",
     "Graphics_ShadingQ": "Shading Quality",
     "Graphics_Distortion": "Distortion",
+    "Graphics_HighPrecisionCharacterAnimation": "High-Precision Character Animation",
     "Audio_PlaybackDev": "Audio Playback Device",
     "Audio_PlaybackDev_Headphones": "Headphones",
     "Audio_PlaybackDev_Speakers": "Speakers",

--- a/Hi3Helper.Core/Lang/id_ID.json
+++ b/Hi3Helper.Core/Lang/id_ID.json
@@ -157,6 +157,7 @@
     "GameSettings_Panel4ShowEventsPanel": "Munculkan Panel Event",
     "GameSettings_Panel4ShowSocialMediaPanel": "Munculkan Panel Sosmed",
     "GameSettings_Panel4ShowPlaytimeButton": "Munculkan Tombol \"Waktu Main\"",
+    "GameSettings_Panel4SyncPlaytimeDatabase": "Sinkronisasi Waktu Mulai dengan Database",
     "GameSettings_Panel4CreateShortcutBtn": "Buat pintasan",
     "GameSettings_Panel4AddToSteamBtn": "Tambahkan ke Steam",
 
@@ -165,6 +166,7 @@
     "GamePlaytime_Idle_Panel1Minutes": "Menit",
     "GamePlaytime_Idle_ResetBtn": "Atur Ulang",
     "GamePlaytime_Idle_ChangeBtn": "Ubah",
+    "GamePlaytime_Idle_SyncDb": "Sinkronkan",
     "GamePlaytime_Running_Info1": "Game ini sedang berjalan, maka dari itu waktu main tidak dapat diubah.",
     "GamePlaytime_Running_Info2": "Perlu diingat bahwa menutup Collapse Launcher akan menghentikan penghitungan waktu main (selama game dimainkan dari awal sampai akhir).",
     "GamePlaytime_Display": "{0}j {1}m",
@@ -635,7 +637,25 @@
     "FileDownloadSettings_BurstDownloadHelp4": "berjalan secara bersamaan sehingga proses unduhan berjalan lebih cepat dan efisien.",
     "FileDownloadSettings_BurstDownloadHelp5": "Ketika dimatikan, proses unduhan pada",
     "FileDownloadSettings_BurstDownloadHelp6": "dan",
-    "FileDownloadSettings_BurstDownloadHelp7": "akan berjalan satu-per-satu."
+    "FileDownloadSettings_BurstDownloadHelp7": "akan berjalan satu-per-satu.",
+
+    "Database_Title": "Sinkronisasi Database Pengguna",
+    "Database_ConnectionOk": "Database berhasil terhubung!",
+    "Database_ConnectFail": "Gagal menghubungi database, periksa error di bawah ini:",
+    "Database_Toggle": "Gunakan Database Online",
+    "Database_Url": "URL Database",
+    "Database_Url_Example": "Contoh: https://db-collapse.turso.io",
+    "Database_Token": "Token",
+    "Database_UserId": "ID Pengguna",
+    "Database_GenerateGuid": "Hasilkan UID",
+    "Database_Validate": "Validasi & Simpan Pengaturan",
+    "Database_Error_EmptyUri": "URL Database tidak boleh kosong!",
+    "Database_Error_EmptyToken": "Token Database tidak boleh kosong!",
+    "Database_Error_InvalidGuid": "GUID pada User ID tidak valid!",
+    "Database_Warning_PropertyChanged": "Pengaturan Database telah berubah",
+    "Database_ValidationChecking": "Validasi Pengaturan...",
+    "Database_Placeholder_DbUserIdTextBox": "Contoh GUID: ed6e8048-e3a0-4983-bd56-ad19956c701f",
+    "Database_Placeholder_DbTokenPasswordBox": "Masukkan token autentikasimu di sini"
   },
 
   "_Misc": {
@@ -655,6 +675,7 @@
     "PerFromTo": "{0} / {1}",
     "PerFromToPlaceholder": "- / -",
 
+    "EverythingIsOkay": "Semuanya Berhasil!",
     "Cancel": "Batal",
     "Close": "Tutup",
     "UseCurrentDir": "Pakai lokasi saat ini",
@@ -892,6 +913,22 @@
 
     "CannotUseAppLocationForGameDirTitle": "Folder tidak valid!",
     "CannotUseAppLocationForGameDirSubtitle": "Anda tidak dapat menggunakan folder ini karena digunakan sebagai folder sistem atau digunakan sebagai folder utama dari executable aplikasi ini. Mohon untuk gunakan folder lainnya!",
+    "InvalidGameDirNewTitleFormat": "Path tidak valid: {0}",
+    "InvalidGameDirNewSubtitleSelectedPath": "Path Terpilih: ",
+    "InvalidGameDirNewSubtitleSelectOther": "Mohon pilih lokasi/folder lainnya!",
+    "InvalidGameDirNew1Title": "Folder tidak valid!",
+    "InvalidGameDirNew1Subtitle": "Kamu tidak bisa menggunakan folder ini karena folder ini digunakan oleh system ataupun digunakan oleh aplikasi ini. Silahkan pilih folder lainnya!",
+    "InvalidGameDirNew2Title": "Tidak dapat mengakses folder yang dipilih",
+    "InvalidGameDirNew2Subtitle": "Launcher tidak memiliki izin untuk mengakses folder ini!",
+    "InvalidGameDirNew3Title": "Tidak dapat memilih root drive",
+    "InvalidGameDirNew3Subtitle": "Kamu memilih path pada root drive. Kamu tidak bisa memilih path ini!",
+    "InvalidGameDirNew4Title": "Tidak dapat memilih folder Windows",
+    "InvalidGameDirNew4Subtitle": "Kamu tidak dapat menggunakan folder Windows sebagai lokasi pemasangan Game, hal ini untuk mencegah hal yang tidak diinginkan terjadi.",
+    "InvalidGameDirNew5Title": "Tidak dapat memilih folder Program Data",
+    "InvalidGameDirNew5Subtitle": "Kamu tidak dapat menggunakan folder Program Data sebagai lokasi pemasangan Game, hal ini untuk mencegah hal yang diinginkan terjadi.",
+    "InvalidGameDirNew6Title": "Tidak dapat memilih folder Program Files atau Program Files (x86)",
+    "InvalidGameDirNew6Subtitle": "Kamu tidak dapat menggunakan folder Program Files atau Program Files (x86) sebagai lokasi pemasangan Game, hal ini untuk mencegah hal yang diinginkan terjadi.",
+    "FolderDialogTitle1": "Pilih Lokasi Pemsangan Game",
 
     "StopGameTitle": "Tutup Paksa Game",
     "StopGameSubtitle": "Apakah anda yakin ingin menutup game yang sedang berjalan?\nAnda akan kehilangan progress di dalam game.",
@@ -946,7 +983,10 @@
     "DownloadSettingsOption1": "Mulai game setelah proses pemasangan",
 
     "OpenInExternalBrowser": "Buka di Browser Eksternal",
-    "CloseOverlay": "Tutup Overlay"
+    "CloseOverlay": "Tutup Overlay",
+
+    "DbGenerateUid_Title": "Apakah kamu yakin ingin mengubah ID User-mu?",
+    "DbGenerateUid_Content": "Mengubah User ID-mu dapat menyebabkan kehilangan data yang sudah tersimpan."
   },
 
   "_FileMigrationProcess": {
@@ -1466,6 +1506,7 @@
     "Graphics_EffectsQ": "Kualitas Efek",
     "Graphics_ShadingQ": "Kualitas Shading",
     "Graphics_Distortion": "Distorsi",
+    "Graphics_HighPrecisionCharacterAnimation": "Animasi Akurasi Tinggi pada Karakter",
     "Audio_PlaybackDev": "Perangkat Pemutaran Suara",
     "Audio_PlaybackDev_Headphones": "Headphone",
     "Audio_PlaybackDev_Speakers": "Speaker",

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -638,7 +638,7 @@
     "FileDownloadSettings_BurstDownloadHelp5": "禁用后，",
     "FileDownloadSettings_BurstDownloadHelp6": "与",
     "FileDownloadSettings_BurstDownloadHelp7": "功能的下载过程将会按顺序下载。",
-    
+
     "Database_Title": "用户同步数据库",
     "Database_ConnectionOk": "数据库连接成功！",
     "Database_ConnectFail": "连接数据库失败，请参阅下面的错误：",
@@ -650,7 +650,12 @@
     "Database_GenerateGuid": "生成 UID",
     "Database_Validate": "验证并保存设置",
     "Database_Error_EmptyUri": "数据库 URL 不能为空！",
-    "Database_Error_EmptyToken": "数据库令牌不能为空！"
+    "Database_Error_EmptyToken": "数据库令牌不能为空！",
+    "Database_Error_InvalidGuid": "用户 ID 不是有效的 GUID！",
+    "Database_Warning_PropertyChanged": "数据库设置已更改",
+    "Database_ValidationChecking": "验证设置中……",
+    "Database_Placeholder_DbUserIdTextBox": "GUID 示例：ed6e8048-e3a0-4983-bd56-ad19956c701f",
+    "Database_Placeholder_DbTokenPasswordBox": "在这里输入您的身份验证令牌"
   },
 
   "_Misc": {
@@ -908,6 +913,22 @@
 
     "CannotUseAppLocationForGameDirTitle": "文件夹无效！",
     "CannotUseAppLocationForGameDirSubtitle": "您无法使用此文件夹，因为它已被用作系统文件夹或被用于存放应用程序的主执行文件。请选择其他文件夹！",
+    "InvalidGameDirNewTitleFormat": "路径无效：{0}",
+    "InvalidGameDirNewSubtitleSelectedPath": "选择的路径：",
+    "InvalidGameDirNewSubtitleSelectOther": "请选择另一个文件夹/位置！",
+    "InvalidGameDirNew1Title": "文件夹无效！",
+    "InvalidGameDirNew1Subtitle": "您不能使用此文件夹，因为它被用作系统文件夹或应用程序的主执行文件。请选择其他文件夹！",
+    "InvalidGameDirNew2Title": "无法访问所选文件夹",
+    "InvalidGameDirNew2Subtitle": "启动器没有访问此文件夹的权限！",
+    "InvalidGameDirNew3Title": "无法选择驱动器根目录",
+    "InvalidGameDirNew3Subtitle": "您选择了驱动器的根目录，这是禁止的！",
+    "InvalidGameDirNew4Title": "无法选择 Windows 文件夹",
+    "InvalidGameDirNew4Subtitle": "您不能使用 Windows 文件夹作为游戏安装位置，以免发生任何不必要的情况。",
+    "InvalidGameDirNew5Title": "无法选择 Program Data 文件夹",
+    "InvalidGameDirNew5Subtitle": "您不能使用 Program Data 文件夹作为游戏安装位置，以免发生任何不必要的情况。",
+    "InvalidGameDirNew6Title": "无法选择 Program Files 或 Program Files (x86) 文件夹",
+    "InvalidGameDirNew6Subtitle": "您不能使用 Program Files 或 Program Files (x86) 文件夹作为游戏安装位置，以免发生任何不必要的情况。",
+    "FolderDialogTitle1": "选择游戏安装位置",
 
     "StopGameTitle": "强制停止游戏",
     "StopGameSubtitle": "您确定要强制中止当前正在运行的游戏吗？\n您的游戏进度可能会丢失。",
@@ -963,7 +984,7 @@
 
     "OpenInExternalBrowser": "在外部浏览器中打开",
     "CloseOverlay": "关闭",
-    
+
     "DbGenerateUid_Title": "您确定要更改用户 ID 吗？",
     "DbGenerateUid_Content": "更改用户 ID 后，如果遗失了用户 ID，与之相关的数据将会丢失。"
   },

--- a/Hi3Helper.TaskScheduler/Hi3Helper.TaskScheduler.csproj
+++ b/Hi3Helper.TaskScheduler/Hi3Helper.TaskScheduler.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="TaskScheduler" Version="2.11.0" />
-    <PackageReference Include="Velopack" Version="0.0.626" />
+    <PackageReference Include="Velopack" Version="0.0.869" />
   </ItemGroup>
 
 </Project>

--- a/Hi3Helper.TaskScheduler/packages.lock.json
+++ b/Hi3Helper.TaskScheduler/packages.lock.json
@@ -50,13 +50,13 @@
       },
       "Velopack": {
         "type": "Direct",
-        "requested": "[0.0.626, )",
-        "resolved": "0.0.626",
-        "contentHash": "el6qqNyJM3GA11j6SFZgcQJ/AFg7ocQQSu+Tk/+OIzejZlROGLK+RDWPb4tcp9E9ug9aT4HV0m35zISMSC++/Q==",
+        "requested": "[0.0.869, )",
+        "resolved": "0.0.869",
+        "contentHash": "oGk+2xphxXDm2rsj4z5JTOnfE7CydgEmsbadubkJOUAbLcaAnuLZQF+3EgVZEiuEFLgtdtl7BBhZ8GrDs41l1g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.1",
-          "NuGet.Versioning": "6.10.1"
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Versioning": "6.11.1"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -132,13 +132,13 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "NuGet.Versioning": {
         "type": "Transitive",
-        "resolved": "6.10.1",
-        "contentHash": "tovHZ3OlMVmsTdhv2z5nwnnhoA1ryhfJMyVQ9/+iv6d3h78fp230XaGy3K/iVcLwB50DdfNfIsitW97KSOWDFg=="
+        "resolved": "6.11.1",
+        "contentHash": "YNn3BB71F+guJW42TbAhGcMh3gpyqFMZcPVD9pm5vcvGivTALtRely/VCPWQQ6JQ5PfwIrjPaJMO7VnqyeK3rg=="
       },
       "System.AppContext": {
         "type": "Transitive",

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 [<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.80.19/CL-1.80.19-stable_Installer.exe)
 > **Note**: The version for this build is `1.80.19` (Released on: August 13rd, 2024).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.81.6-pre/CL-1.81.6-preview_Installer.exe)
-> **Note**: The version for this build is `1.81.6` (Released on: September 16th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.0-pre/CL-1.82-preview_Installer.exe)
+> **Note**: The version for this build is `1.82.0` (Released on: November 2nd, 2024).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ for:
         
         dotnet restore
         
-        dotnet publish CollapseLauncher -c Release -p:PublishProfile=Publish-PreviewReleaseAOT -p:PublishDir=".\preview-build\"
+        dotnet publish CollapseLauncher -c Release -p:PublishProfile=Publish-PreviewRelease -p:PublishDir=".\preview-build\"
         
         
         echo Getting app version...
@@ -127,7 +127,7 @@ for:
 
     deploy:
     - provider: Webhook
-      url: https://app.signpath.io/API/v1/6988fc60-19f4-4710-8eb7-e837c60c83b4/Integrations/AppVeyor?ProjectSlug=Collapse&SigningPolicySlug=release-signing&ArtifactConfigurationSlug=aot-release
+      url: https://app.signpath.io/API/v1/6988fc60-19f4-4710-8eb7-e837c60c83b4/Integrations/AppVeyor?ProjectSlug=Collapse&SigningPolicySlug=release-signing&ArtifactConfigurationSlug=preview
       authorization:
         secure: B8zpDU6wkKuCBRz65VfTFxUCxY7HniWmRbJP/E3tE40kGmHKdaFnMCDSURQFWwR1pCcXHqbkJd3YX76tnTXQow==
       on:


### PR DESCRIPTION
# What's New? - 1.82.1
- **[Fix]** Revert NativeAOT publishing and use regular trimmed builds instead, by @bagusnl 
  - This due to several reports about freezing and memory leaks. We will try to evaluate this kind of builds more in the future once .NET 9 is fully released.
- **[Imp]** Add new settings for Zenless Zone Zero, by @bagusnl 
  - The setting in English is called "High-Precision Character Animation" but in Indonesian its roughly translated as "Dynamic Character Resolution". I honestly don't know what they are doing LMAO
- **[Fix]** Adjusted Star Rail game repair mechanism, by @neon-nyan 
- **[Fix]** Sophon pre-download showing the wrong size, by @neon-nyan 
- **[Fix]** Plugin update launch errors, by @bagusnl 
- **[Fix]** NullReferenceException when checking for launcher update when it's on the latest, by @bagusnl 
- **[Imp]** Use async when opening folders from buttons, by @bagusnl 
  - Reduces time that the launcher UI freezes when Windows Explorer is taking its time to open
- **[Imp]** Add "Updating" status for Discord RPC that is raised when installing/updating game, by @bagusnl 
- **[Fix]** Disable page caching for Repair, Cache Update, and Game Settings Pages, by @neon-nyan 
  - This fixes behaviour where those pages are stuck in certain state and F5 does not work.

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
