### PR TITLE
Stable 1.82.12 Emergency Hotfix

### DIFF
--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -486,7 +486,7 @@ namespace CollapseLauncher.InstallManager.Base
             _progressAllCountCurrent = 1;
 
             // Start the verification routine
-            foreach (GameInstallPackage asset in gamePackage)
+            foreach (GameInstallPackage asset in gamePackage.ToList())
             {
                 switch (await RunPackageVerificationRoutine(asset, _token!.Token))
                 {
@@ -677,7 +677,7 @@ namespace CollapseLauncher.InstallManager.Base
             _status.IsProgressAllIndetermined     = false;
 
             // Iterate the asset
-            foreach (GameInstallPackage asset in gamePackage)
+            foreach (GameInstallPackage asset in gamePackage.ToList())
             {
                 int returnCode;
 
@@ -854,7 +854,7 @@ namespace CollapseLauncher.InstallManager.Base
             TryRemoveRedundantHDiffList();
 
             // Enumerate the installation package
-            foreach (GameInstallPackage asset in gamePackage)
+            foreach (GameInstallPackage asset in gamePackage.ToList())
             {
                 // Update the status
                 _status.ActivityStatus =
@@ -2804,7 +2804,7 @@ namespace CollapseLauncher.InstallManager.Base
                 // Write to log if the package has segments (Example: Genshin Impact)
                 if (package.Segments != null)
                 {
-                    foreach (GameInstallPackage segment in package.Segments)
+                    foreach (GameInstallPackage segment in package.Segments.ToList())
                     {
                         LogWriteLine($"Adding segmented package: {segment.Name} to the list (Hash: {segment.HashString})",
                                      LogType.Default, true);
@@ -2964,7 +2964,7 @@ namespace CollapseLauncher.InstallManager.Base
             try
             {
                 // Iterate the package list
-                foreach (GameInstallPackage package in packageList)
+                foreach (GameInstallPackage package in packageList.ToList())
                 {
                     // If the package is segmented, then iterate and run the routine for segmented packages
                     if (package.Segments != null)

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -16,7 +16,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.82.11</Version>
+        <Version>1.82.12</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -301,9 +301,8 @@ namespace CollapseLauncher
             get
             {
                 double scaleFactor = WindowUtility.CurrentWindowMonitorScaleFactor;
-                RectInt32[] rect = new RectInt32[2]
+                RectInt32[] rect = new[]
                 {
-
                     new RectInt32((int)(TitleBarDrag1.ActualOffset.X * scaleFactor),
                                   0,
                                   (int)(TitleBarDrag1.ActualWidth * scaleFactor),
@@ -324,7 +323,7 @@ namespace CollapseLauncher
                 Rect currentWindowPos = WindowUtility.CurrentWindowPosition;
                 double scaleFactor = WindowUtility.CurrentWindowMonitorScaleFactor;
 
-                RectInt32[] rect = new RectInt32[1]
+                RectInt32[] rect = new[]
                 {
                     new RectInt32(0,
                                   0,
@@ -364,7 +363,7 @@ namespace CollapseLauncher
             switch (e.Template)
             {
                 case DragAreaTemplate.None:
-                    nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, new RectInt32[]
+                    nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, new[]
                     {
                         GetElementPos((WindowUtility.CurrentWindow as MainWindow)?.AppTitleBar)
                     });
@@ -374,7 +373,7 @@ namespace CollapseLauncher
                     break;
                 case DragAreaTemplate.Default:
                     nonClientInputSrc.ClearAllRegionRects();
-                    nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, new RectInt32[]
+                    nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, new[]
                     {
                         GetElementPos(GridBG_RegionGrid),
                         GetElementPos(GridBG_IconGrid),
@@ -815,7 +814,7 @@ namespace CollapseLauncher
         {
             TypedEventHandler<InfoBar, object> ClickCloseAction;
             if (NotificationData?.AppPush == null) return;
-            foreach (NotificationProp Entry in NotificationData.AppPush)
+            foreach (NotificationProp Entry in NotificationData.AppPush.ToList())
             {
                 // Check for Close Action for certain MsgIds
                 switch (Entry.MsgId)
@@ -926,25 +925,36 @@ namespace CollapseLauncher
 
                         // Create notification
                         NotificationContent toastContent = NotificationContent.Create()
-                            .SetTitle(Lang._NotificationToast.LauncherUpdated_NotifTitle)
-                            .SetContent(
-                                string.Format(Lang._NotificationToast.LauncherUpdated_NotifSubtitle,
-                                    VerString + (IsPreview ? "-preview" : ""),
-                                    Lang._SettingsPage.PageTitle,
-                                    Lang._SettingsPage.Update_SeeChangelog)
-                                )
-                            .AddAppHeroImagePath(heroImage);
+                                                                              .SetTitle(Lang._NotificationToast
+                                                                                  .LauncherUpdated_NotifTitle)
+                                                                              .SetContent(
+                                                                                    string
+                                                                                       .Format(Lang._NotificationToast.LauncherUpdated_NotifSubtitle,
+                                                                                            VerString + (IsPreview
+                                                                                                ? "-preview"
+                                                                                                : ""),
+                                                                                            Lang._SettingsPage
+                                                                                               .PageTitle,
+                                                                                            Lang._SettingsPage
+                                                                                               .Update_SeeChangelog)
+                                                                                   )
+                                                                              .AddAppHeroImagePath(heroImage);
 
                         // Get notification service
                         Windows.UI.Notifications.ToastNotification notificationService =
-                            WindowUtility.CurrentToastNotificationService?.CreateToastNotification(toastContent);
+                            WindowUtility.CurrentToastNotificationService.CreateToastNotification(toastContent);
 
                         // Spawn notification service
                         Windows.UI.Notifications.ToastNotifier notifier =
-                            WindowUtility.CurrentToastNotificationService?.CreateToastNotifier();
+                            WindowUtility.CurrentToastNotificationService.CreateToastNotifier();
                         notifier.Show(notificationService);
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        LogWriteLine($"[SpawnAppUpdatedNotification] Failed to spawn toast notification!\r\n{ex}",
+                                     LogType.Error, true);
+                        SentryHelper.ExceptionHandler(ex);
+                    }
                 }
             }
             catch
@@ -1950,7 +1960,7 @@ namespace CollapseLauncher
             List<string>? gameNameCollection = LauncherMetadataHelper.GetGameNameCollection();
             _ = LauncherMetadataHelper.GetGameRegionCollection(gameName);
 
-            var indexCategory                    = gameNameCollection?.IndexOf(gameName!) ?? -1;
+            var indexCategory                    = gameNameCollection?.IndexOf(gameName) ?? -1;
             if (indexCategory < 0) indexCategory = 0;
 
             var indexRegion = LauncherMetadataHelper.GetPreviousGameRegion(gameName);

--- a/Hi3Helper.Core/Classes/SentryHelper/SentryHelper.cs
+++ b/Hi3Helper.Core/Classes/SentryHelper/SentryHelper.cs
@@ -9,7 +9,9 @@ using Sentry.Protocol;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -483,8 +485,11 @@ namespace Hi3Helper.SentryHelper
                 }
             });
 
-            SentrySdk.AddBreadcrumb("Loaded Modules", "AppInfo", 
-                                    "system.module", modulesInfo.ToDictionary());
+            var sbModulesInfo = new StringBuilder();
+            foreach (var (key, value) in modulesInfo)
+            {
+                sbModulesInfo.AppendLine($"{key}: {value}");
+            }
             
             ex.Data[Mechanism.HandledKey] ??= exT == ExceptionType.Handled;
 
@@ -513,6 +518,9 @@ namespace Hi3Helper.SentryHelper
                     SentrySdk.CaptureException(ex, s =>
                                                    {
                                                        s.AddAttachment(LoggerBase.LogPath, AttachmentType.Default, "text/plain");
+                                                       s.AddAttachment(new MemoryStream(Encoding.UTF8.GetBytes(sbModulesInfo.ToString())),
+                                                                       "LoadedModules.txt", AttachmentType.Default,
+                                                                       "text/plain");
                                                    });
             }
             else

--- a/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
@@ -177,6 +177,11 @@ namespace Hi3Helper
 
                 public string DbGenerateUid_Title   { get; set; } = LangFallback?._Dialogs.DbGenerateUid_Title;
                 public string DbGenerateUid_Content { get; set; } = LangFallback?._Dialogs.DbGenerateUid_Content;
+                public string SophonIncrementUpdateUnavailTitle { get; set; } = LangFallback?._Dialogs.SophonIncrementUpdateUnavailTitle;
+                public string SophonIncrementUpdateUnavailSubtitle1 { get; set; } = LangFallback?._Dialogs.SophonIncrementUpdateUnavailSubtitle1;
+                public string SophonIncrementUpdateUnavailSubtitle2 { get; set; } = LangFallback?._Dialogs.SophonIncrementUpdateUnavailSubtitle2;
+                public string SophonIncrementUpdateUnavailSubtitle3 { get; set; } = LangFallback?._Dialogs.SophonIncrementUpdateUnavailSubtitle3;
+                public string SophonIncrementUpdateUnavailSubtitle4 { get; set; } = LangFallback?._Dialogs.SophonIncrementUpdateUnavailSubtitle4;
             }
         }
         #endregion

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -995,7 +995,13 @@
     "CloseOverlay": "Close Overlay",
 
     "DbGenerateUid_Title": "Are you sure you wish to change your user ID?",
-    "DbGenerateUid_Content": "Changing the current user ID will cause the associated data to be lost if you lose it."
+    "DbGenerateUid_Content": "Changing the current user ID will cause the associated data to be lost if you lose it.",
+
+    "SophonIncrementUpdateUnavailTitle": "Incremental Update is Unavailable: Version is Too Obsolete!",
+    "SophonIncrementUpdateUnavailSubtitle1": "Your game version: {0}",
+    "SophonIncrementUpdateUnavailSubtitle2": " is too obsolete",
+    "SophonIncrementUpdateUnavailSubtitle3": " and incremental update for your version is not available. However, you could still update your game by re-downloading the entire thing from scratch.",
+    "SophonIncrementUpdateUnavailSubtitle4": "Click \"{0}\" to continue updating the entire thing or click \"{1}\" to cancel the process"
   },
 
   "_FileMigrationProcess": {

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 > > Please keep in mind that the Game Conversion feature is currently only available for Honkai Impact: 3rd. Other miHoYo/Cognosphere Pte. Ltd. games are currently not planned for game conversion. 
 
 # Download Ready-To-Use Builds
-[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.10/CollapseLauncher-stable-Setup.exe)
-> **Note**: The version for this build is `1.82.10` (Released on: December 27th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.11/CollapseLauncher-stable-Setup.exe)
+> **Note**: The version for this build is `1.82.11` (Released on: January 1st, 2025).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.10-pre/CollapseLauncher-preview-Setup.exe)
-> **Note**: The version for this build is `1.82.10` (Released on: December 27th, 2024).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.11-pre/CollapseLauncher-preview-Setup.exe)
+> **Note**: The version for this build is `1.82.11` (Released on: January 1st, 2025).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 


### PR DESCRIPTION
# What's new ? - 1.82.12
- **[Fix]** Failure when installing sophon, by @neon-nyan 
  - neon forgor to put the variable into the right line
- **[Fix]** Disk space recognition when resuming game install with
sophon, by @neon-nyan
  - neon forgor to return the right value
- **[Fix]** Game update with sophon failing if its updating from a
version that is too old, by @neon-nyan
- neon too eepy and forgor to check if the manifest exist for those
older game version
- if the game is too old then fallback to use install method and replace
any assets that is not matching with the target version.
- **[Fix]** `EnumFailedVersion` errors when installing games and (super
rarely) in early launch, by @bagusnl
- **[Imp]** Use Attachment instead of breadcrumbs for LoadedModules
reporting in Sentry, by @bagusnl