### PR TITLE
[Urgent] Preview 1.82.7 Hotfix Release

### DIFF
--- a/CollapseLauncher/Classes/Helper/Database/DBConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Database/DBConfig.cs
@@ -17,7 +17,7 @@ namespace CollapseLauncher.Helper.Database
         private const string _configFileName = "dbConfig.ini";
         private const string DbSectionName   = "database";
 
-        private static readonly string  _configPath = Path.Combine(_configFolder, _configFileName);
+        private static readonly string _configPath = Path.Combine(_configFolder, _configFileName);
 
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private static IniFile _config = new();
@@ -32,7 +32,7 @@ namespace CollapseLauncher.Helper.Database
 
             DefaultChecker();
         }
-        
+
         private static void EnsureConfigExist()
         {
             if (File.Exists(_configPath)) return;
@@ -53,7 +53,14 @@ namespace CollapseLauncher.Helper.Database
             }
         }
 
-        private static void Load(CancellationToken token = default) => _config.Load(_configPath);
+        private static void Load(CancellationToken token = default)
+        {
+            if (File.Exists(_configPath))
+            {
+                _config.Load(_configPath);
+            }
+        }
+
         private static void Save(CancellationToken token = default) => _config.Save(_configPath);
         
         public static IniValue GetConfig(string key) => _config[DbSectionName][key];

--- a/CollapseLauncher/Classes/Helper/TaskSchedulerHelper.cs
+++ b/CollapseLauncher/Classes/Helper/TaskSchedulerHelper.cs
@@ -215,7 +215,7 @@ namespace CollapseLauncher.Helper
             appProductName = currentExecVersionInfo.ProductName;
             string shortcutFilename = appProductName + ".lnk";
             string startMenuLocation = Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu);
-            string desktopLocation = Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory);
+            string desktopLocation = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
             string iconLocationStartMenu = Path.Combine(
                 startMenuLocation,
                 "Programs",

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -16,7 +16,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.82.6</Version>
+        <Version>1.82.7</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>

--- a/CollapseLauncher/XAMLs/Invoker/Classes/Migrate.cs
+++ b/CollapseLauncher/XAMLs/Invoker/Classes/Migrate.cs
@@ -98,9 +98,11 @@ namespace CollapseLauncher
 
             IniFile iniFile = new IniFile();
 
-            if (File.Exists(Path.Combine(source, "config.ini")))
+            string configFilePath = Path.Combine(source, "config.ini");
+
+            if (File.Exists(configFilePath))
             {
-                iniFile.Load(Path.Combine(source, "config.ini"));
+                iniFile.Load(configFilePath, true);
                 sourceGame = ConverterTool.NormalizePath(iniFile["launcher"]["game_install_path"].ToString());
                 targetGame = Path.Combine(target, Path.GetFileName(sourceGame));
                 Console.WriteLine($"Moving From:\r\n\t{source}\r\nTo Destination:\r\n\t{target}");

--- a/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
+++ b/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
@@ -95,7 +95,7 @@ namespace Hi3Helper.Shared.Region
         }
         public static void SetAppConfigValue(string key, IniValue value) => appIni.Profile![SectionName]![key!] = value;
 
-        public static void LoadAppConfig() => appIni.Profile!.Load(appIni.ProfilePath);
+        public static void LoadAppConfig() => appIni.Profile!.Load(appIni.ProfilePath, true);
         public static void SaveAppConfig() => appIni.Profile!.Save(appIni.ProfilePath);
 
         public static void CheckAndSetDefaultConfigValue()

--- a/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
+++ b/Hi3Helper.Core/Classes/Shared/Region/LauncherConfig.cs
@@ -102,7 +102,7 @@ namespace Hi3Helper.Shared.Region
         {
             foreach (KeyValuePair<string, IniValue> Entry in AppSettingsTemplate!)
             {
-                if (!appIni.Profile![SectionName]!.ContainsKey(Entry.Key!) || string.IsNullOrEmpty(appIni.Profile[SectionName][Entry.Key]))
+                if (!appIni.Profile![SectionName]!.ContainsKey(Entry.Key!) || appIni.Profile[SectionName][Entry.Key].IsEmpty)
                 {
                     SetAppConfigValue(Entry.Key, Entry.Value);
                 }
@@ -111,7 +111,7 @@ namespace Hi3Helper.Shared.Region
         #endregion
 
         #region Misc Methods
-        public static void LoadGamePreset() => AppGameFolder = Path.Combine(GetAppConfigValue("GameFolder").ToString()!);
+        public static void LoadGamePreset() => AppGameFolder = Path.Combine(GetAppConfigValue("GameFolder")!);
 
         public static void GetScreenResolutionString(ScreenProp screenProp)
         {
@@ -161,7 +161,7 @@ namespace Hi3Helper.Shared.Region
               },
           };
 
-        public static CDNURLProperty GetCurrentCDN() => CDNList![GetAppConfigValue("CurrentCDN").ToInt()];
+        public static CDNURLProperty GetCurrentCDN() => CDNList![GetAppConfigValue("CurrentCDN")];
         #endregion
 
         #region Misc Fields
@@ -202,7 +202,7 @@ namespace Hi3Helper.Shared.Region
         public static string AppImagesFolder = Path.Combine(AppFolder, "Assets", "Images");
         public static string AppGameFolder
         {
-            get => GetAppConfigValue("GameFolder").ToString();
+            get => GetAppConfigValue("GameFolder");
             set => SetAppConfigValue("GameFolder", value);
         }
         public static string[] AppCurrentArgument;
@@ -262,11 +262,11 @@ namespace Hi3Helper.Shared.Region
         {
             get
             {
-                int val = GetAppConfigValue("ExtractionThread").ToInt();
+                int val = GetAppConfigValue("ExtractionThread");
                 return val <= 0 ? Environment.ProcessorCount : val;
             }
         }
-        public static int AppCurrentDownloadThread => GetAppConfigValue("DownloadThread").ToInt();
+        public static int AppCurrentDownloadThread => GetAppConfigValue("DownloadThread");
         public static string AppGameConfigMetadataFolder { get => Path.Combine(AppGameFolder!, "_metadatav3"); }
 
         public static readonly bool IsAppLangNeedRestart    = false;
@@ -278,55 +278,55 @@ namespace Hi3Helper.Shared.Region
         public static bool IsFirstInstall                   = false;
         public static bool IsConsoleEnabled
         {
-            get => GetAppConfigValue("EnableConsole").ToBoolNullable() ?? false;
+            get => GetAppConfigValue("EnableConsole");
             set => SetAppConfigValue("EnableConsole", value);
         }
 
         public static bool IsMultipleInstanceEnabled
         {
-            get => GetAppConfigValue("EnableMultipleInstance").ToBoolNullable() ?? false;
+            get => GetAppConfigValue("EnableMultipleInstance");
             set => SetAndSaveConfigValue("EnableMultipleInstance", value);
         }
 
         public static bool IsShowRegionChangeWarning
         {
-            get => GetAppConfigValue("ShowRegionChangeWarning").ToBool();
+            get => GetAppConfigValue("ShowRegionChangeWarning");
             set => SetAndSaveConfigValue("ShowRegionChangeWarning", value);
         }
 
         public static bool EnableAcrylicEffect
         {
-            get => GetAppConfigValue("EnableAcrylicEffect").ToBoolNullable() ?? false;
+            get => GetAppConfigValue("EnableAcrylicEffect");
             set => SetAndSaveConfigValue("EnableAcrylicEffect", value);
         }
 
         public static bool IsUseVideoBGDynamicColorUpdate
         {
-            get => GetAppConfigValue("IsUseVideoBGDynamicColorUpdate").ToBoolNullable() ?? false;
+            get => GetAppConfigValue("IsUseVideoBGDynamicColorUpdate");
             set => SetAndSaveConfigValue("IsUseVideoBGDynamicColorUpdate", value);
         }
 
         public static bool IsIntroEnabled
         {
-            get => GetAppConfigValue("IsIntroEnabled").ToBoolNullable() ?? true;
+            get => GetAppConfigValue("IsIntroEnabled");
             set => SetAndSaveConfigValue("IsIntroEnabled", value);
         }
 
         public static bool IsBurstDownloadModeEnabled
         {
-            get => GetAppConfigValue("IsBurstDownloadModeEnabled").ToBoolNullable() ?? true;
+            get => GetAppConfigValue("IsBurstDownloadModeEnabled");
             set => SetAndSaveConfigValue("IsBurstDownloadModeEnabled", value);
         }
 
         public static bool IsUsePreallocatedDownloader
         {
-            get => GetAppConfigValue("IsUsePreallocatedDownloader").ToBoolNullable() ?? true;
+            get => GetAppConfigValue("IsUsePreallocatedDownloader");
             set => SetAndSaveConfigValue("IsUsePreallocatedDownloader", value);
         }
 
         public static bool IsUseDownloadSpeedLimiter
         {
-            get => GetAppConfigValue("IsUseDownloadSpeedLimiter").ToBoolNullable() ?? true;
+            get => GetAppConfigValue("IsUseDownloadSpeedLimiter");
             set
             {
                 SetAndSaveConfigValue("IsUseDownloadSpeedLimiter", value);
@@ -337,7 +337,7 @@ namespace Hi3Helper.Shared.Region
 
         public static long DownloadSpeedLimit
         {
-            get => DownloadSpeedLimitCached = GetAppConfigValue("DownloadSpeedLimit").ToLong();
+            get => DownloadSpeedLimitCached = GetAppConfigValue("DownloadSpeedLimit");
             set => SetAndSaveConfigValue("DownloadSpeedLimit", DownloadSpeedLimitCached = value);
         }
 
@@ -346,7 +346,7 @@ namespace Hi3Helper.Shared.Region
             get
             {
                 // Clamp value, Min: 32 MiB, Max: 512 MiB
-                int configValue = GetAppConfigValue("DownloadChunkSize").ToInt();
+                int configValue = GetAppConfigValue("DownloadChunkSize");
                 configValue = Math.Clamp(configValue, 32 << 20, 512 << 20);
                 return configValue;
             }
@@ -360,7 +360,7 @@ namespace Hi3Helper.Shared.Region
 
         public static bool IsEnforceToUse7zipOnExtract
         {
-            get => GetAppConfigValue("EnforceToUse7zipOnExtract").ToBool();
+            get => GetAppConfigValue("EnforceToUse7zipOnExtract");
             set => SetAndSaveConfigValue("EnforceToUse7zipOnExtract", value);
         }
 
@@ -384,7 +384,7 @@ namespace Hi3Helper.Shared.Region
         {
             get
             {
-                _cachedIsInstantRegionChange ??= GetAppConfigValue("UseInstantRegionChange").ToBool();
+                _cachedIsInstantRegionChange ??= GetAppConfigValue("UseInstantRegionChange");
                 return (bool)_cachedIsInstantRegionChange;
             }
             set => SetAndSaveConfigValue("UseInstantRegionChange", value);
@@ -395,14 +395,14 @@ namespace Hi3Helper.Shared.Region
 
         public static Guid GetGuid(int sessionNum)
         {
-            var guidString = GetAppConfigValue($"sessionGuid{sessionNum}").ToString();
-            if (string.IsNullOrEmpty(guidString))
+            Guid guidString = GetAppConfigValue($"sessionGuid{sessionNum}");
+            if (guidString == Guid.Empty)
             {
                 var g = Guid.NewGuid();
-                SetAndSaveConfigValue($"sessionGuid{sessionNum}", g.ToString());
+                SetAndSaveConfigValue($"sessionGuid{sessionNum}", g);
                 return g;
             }
-            return Guid.Parse(guidString);
+            return guidString;
         }
         #endregion
 
@@ -422,7 +422,7 @@ namespace Hi3Helper.Shared.Region
             { "SendRemoteCrashData", true },
             { "EnableMultipleInstance", false },
             { "DontAskUpdate", false },
-            { "ThemeMode", new IniValue(AppThemeMode.Default) },
+            { "ThemeMode", IniValue.Create(AppThemeMode.Default) },
             { "AppLanguage", "en-us" },
             { "UseCustomBG", false },
             { "IsUseVideoBGDynamicColorUpdate", false },

--- a/Hi3Helper.Core/Data/IniFile.cs
+++ b/Hi3Helper.Core/Data/IniFile.cs
@@ -104,6 +104,8 @@ namespace Hi3Helper.Data
         #region Load and Save Methods
         public void Save(string path)
         {
+            EnsureFolderExist(path);
+
             using FileStream stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite, CreateStreamBufferSize, FileOptions.None);
             using StreamWriter writer = new StreamWriter(stream, encoding: Encoding.UTF8, leaveOpen: false);
             SaveInner(writer);
@@ -152,9 +154,16 @@ namespace Hi3Helper.Data
             }
         }
 
-        public void Load(string path)
+        public void Load(string path, bool createIfNotExist = false)
         {
-            using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, OpenStreamBufferSize, FileOptions.None);
+            FileMode fileMode = createIfNotExist ? FileMode.OpenOrCreate : FileMode.Open;
+            if (createIfNotExist)
+            {
+                // Always ensure folder existence if createIfNotExist was toggled
+                EnsureFolderExist(path);
+            }
+
+            using FileStream stream = new FileStream(path, fileMode, FileAccess.Read, FileShare.ReadWrite, OpenStreamBufferSize, FileOptions.None);
             using StreamReader reader = new StreamReader(stream, leaveOpen: false);
             LoadInner(reader);
         }
@@ -225,6 +234,14 @@ namespace Hi3Helper.Data
             {
                 Add("default", DefaultSection);
             }
+        }
+
+        private void EnsureFolderExist(string filePath)
+        {
+            // Always create the directory if none of it exist
+            string? pathDirectory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(pathDirectory))
+                _ = Directory.CreateDirectory(pathDirectory);
         }
 
         private void GetOrCreateSection(string sectionName, [NotNull] out IniSection? iniSection)

--- a/Hi3Helper.Core/Data/IniValue.cs
+++ b/Hi3Helper.Core/Data/IniValue.cs
@@ -401,7 +401,7 @@ namespace Hi3Helper.Data
 
         public static implicit operator ushort(IniValue value) => value.ToNumber<ushort>();
 
-        public static implicit operator int(IniValue value) => value.ToNumber<ushort>();
+        public static implicit operator int(IniValue value) => value.ToNumber<int>();
 
         public static implicit operator uint(IniValue value) => value.ToNumber<uint>();
 

--- a/Hi3Helper.Core/Data/IniValue.cs
+++ b/Hi3Helper.Core/Data/IniValue.cs
@@ -8,11 +8,18 @@ namespace Hi3Helper.Data
     public struct IniValue
     {
         #region Fields
-        public string? Value;
+        private string? _value;
+        private bool _isEmpty = true;
         #endregion
 
         #region Methods
-        public bool IsEmpty { get => string.IsNullOrEmpty(Value) || string.IsNullOrWhiteSpace(Value); }
+        public string? Value
+        {
+            get => _value;
+            set => _isEmpty = string.IsNullOrEmpty(_value = value);
+        }
+
+        public bool IsEmpty => _isEmpty;
         #endregion
 
         #region Constructors
@@ -39,8 +46,14 @@ namespace Hi3Helper.Data
         /// <summary>
         /// Create <seealso cref="IniValue"/> instance from <seealso cref="IFormattable"/> members
         /// </summary>
-        /// <param name="formattableObj">Value to convert from <seealso cref="IFormattable"/> members</param>
+        /// <param name="formattableValue">Value to convert from <seealso cref="IFormattable"/> members</param>
         public IniValue(IFormattable? formattableValue) => Value = formattableValue?.ToString(null, IniFile.DefaultCulture);
+
+        /// <summary>
+        /// Create <seealso cref="IniValue"/> instance from a <seealso cref="Boolean"/>
+        /// </summary>
+        /// <param name="value">Value to convert from <seealso cref="Boolean"/></param>
+        public IniValue(bool value) => Value = value ? "True" : "False";
 
         /// <summary>
         /// Create <seealso cref="IniValue"/> instance from a <seealso cref="string"/>
@@ -53,6 +66,33 @@ namespace Hi3Helper.Data
         /// </summary>
         /// <param name="value">Value to convert from <seealso cref="Size"/></param>
         public IniValue(Size value) => Value = $"{value.Width}x{value.Height}";
+
+        /// <summary>
+        /// Create <seealso cref="IniValue"/> instance from <seealso cref="Guid"/>
+        /// </summary>
+        /// <param name="value">Value to convert from <seealso cref="Guid"/></param>
+        public IniValue(Guid value)
+        {
+            string guidAsString = value.ToString(null, IniFile.DefaultCulture);
+            Value = guidAsString;
+        }
+        #endregion
+
+        #region Create Methods
+        public static IniValue Create<TEnum>(TEnum value)
+            where TEnum : struct, Enum => new IniValue(Enum.GetName(value));
+
+        public static IniValue Create(IFormattable? value) => new IniValue(value);
+
+        public static IniValue Create(object? value) => new IniValue(value);
+
+        public static IniValue Create(string? value) => new IniValue(value);
+
+        public static IniValue Create(bool value) => new IniValue(value);
+
+        public static IniValue Create(Size value) => new IniValue(value);
+
+        public static IniValue CreateEmpty() => new IniValue();
         #endregion
 
         #region Try Methods
@@ -65,7 +105,7 @@ namespace Hi3Helper.Data
         public bool TryParseValue<TNumber>(out TNumber result)
             where TNumber : struct, ISpanParsable<TNumber>
         {
-            ReadOnlySpan<char> valueSpan = Value;
+            ReadOnlySpan<char> valueSpan = _value;
 
             // Assign the default value first
             result = default;
@@ -95,7 +135,7 @@ namespace Hi3Helper.Data
             const string PossibleSeparators = ",x:";
 
             // Assign value string to span
-            ReadOnlySpan<char> valueString = Value;
+            ReadOnlySpan<char> valueString = _value;
 
             // If it's empty due to null or is empty, return default size
             if (valueString.IsEmpty)
@@ -142,6 +182,29 @@ namespace Hi3Helper.Data
         }
 
         /// <summary>
+        /// Convert the <seealso cref="IniValue"/> into <seealso cref="Guid"/>
+        /// </summary>
+        /// <returns>Value of <seealso cref="Guid"/>. If <see cref="IsEmpty"/> is true, or the value is not
+        /// in a valid <seealso cref="Guid"/> form, then return <see cref="Guid.Empty"/></returns>
+        public readonly Guid ToGuid()
+        {
+            // If the back value is empty, return an empty Guid
+            if (_isEmpty)
+            {
+                return Guid.Empty;
+            }
+
+            // If the back value can be parsed to Guid, then return
+            if (Guid.TryParse(_value, out Guid guid))
+            {
+                return guid;
+            }
+
+            // Otherwise, return the empty guid again
+            return Guid.Empty;
+        }
+
+        /// <summary>
         /// Convert the <seealso cref="IniValue"/> to <seealso cref="bool"/>
         /// </summary>
         /// <param name="defaultValue">The default value to be returned if the <seealso cref="IniValue"/> is invalid</param>
@@ -149,7 +212,7 @@ namespace Hi3Helper.Data
         public bool ToBool(bool defaultValue = false)
         {
             // Try parse the value
-            if (bool.TryParse(Value, out bool result))
+            if (bool.TryParse(_value, out bool result))
             {
                 return result;
             }
@@ -164,8 +227,8 @@ namespace Hi3Helper.Data
         /// <returns>Value of a nullable <seealso cref="bool"/></returns>
         public bool? ToBoolNullable()
         {
-            // If the value is empty or null, return null
-            if (string.IsNullOrEmpty(Value) || string.IsNullOrWhiteSpace(Value))
+            // If the value is empty, return null
+            if (_isEmpty)
             {
                 return null;
             }
@@ -286,9 +349,9 @@ namespace Hi3Helper.Data
         #endregion
 
         #region Get String Methods
-        private string? GetStringValue() => Value;
+        private string? GetStringValue() => _value;
 
-        public override string? ToString() => Value;
+        public override string? ToString() => _value;
         #endregion
 
         #region Implicit Cast Operators
@@ -326,6 +389,10 @@ namespace Hi3Helper.Data
 
         public static implicit operator IniValue(nuint o) => new IniValue(o);
 
+        public static implicit operator IniValue(Size o) => new IniValue(o);
+
+        public static implicit operator IniValue(Guid o) => new IniValue(o);
+
         public static implicit operator sbyte(IniValue value) => value.ToNumber<sbyte>();
 
         public static implicit operator byte(IniValue value) => value.ToNumber<byte>();
@@ -359,6 +426,10 @@ namespace Hi3Helper.Data
         public static implicit operator nint(IniValue value) => value.ToNumber<nint>();
 
         public static implicit operator nuint(IniValue value) => value.ToNumber<nuint>();
+
+        public static implicit operator Size(IniValue value) => value.ToSize();
+
+        public static implicit operator Guid(IniValue value) => value.ToGuid();
         #endregion
     }
 }


### PR DESCRIPTION
# What's new? - 1.82.7 Hotfix
- **[Fix]** Fix redundant Ini save-load mechanism and FileNotFoundException upon loading, by @neon-nyan 
  This caused the launcher to throw ``FileNotFoundException`` error in the background and causing the region fail to load.
- **[Imp]** Improvement on ``IniValue``, by @neon-nyan 
  - Always cache ``IsEmpty`` property and update it only if the ``Value`` property is being set.
  - Add missing casting for ``Size`` struct
  - Add ``Create()`` static method
  - Add ``ToGuid()`` method and cast support
  - Add support for creating ``IniValue`` from ``Enum``
- **[Fix]** Avoid double desktop shortcut by using user's Desktop path, by @neon-nyan 
- **[Fix]** Fix wrong casting on implicit IniValue operator for Int32, by @neon-nyan 

----------------

# What's new? - 1.82.6
- **[Fix]** Download corruption due to download chunk size being too small, by @neon-nyan 
- **[Fix]** Double taskbar entry if console is enabled, by @bagusnl 
- **[Fix]** Repair function for GI/SR/HI3 detected updated plugin as corrupted, by @bagusnl 
- **[Imp]** Update 7z dll to 24.09, by @neon-nyan 
- **[Imp]** Http downloader module improvements, by @neon-nyan 
  - Bypass drive write cache
  - Use multi threaded file writer
- **[Imp]** ``IniFile`` parser improvements, by @neon-nyan 
    + Improving implicit casting on IniValue to numbers
       This to allow maintainers to directly assign the IniValue to variable types.
    + Reduce memory allocation on loading and saving IniFile
    + Improving saving performance to file or a stream.
    + More safety bound check to IniSection
    + Reduce overhead on checking Section Keys and Value Keys
    + Add more checks on loading values
    + Splitting class and structs into their own files

## ```IniFile``` benchmark (Old vs. New)
### Note
There might be some minor performance degradation on Loading mechanism due to additional check overhead.
More work will be implemented later to fix this.
| Method           | Mean Time   | Ratio | Time Imp (%) | Allocated Mem. | Ratio | Mem. Imp (%) |
|----------------- |-----------:|-----------:|----------------------:|------------:|------------:|-----------------------:|
| Load_Old        | 77.85 µs   | 1.000      |                     - |  217.3 KB   |       1.000 |                      - |
| Load_New        | 80.80 µs   | 1.038      |                 -3.8% |  138.3 KB   |       0.637 |                 +36.4% |
| Load_OrderedNew | 79.73 µs   | 1.024      |                 -2.4% |  138.3 KB   |       0.637 |                 +36.4% |
| Save_Old        |  0.10 µs   | 1.000      |                     - |    2.2 KB   |       1.000 |                      - |
| Save_New        |  0.06 µs   | 0.630      |                +37.0% |    0.4 KB   |       0.181 |                 +81.8% |
| Save_OrderedNew |  0.06 µs   | 0.665      |                +33.5% |    0.4 KB   |       0.181 |                 +81.8% |


### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>