### PR TITLE
Preview 1.82.16 Hotfix Release

### DIFF
--- a/.github/workflows/vt-scan-releases.yml
+++ b/.github/workflows/vt-scan-releases.yml
@@ -8,8 +8,7 @@ jobs:
   virustotal:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: VirusTotal Scan
+      - name: VirusTotal Scan Executables
         uses: crazy-max/ghaction-virustotal@v4
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
@@ -17,4 +16,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             *.exe
+
+      - name: VirusTotal Scan Archive
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          update_release_body: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
             *.7z

--- a/CollapseLauncher/App.xaml.cs
+++ b/CollapseLauncher/App.xaml.cs
@@ -91,7 +91,7 @@ namespace CollapseLauncher
                       WindowUtility.CurrentAppWindow!.TitleBar!.ButtonForegroundColor = color;
                       WindowUtility.CurrentAppWindow!.TitleBar!.ButtonInactiveBackgroundColor = color;
 
-                      if (WindowUtility.CurrentWindow!.Content is not null and FrameworkElement frameworkElement)
+                      if (WindowUtility.CurrentWindow!.Content is FrameworkElement frameworkElement)
                           frameworkElement.RequestedTheme = isThemeLight ? ElementTheme.Light : ElementTheme.Dark;
                   };
 

--- a/CollapseLauncher/Classes/CachesManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/Check.cs
@@ -161,7 +161,7 @@ namespace CollapseLauncher
             }
         }
 
-        private void AddGenericCheckAsset(CacheAsset asset, CacheAssetStatus assetStatus, List<CacheAsset> returnAsset, byte[] localCRC, byte[] remoteCRC)
+        private void AddGenericCheckAsset(CacheAsset asset, CacheAssetStatus assetStatus, List<CacheAsset> returnAsset, byte[] localCrc, byte[] remoteCrc)
         {
             // Increment the count and total size
             lock (this)
@@ -187,8 +187,8 @@ namespace CollapseLauncher
                     asset.DataType,
                     Path.GetDirectoryName(asset.N),
                     asset.CS,
-                    localCRC,
-                    remoteCRC
+                    localCrc,
+                    remoteCrc
                 ))
             );
         }

--- a/CollapseLauncher/Classes/CachesManagement/Honkai/HonkaiCache.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/HonkaiCache.cs
@@ -59,7 +59,7 @@ namespace CollapseLauncher
             // Step 2: Start assets checking
             UpdateAssetIndex = await Check(AssetIndex, Token!.Token);
 
-            // Step 3: Summarize and returns true if the assetIndex count != 0 indicates caches needs to be update.
+            // Step 3: Summarize and returns true if the assetIndex count != 0 indicates caches needs to be updated.
             //         either way, returns false.
             return SummarizeStatusAndProgress(
                 UpdateAssetIndex,

--- a/CollapseLauncher/Classes/CachesManagement/StarRail/StarRailCache.cs
+++ b/CollapseLauncher/Classes/CachesManagement/StarRail/StarRailCache.cs
@@ -46,7 +46,7 @@ namespace CollapseLauncher
             // Step 2: Start assets checking
             UpdateAssetIndex = await Check(AssetIndex, Token.Token);
 
-            // Step 3: Summarize and returns true if the assetIndex count != 0 indicates caches needs to be update.
+            // Step 3: Summarize and returns true if the assetIndex count != 0 indicates caches needs to be updated.
             //         either way, returns false.
             return SummarizeStatusAndProgress(
                 UpdateAssetIndex,

--- a/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
+++ b/CollapseLauncher/Classes/EventsManagement/EventsHandler.cs
@@ -17,6 +17,7 @@ using static Hi3Helper.Shared.Region.LauncherConfig;
 // ReSharper disable SwitchStatementHandlesSomeKnownEnumValuesWithDefault
 // ReSharper disable IdentifierTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/Classes/Extension/TaskExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/TaskExtensions.cs
@@ -1,34 +1,112 @@
 ﻿using Hi3Helper;
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 #nullable enable
 namespace CollapseLauncher.Extension
 {
-    public delegate Task<TResult?> ActionTimeoutValueTaskCallback<TResult>(CancellationToken token);
+    public delegate Task<TResult?> ActionTimeoutTaskCallback<TResult>(CancellationToken token);
+    public delegate ConfiguredTaskAwaitable<TResult?> ActionTimeoutTaskAwaitableCallback<TResult>(CancellationToken token);
     public delegate void ActionOnTimeOutRetry(int retryAttemptCount, int retryAttemptTotal, int timeOutSecond, int timeOutStep);
     internal static class TaskExtensions
     {
         internal const int DefaultTimeoutSec = 10;
         internal const int DefaultRetryAttempt = 5;
 
-        internal static async Task AsTaskAndDoAction<TResult>(this Task<TResult?> taskResult, Action<TResult?> doAction)
+        internal static Task<TResult?>
+            WaitForRetryAsync<TResult>(this ActionTimeoutTaskAwaitableCallback<TResult?> funcCallback,
+                                       int?                                              timeout       = null,
+                                       int?                                              timeoutStep   = null,
+                                       int?                                              retryAttempt  = null,
+                                       ActionOnTimeOutRetry?                             actionOnRetry = null,
+                                       CancellationToken                                 fromToken     = default)
+            => WaitForRetryAsync(() => funcCallback, timeout, timeoutStep, retryAttempt, actionOnRetry, fromToken);
+
+        internal static async Task<TResult?>
+            WaitForRetryAsync<TResult>(Func<ActionTimeoutTaskAwaitableCallback<TResult?>> funcCallback,
+                                       int?                                               timeout       = null,
+                                       int?                                               timeoutStep   = null,
+                                       int?                                               retryAttempt  = null,
+                                       ActionOnTimeOutRetry?                              actionOnRetry = null,
+                                       CancellationToken                                  fromToken     = default)
         {
-            TResult? result = await taskResult;
-            doAction(result);
+            timeout      ??= DefaultTimeoutSec;
+            timeoutStep  ??= 0;
+            retryAttempt ??= DefaultRetryAttempt;
+
+            int        retryAttemptCurrent = 1;
+            Exception? lastException       = null;
+            while (retryAttemptCurrent < retryAttempt)
+            {
+                fromToken.ThrowIfCancellationRequested();
+                CancellationTokenSource? innerCancellationToken = null;
+                CancellationTokenSource? consolidatedToken = null;
+
+                try
+                {
+                    innerCancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(timeout ?? DefaultTimeoutSec));
+                    consolidatedToken = CancellationTokenSource.CreateLinkedTokenSource(innerCancellationToken.Token, fromToken);
+
+                    ActionTimeoutTaskAwaitableCallback<TResult?> delegateCallback = funcCallback();
+                    return await delegateCallback(consolidatedToken.Token);
+                }
+                catch (OperationCanceledException) when (fromToken.IsCancellationRequested) { throw; }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    actionOnRetry?.Invoke(retryAttemptCurrent, (int)retryAttempt, timeout ?? 0, timeoutStep ?? 0);
+
+                    if (ex is TimeoutException)
+                    {
+                        string msg = $"The operation has timed out! Retrying attempt left: {retryAttemptCurrent}/{retryAttempt}";
+                        Logger.LogWriteLine(msg, LogType.Warning, true);
+                    }
+                    else
+                    {
+                        string msg = $"The operation has thrown an exception! Retrying attempt left: {retryAttemptCurrent}/{retryAttempt}\r\n{ex}";
+                        Logger.LogWriteLine(msg, LogType.Error, true);
+                    }
+
+                    retryAttemptCurrent++;
+                    timeout += timeoutStep;
+                }
+                finally
+                {
+                    innerCancellationToken?.Dispose();
+                    consolidatedToken?.Dispose();
+                }
+            }
+
+            if (lastException is not null
+                && !fromToken.IsCancellationRequested)
+                throw lastException is TaskCanceledException ?
+                    new TimeoutException("The operation has timed out with inner exception!", lastException) :
+                    lastException;
+
+            throw new TimeoutException("The operation has timed out!");
         }
 
-        internal static async Task<TResult?> WaitForRetryAsync<TResult>(this ActionTimeoutValueTaskCallback<TResult?> funcCallback, int? timeout = null,
-            int? timeoutStep = null, int? retryAttempt = null, ActionOnTimeOutRetry? actionOnRetry = null, CancellationToken fromToken = default)
+        internal static async Task<TResult?>
+            WaitForRetryAsync<TResult>(this ActionTimeoutTaskCallback<TResult?> funcCallback,
+                                       int?                                     timeout       = null,
+                                       int?                                     timeoutStep   = null,
+                                       int?                                     retryAttempt  = null,
+                                       ActionOnTimeOutRetry?                    actionOnRetry = null,
+                                       CancellationToken                        fromToken     = default)
             => await WaitForRetryAsync(() => funcCallback, timeout, timeoutStep, retryAttempt, actionOnRetry, fromToken);
 
-        internal static async Task<TResult?> WaitForRetryAsync<TResult>(Func<ActionTimeoutValueTaskCallback<TResult?>> funcCallback, int? timeout = null,
-            int? timeoutStep = null, int? retryAttempt = null, ActionOnTimeOutRetry? actionOnRetry = null, CancellationToken fromToken = default)
+        internal static async Task<TResult?>
+            WaitForRetryAsync<TResult>(Func<ActionTimeoutTaskCallback<TResult?>> funcCallback,
+                                       int?                                      timeout       = null,
+                                       int?                                      timeoutStep   = null,
+                                       int?                                      retryAttempt  = null,
+                                       ActionOnTimeOutRetry?                     actionOnRetry = null,
+                                       CancellationToken                         fromToken     = default)
         {
-            timeout ??= DefaultTimeoutSec;
-            timeoutStep ??= 0;
-
+            timeout      ??= DefaultTimeoutSec;
+            timeoutStep  ??= 0;
             retryAttempt ??= DefaultRetryAttempt;
 
             int retryAttemptCurrent = 1;
@@ -44,7 +122,7 @@ namespace CollapseLauncher.Extension
                     innerCancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(timeout ?? DefaultTimeoutSec));
                     consolidatedToken = CancellationTokenSource.CreateLinkedTokenSource(innerCancellationToken.Token, fromToken);
 
-                    ActionTimeoutValueTaskCallback<TResult?> delegateCallback = funcCallback();
+                    ActionTimeoutTaskCallback<TResult?> delegateCallback = funcCallback();
                     return await delegateCallback(consolidatedToken.Token);
                 }
                 catch (OperationCanceledException) when (fromToken.IsCancellationRequested) { throw; }

--- a/CollapseLauncher/Classes/Extension/TaskExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/TaskExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Extension

--- a/CollapseLauncher/Classes/Extension/TaskExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/TaskExtensions.cs
@@ -9,6 +9,7 @@ namespace CollapseLauncher.Extension
 {
     public delegate Task<TResult?> ActionTimeoutTaskCallback<TResult>(CancellationToken token);
     public delegate void ActionOnTimeOutRetry(int retryAttemptCount, int retryAttemptTotal, int timeOutSecond, int timeOutStep);
+
     internal static partial class TaskExtensions
     {
         internal const int DefaultTimeoutSec = 10;

--- a/CollapseLauncher/Classes/Extension/UIElementExtensions.UnsafeAccessorExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/UIElementExtensions.UnsafeAccessorExtensions.cs
@@ -20,10 +20,10 @@ namespace CollapseLauncher.Extension
         /// </summary>
         /// <param name="element">The <seealso cref="UIElement"/> member of an element</param>
         /// <param name="inputCursor">The cursor you want to set. Use <see cref="InputSystemCursor.Create"/> to choose the cursor you want to set.</param>
-        internal static ref T WithCursor<T>(this T element, InputCursor inputCursor) where T : UIElement
+        internal static T WithCursor<T>(this T element, InputCursor inputCursor) where T : UIElement
         {
             element.SetCursor(inputCursor);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
     }
 }

--- a/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using Windows.UI;
 using Windows.UI.Text;
 // ReSharper disable SwitchStatementHandlesSomeKnownEnumValuesWithDefault

--- a/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
@@ -40,7 +40,7 @@ namespace CollapseLauncher.Extension
         /// <param name="localeSetName">The instance name of a <seealso cref="Hi3Helper.Locale"/> members.</param>
         /// <param name="localePropertyName">Name of the locale property</param>
         /// <returns>A reference of the <typeparamref name="T"/></returns>
-        internal static ref T BindNavigationViewItemText<T>(this T element, string localeSetName, string localePropertyName)
+        internal static T BindNavigationViewItemText<T>(this T element, string localeSetName, string localePropertyName)
             where T : NavigationViewItemBase
         {
             NavigationViewItemLocaleTextProperty property = new NavigationViewItemLocaleTextProperty
@@ -58,10 +58,10 @@ namespace CollapseLauncher.Extension
                 TextBlock textBlock = new TextBlock().WithTag(property);
                 element.Content = textBlock;
             }
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static void SetAllControlsCursorRecursive(this UIElement element, InputSystemCursor toCursor)
+        internal static void SetAllControlsCursorRecursive(this UIElement? element, InputSystemCursor toCursor)
         {
             while (true)
             {
@@ -110,16 +110,15 @@ namespace CollapseLauncher.Extension
                 {
                     case NavigationView navigationViewKind:
                     {
-                        foreach (var o in navigationViewKind.FindDescendants())
+                        foreach (DependencyObject o in navigationViewKind.FindDescendants())
                         {
-                            var navigationViewElements = (UIElement)o;
-                            if (navigationViewElements is NavigationViewItem)
+                            if (o is NavigationViewItem navigationViewItem)
                             {
-                                navigationViewElements.SetCursor(toCursor);
+                                navigationViewItem.SetCursor(toCursor);
                                 continue;
                             }
 
-                            SetAllControlsCursorRecursive(navigationViewElements, toCursor);
+                            SetAllControlsCursorRecursive(o as UIElement, toCursor);
                         }
 
                         break;
@@ -182,7 +181,7 @@ namespace CollapseLauncher.Extension
             navViewControl.UpdateLayout();
         }
 
-        internal static ref T BindProperty<T>(this T element, DependencyProperty dependencyProperty, object objectToBind, string propertyName, IValueConverter? converter = null, BindingMode bindingMode = BindingMode.OneWay)
+        internal static T BindProperty<T>(this T element, DependencyProperty dependencyProperty, object objectToBind, string propertyName, IValueConverter? converter = null, BindingMode bindingMode = BindingMode.OneWay)
             where T : FrameworkElement
         {
             // Create a new binding instance
@@ -203,7 +202,7 @@ namespace CollapseLauncher.Extension
             // Set binding to the element
             element.SetBinding(dependencyProperty, binding);
 
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 #nullable restore
 
@@ -277,11 +276,11 @@ namespace CollapseLauncher.Extension
             foreach (FrameworkElement element in elements)
                 stackPanel.Children.Add(element);
         }
-        internal static ref TElement AddElementToStackPanel<TElement>(this Panel stackPanel, TElement element)
+        internal static TElement AddElementToStackPanel<TElement>(this Panel stackPanel, TElement element)
             where TElement : FrameworkElement
         {
             stackPanel.Children.Add(element);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
         internal static void AddGridColumns(this Grid grid, params GridLength[] columnWidths)
@@ -312,27 +311,27 @@ namespace CollapseLauncher.Extension
             });
         }
 
-        internal static ref TElement AddElementToGridRowColumn<TElement>(this Grid grid, TElement element, int rowIndex = 0, int columnIndex = 0, int rowSpan = 0, int columnSpan = 0)
+        internal static TElement AddElementToGridRowColumn<TElement>(this Grid grid, TElement element, int rowIndex = 0, int columnIndex = 0, int rowSpan = 0, int columnSpan = 0)
             where TElement : FrameworkElement
         {
             grid.Children.Add(element);
             SetElementGridRowPosition(element, rowIndex, rowSpan);
             SetElementGridColumnPosition(element, columnIndex, columnSpan);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement AddElementToGridRow<TElement>(this Grid grid, TElement element, int index, int span = 0)
+        internal static TElement AddElementToGridRow<TElement>(this Grid grid, TElement element, int index, int span = 0)
             where TElement : FrameworkElement
         {
             grid.Children.Add(element);
             SetElementGridRowPosition(element, index, span);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement AddElementToGridColumn<TElement>(this Grid grid, TElement element, int index, int span = 0)
+        internal static TElement AddElementToGridColumn<TElement>(this Grid grid, TElement element, int index, int span = 0)
             where TElement : FrameworkElement
         {
             grid.Children.Add(element);
             SetElementGridColumnPosition(element, index, span);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
         internal static void ClearChildren<TElement>(this TElement element)
@@ -355,23 +354,23 @@ namespace CollapseLauncher.Extension
             if (span > 0) Grid.SetColumnSpan(element, span);
         }
 
-        internal static ref TextBlock AddTextBlockNewLine(this TextBlock textBlock, int count = 1)
+        internal static TextBlock AddTextBlockNewLine(this TextBlock textBlock, int count = 1)
         {
             while (count-- > 0) { textBlock.Inlines.Add(new LineBreak()); }
-            return ref Unsafe.AsRef(ref textBlock);
+            return textBlock;
         }
 
-        internal static ref TextBlock AddTextBlockLine(this TextBlock textBlock, string message, bool appendSpaceAtEnd, FontWeight? weight = null, double size = 14d)
+        internal static TextBlock AddTextBlockLine(this TextBlock textBlock, string message, bool appendSpaceAtEnd, FontWeight? weight = null, double size = 14d)
         {
             message += ' ';
-            return ref textBlock.AddTextBlockLine(message, weight, size);
+            return textBlock.AddTextBlockLine(message, weight, size);
         }
 
-        internal static ref TextBlock AddTextBlockLine(this TextBlock textBlock, string message, FontWeight? weight = null, double size = 14d)
+        internal static TextBlock AddTextBlockLine(this TextBlock textBlock, string message, FontWeight? weight = null, double size = 14d)
         {
             weight ??= FontWeights.Normal;
             textBlock.Inlines.Add(new Run { Text = message, FontWeight = weight.Value, FontSize = size });
-            return ref Unsafe.AsRef(ref textBlock);
+            return textBlock;
         }
 
         internal static TReturnType GetApplicationResource<TReturnType>(string resourceKey)
@@ -471,217 +470,217 @@ namespace CollapseLauncher.Extension
             }
         }
 
-        internal static ref TElement WithWidthAndHeight<TElement>(this TElement element, double uniform)
+        internal static TElement WithWidthAndHeight<TElement>(this TElement element, double uniform)
             where TElement : FrameworkElement
         {
             SetWidth(element, uniform);
             SetHeight(element, uniform);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithMinWidthAndMinHeight<TElement>(this TElement element, double uniform)
+        internal static TElement WithMinWidthAndMinHeight<TElement>(this TElement element, double uniform)
             where TElement : FrameworkElement
         {
             SetMinWidth(element, uniform);
             SetMinHeight(element, uniform);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithWidth<TElement>(this TElement element, double width)
+        internal static TElement WithWidth<TElement>(this TElement element, double width)
             where TElement : FrameworkElement
         {
             SetWidth(element, width);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithMinWidth<TElement>(this TElement element, double width)
+        internal static TElement WithMinWidth<TElement>(this TElement element, double width)
             where TElement : FrameworkElement
         {
             SetMinWidth(element, width);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithHeight<TElement>(this TElement element, double height)
+        internal static TElement WithHeight<TElement>(this TElement element, double height)
             where TElement : FrameworkElement
         {
             SetHeight(element, height);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithMinHeight<TElement>(this TElement element, double height)
+        internal static TElement WithMinHeight<TElement>(this TElement element, double height)
             where TElement : FrameworkElement
         {
             SetMinHeight(element, height);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TGrid WithRowSpacing<TGrid>(this TGrid grid, double rowSpacing)
+        internal static TGrid WithRowSpacing<TGrid>(this TGrid grid, double rowSpacing)
             where TGrid : Grid
         {
             SetRowSpacing(grid, rowSpacing);
-            return ref Unsafe.AsRef(ref grid);
+            return grid;
         }
-        internal static ref TGrid WithColumnSpacing<TGrid>(this TGrid grid, double columnSpacing)
+        internal static TGrid WithColumnSpacing<TGrid>(this TGrid grid, double columnSpacing)
             where TGrid : Grid
         {
             SetColumnSpacing(grid, columnSpacing);
-            return ref Unsafe.AsRef(ref grid);
+            return grid;
         }
-        internal static ref TGrid WithColumns<TGrid>(this TGrid grid, params GridLength[] columns)
+        internal static TGrid WithColumns<TGrid>(this TGrid grid, params GridLength[] columns)
             where TGrid : Grid
         {
             SetGridSlices(grid, columns, true);
-            return ref Unsafe.AsRef(ref grid);
+            return grid;
         }
-        internal static ref TGrid WithRows<TGrid>(this TGrid grid, params GridLength[] rows)
+        internal static TGrid WithRows<TGrid>(this TGrid grid, params GridLength[] rows)
             where TGrid : Grid
         {
             SetGridSlices(grid, rows, false);
-            return ref Unsafe.AsRef(ref grid);
+            return grid;
         }
 
-        internal static ref TElement WithCornerRadius<TElement>(this TElement element, double uniform, CornerRadiusKind kind = CornerRadiusKind.Normal)
+        internal static TElement WithCornerRadius<TElement>(this TElement element, double uniform, CornerRadiusKind kind = CornerRadiusKind.Normal)
             where TElement : FrameworkElement
         {
             SetCornerRadius(element, uniform, kind);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithCornerRadius<TElement>(this TElement element, double horizontal, double vertical, CornerRadiusKind kind = CornerRadiusKind.Normal)
+        internal static TElement WithCornerRadius<TElement>(this TElement element, double horizontal, double vertical, CornerRadiusKind kind = CornerRadiusKind.Normal)
             where TElement : FrameworkElement
         {
             SetCornerRadius(element, horizontal, vertical, kind);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithCornerRadius<TElement>(this TElement element, double left, double top, double right, double bottom, CornerRadiusKind kind = CornerRadiusKind.Normal)
+        internal static TElement WithCornerRadius<TElement>(this TElement element, double left, double top, double right, double bottom, CornerRadiusKind kind = CornerRadiusKind.Normal)
             where TElement : FrameworkElement
         {
             SetCornerRadius(element, left, top, right, bottom, kind);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithVisibility<TElement>(this TElement element, Visibility visibility)
+        internal static TElement WithVisibility<TElement>(this TElement element, Visibility visibility)
             where TElement : FrameworkElement
         {
             SetVisibility(element, visibility);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithTag<TElement>(this TElement element, object tag)
+        internal static TElement WithTag<TElement>(this TElement element, object tag)
             where TElement : FrameworkElement
         {
             SetTag(element, tag);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithDataContext<TElement>(this TElement element, object dataContext)
+        internal static TElement WithDataContext<TElement>(this TElement element, object dataContext)
             where TElement : FrameworkElement
         {
             SetDataContext(element, dataContext);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithBackground<TElement>(this TElement element, Brush brush)
+        internal static TElement WithBackground<TElement>(this TElement element, Brush brush)
             where TElement : FrameworkElement
         {
             SetBackground(element, brush);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithForeground<TElement>(this TElement element, Brush brush)
+        internal static TElement WithForeground<TElement>(this TElement element, Brush brush)
             where TElement : FrameworkElement
         {
             SetForeground(element, brush);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithOpacity<TElement>(this TElement element, double opacity)
+        internal static TElement WithOpacity<TElement>(this TElement element, double opacity)
             where TElement : FrameworkElement
         {
             SetOpacity(element, opacity);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithStretch<TElement>(this TElement element, Stretch stretch)
+        internal static TElement WithStretch<TElement>(this TElement element, Stretch stretch)
             where TElement : FrameworkElement
         {
             SetStretch(element, stretch);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithPadding<TElement>(this TElement element, double uniform)
+        internal static TElement WithPadding<TElement>(this TElement element, double uniform)
             where TElement : FrameworkElement
         {
             SetPadding(element, uniform);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithPadding<TElement>(this TElement element, double horizontal, double vertical)
+        internal static TElement WithPadding<TElement>(this TElement element, double horizontal, double vertical)
             where TElement : FrameworkElement
         {
             SetPadding(element, horizontal, vertical);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithPadding<TElement>(this TElement element, double left, double top, double right, double bottom)
+        internal static TElement WithPadding<TElement>(this TElement element, double left, double top, double right, double bottom)
             where TElement : FrameworkElement
         {
             SetPadding(element, left, top, right, bottom);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithPadding<TElement>(this TElement element, Thickness thickness)
+        internal static TElement WithPadding<TElement>(this TElement element, Thickness thickness)
             where TElement : FrameworkElement
         {
             SetPadding(element, thickness);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TElement WithMargin<TElement>(this TElement element, double uniform)
+        internal static TElement WithMargin<TElement>(this TElement element, double uniform)
             where TElement : FrameworkElement
         {
             SetMargin(element, uniform);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithMargin<TElement>(this TElement element, double horizontal, double vertical)
+        internal static TElement WithMargin<TElement>(this TElement element, double horizontal, double vertical)
             where TElement : FrameworkElement
         {
             SetMargin(element, horizontal, vertical);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithMargin<TElement>(this TElement element, double left, double top, double right, double bottom)
+        internal static TElement WithMargin<TElement>(this TElement element, double left, double top, double right, double bottom)
             where TElement : FrameworkElement
         {
             SetMargin(element, left, top, right, bottom);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithMargin<TElement>(this TElement element, Thickness thickness)
+        internal static TElement WithMargin<TElement>(this TElement element, Thickness thickness)
             where TElement : FrameworkElement
         {
             SetMargin(element, thickness);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
-        internal static ref TButton WithFlyout<TButton>(this TButton button, FlyoutBase flyout)
+        internal static TButton WithFlyout<TButton>(this TButton button, FlyoutBase flyout)
             where TButton : Button
         {
             SetButtonFlyout(button, flyout);
-            return ref Unsafe.AsRef(ref button);
+            return button;
         }
 
-        internal static ref TElement WithHorizontalAlignment<TElement>(this TElement element, HorizontalAlignment alignment)
+        internal static TElement WithHorizontalAlignment<TElement>(this TElement element, HorizontalAlignment alignment)
             where TElement : FrameworkElement
         {
             SetHorizontalAlignment(element, alignment);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithHorizontalContentAlignment<TElement>(this TElement element, HorizontalAlignment alignment)
+        internal static TElement WithHorizontalContentAlignment<TElement>(this TElement element, HorizontalAlignment alignment)
             where TElement : Control
         {
             SetHorizontalContentAlignment(element, alignment);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithVerticalAlignment<TElement>(this TElement element, VerticalAlignment alignment)
+        internal static TElement WithVerticalAlignment<TElement>(this TElement element, VerticalAlignment alignment)
             where TElement : FrameworkElement
         {
             SetVerticalAlignment(element, alignment);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
-        internal static ref TElement WithVerticalContentAlignment<TElement>(this TElement element, VerticalAlignment alignment)
+        internal static TElement WithVerticalContentAlignment<TElement>(this TElement element, VerticalAlignment alignment)
             where TElement : Control
         {
             SetVerticalContentAlignment(element, alignment);
-            return ref Unsafe.AsRef(ref element);
+            return element;
         }
 
         internal static void SetGridSlices<TGrid>(this TGrid grid, GridLength[] gridSlices, bool isColumn)

--- a/CollapseLauncher/Classes/GameManagement/GamePlaytime/RegistryClass/CollapsePlaytime.cs
+++ b/CollapseLauncher/Classes/GameManagement/GamePlaytime/RegistryClass/CollapsePlaytime.cs
@@ -217,7 +217,7 @@ namespace CollapseLauncher.GamePlaytime
 
         /// <summary>
         /// Checks if any stats should be reset.<br/>
-        /// Afterwards, the values are saved to the registry.<br/><br/>
+        /// Afterward, the values are saved to the registry.<br/><br/>
         /// </summary>
         private void CheckStatsReset()
         {
@@ -237,7 +237,7 @@ namespace CollapseLauncher.GamePlaytime
 
         /// <summary>
         /// Adds a minute to all fields, and checks if any should be reset.<br/>
-        /// Afterwards, the values are saved to the registry.<br/><br/>
+        /// Afterward, the values are saved to the registry.<br/><br/>
         /// </summary>
         public void AddMinute()
         {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/ImportExportBase.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/ImportExportBase.cs
@@ -17,6 +17,8 @@ using System.Threading.Tasks;
 using static CollapseLauncher.GameSettings.Base.SettingsBase;
 using static Hi3Helper.Locale;
 // ReSharper disable SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
+// ReSharper disable CommentTypo
+// ReSharper disable GrammarMistakeInComment
 
 #nullable enable
 namespace CollapseLauncher.GameSettings.Base

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/ScreenSettingData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/ScreenSettingData.cs
@@ -1,4 +1,6 @@
 ﻿using System.Drawing;
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
 
 namespace CollapseLauncher.GameSettings.Base
 {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/SettingsGameVersionManager.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/BaseClass/SettingsGameVersionManager.cs
@@ -1,5 +1,6 @@
 ﻿using CollapseLauncher.Interfaces;
 using System.IO;
+// ReSharper disable GrammarMistakeInComment
 
 #nullable enable
 namespace CollapseLauncher.GameSettings.Base

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/Enums/Enums.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/Enums/Enums.cs
@@ -1,4 +1,8 @@
 ﻿using System.Collections.Generic;
+// ReSharper disable ArrangeTypeModifiers
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.GameSettings.Genshin.Enums
 {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -12,6 +12,10 @@ using static Hi3Helper.Logger;
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable CommentTypo
+// ReSharper disable UnusedMember.Global
+// ReSharper disable InconsistentNaming
+// ReSharper disable GrammarMistakeInComment
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Genshin
@@ -19,7 +23,7 @@ namespace CollapseLauncher.GameSettings.Genshin
     internal sealed partial class GeneralData
     {
         #region Fields
-        private const string _ValueName = "GENERAL_DATA_h2389025596";
+        private const string ValueName = "GENERAL_DATA_h2389025596";
         
         // Default GENERAL_DATA_h2389025596 value taken from version 5.0.0
         // For the next person, if there is any addition/deletion to the GeneralData props, please update this :)
@@ -28,12 +32,12 @@ namespace CollapseLauncher.GameSettings.Genshin
         // Thank you.
         // Sincerely, bagel 🥯
         // (hoyo why you did this to us)
-        private static readonly string _generalDataDefault = 
-            "{\"deviceUUID\":\"\",\"userLocalDataVersionId\":\"\",\"deviceLanguageType\":1,\"deviceVoiceLanguageType\":1,\"selectedServerName\":\"\",\"localLevelIndex\":0,\"deviceID\":\"\",\"targetUID\":\"\",\"curAccountName\":\"\",\"uiSaveData\":\"\",\"inputData\":\"{\\\"scriptVersion\\\":\\\"OSRELWin5.0.0\\\",\\\"mouseSensitivity\\\":10.0,\\\"joypadSenseIndex\\\":2,\\\"joypadFocusSenseIndex\\\":2,\\\"joypadInvertCameraX\\\":false,\\\"joypadInvertCameraY\\\":false,\\\"joypadInvertFocusCameraX\\\":false,\\\"joypadInvertFocusCameraY\\\":false,\\\"mouseSenseIndex\\\":2,\\\"mouseFocusSenseIndex\\\":2,\\\"touchpadSenseIndex\\\":2,\\\"touchpadFocusSenseIndex\\\":5,\\\"enableTouchpadFocusAcceleration\\\":false,\\\"lastJoypadDefaultScale\\\":1.0,\\\"lastJoypadFocusScale\\\":1.0,\\\"lastPCDefaultScale\\\":0.75,\\\"lastPCFocusScale\\\":1.0,\\\"lastTouchDefaultScale\\\":1.0,\\\"lastTouchFcousScale\\\":1.0,\\\"switchWalkRunByBtn\\\":false,\\\"skiffCameraAutoFix\\\":true,\\\"skiffCameraAutoFixInCombat\\\":false,\\\"cameraDistanceRatio\\\":0.0,\\\"wwiseVibration\\\":true,\\\"isYInited\\\":true,\\\"joypadSenseIndexY\\\":2,\\\"joypadFocusSenseIndexY\\\":2,\\\"mouseSenseIndexY\\\":2,\\\"mouseFocusSenseIndexY\\\":2,\\\"touchpadSenseIndexY\\\":2,\\\"touchpadFocusSenseIndexY\\\":5,\\\"lastJoypadDefaultScaleY\\\":1.0,\\\"lastJoypadFocusScaleY\\\":1.0,\\\"lastPCDefaultScaleY\\\":0.75,\\\"lastPCFocusScaleY\\\":1.0,\\\"lastTouchDefaultScaleY\\\":1.0,\\\"lastTouchFcousScaleY\\\":1.0}\",\"graphicsData\":\"{\\\"currentVolatielGrade\\\":4,\\\"customVolatileGrades\\\":[],\\\"volatileVersion\\\":\\\"OSRELWin5.0.0\\\"}\",\"globalPerfData\":\"{\\\"saveItems\\\":[],\\\"truePortedFromGraphicData\\\":true,\\\"portedVersion\\\":\\\"OSRELWin5.0.0\\\",\\\"volatileUpgradeVersion\\\":0,\\\"portedFromGraphicData\\\":false}\",\"miniMapConfig\":1,\"enableCameraSlope\":true,\"enableCameraCombatLock\":true,\"completionPkg\":false,\"completionPlayGoPkg\":false,\"onlyPlayWithPSPlayer\":false,\"needPlayGoFullPkgPatch\":false,\"resinNotification\":true,\"exploreNotification\":true,\"volumeGlobal\":10,\"volumeSFX\":10,\"volumeMusic\":10,\"volumeVoice\":10,\"audioAPI\":-1,\"audioDynamicRange\":0,\"audioOutput\":0,\"_audioSuccessInit\":true,\"enableAudioChangeAndroidMinimumBufferCapacity\":true,\"audioAndroidMiniumBufferCapacity\":2048,\"vibrationLevel\":0,\"vibrationIntensity\":3,\"usingNewVibrationSetting\":true,\"motionBlur\":true,\"gyroAiming\":false,\"gyroHorMoveSpeedIndex\":2,\"gyroVerMoveSpeedIndex\":2,\"gyroHorReverse\":false,\"gyroVerReverse\":false,\"gyroRotateType\":0,\"gyroExcludeRightStickVerInput\":false,\"firstHDRSetting\":true,\"maxLuminosity\":0.0,\"uiPaperWhite\":0.0,\"scenePaperWhite\":0.0,\"gammaValue\":2.200000047683716,\"enableHDR\":false,\"_overrideControllerMapKeyList\":[],\"_overrideControllerMapValueList\":[],\"rewiredMapMigrateRecord\":[],\"rewiredDisableKeyboard\":false,\"rewiredEnableKeyboard\":false,\"rewiredEnableEDS\":false,\"disableRewiredDelayInit\":false,\"disableRewiredInitProtection\":false,\"conflictKeyBindingElementId\":[],\"conflictKeyBindingActionId\":[],\"lastSeenPreDownloadTime\":0,\"lastSeenSettingResourceTabScriptVersion\":\"\",\"enableEffectAssembleInEditor\":true,\"forceDisableQuestResourceManagement\":false,\"needReportQuestResourceDeleteStatusFiles\":false,\"disableTeamPageBackgroundSwitch\":false,\"disableHttpDns\":false,\"mtrCached\":false,\"mtrIsOpen\":false,\"mtrMaxTTL\":32,\"mtrTimeOut\":5000,\"mtrTraceCount\":5,\"mtrAbortTimeOutCount\":3,\"mtrAutoTraceInterval\":0,\"mtrTraceCDEachReason\":600,\"mtrTimeInterval\":1000,\"mtrBanReasons\":[],\"_customDataKeyList\":[],\"_customDataValueList\":[],\"_serializedCodeSwitches\":[],\"urlCheckCached\":false,\"urlCheckIsOpen\":false,\"urlCheckAllIP\":false,\"urlCheckTimeOut\":5000,\"urlCheckSueecssTraceCount\":5,\"urlCheckErrorTraceCount\":30,\"urlCheckAbortTimeOutCount\":3,\"urlCheckTimeInterval\":1000,\"urlCheckCDEachReason\":600,\"urlCheckBanReasons\":[],\"mtrUseOldWinVersion\":false,\"greyTestDeviceUniqueId\":\"\",\"muteAudioOnAppMinimized\":false,\"disableFallbackControllerType\":false,\"lastShowDoorProgress\":-1.0,\"globalPerfSettingVersion\":2}";
+        private const string GeneralDataDefault = "{\"deviceUUID\":\"\",\"userLocalDataVersionId\":\"\",\"deviceLanguageType\":1,\"deviceVoiceLanguageType\":1,\"selectedServerName\":\"\",\"localLevelIndex\":0,\"deviceID\":\"\",\"targetUID\":\"\",\"curAccountName\":\"\",\"uiSaveData\":\"\",\"inputData\":\"{\\\"scriptVersion\\\":\\\"OSRELWin5.0.0\\\",\\\"mouseSensitivity\\\":10.0,\\\"joypadSenseIndex\\\":2,\\\"joypadFocusSenseIndex\\\":2,\\\"joypadInvertCameraX\\\":false,\\\"joypadInvertCameraY\\\":false,\\\"joypadInvertFocusCameraX\\\":false,\\\"joypadInvertFocusCameraY\\\":false,\\\"mouseSenseIndex\\\":2,\\\"mouseFocusSenseIndex\\\":2,\\\"touchpadSenseIndex\\\":2,\\\"touchpadFocusSenseIndex\\\":5,\\\"enableTouchpadFocusAcceleration\\\":false,\\\"lastJoypadDefaultScale\\\":1.0,\\\"lastJoypadFocusScale\\\":1.0,\\\"lastPCDefaultScale\\\":0.75,\\\"lastPCFocusScale\\\":1.0,\\\"lastTouchDefaultScale\\\":1.0,\\\"lastTouchFcousScale\\\":1.0,\\\"switchWalkRunByBtn\\\":false,\\\"skiffCameraAutoFix\\\":true,\\\"skiffCameraAutoFixInCombat\\\":false,\\\"cameraDistanceRatio\\\":0.0,\\\"wwiseVibration\\\":true,\\\"isYInited\\\":true,\\\"joypadSenseIndexY\\\":2,\\\"joypadFocusSenseIndexY\\\":2,\\\"mouseSenseIndexY\\\":2,\\\"mouseFocusSenseIndexY\\\":2,\\\"touchpadSenseIndexY\\\":2,\\\"touchpadFocusSenseIndexY\\\":5,\\\"lastJoypadDefaultScaleY\\\":1.0,\\\"lastJoypadFocusScaleY\\\":1.0,\\\"lastPCDefaultScaleY\\\":0.75,\\\"lastPCFocusScaleY\\\":1.0,\\\"lastTouchDefaultScaleY\\\":1.0,\\\"lastTouchFcousScaleY\\\":1.0}\",\"graphicsData\":\"{\\\"currentVolatielGrade\\\":4,\\\"customVolatileGrades\\\":[],\\\"volatileVersion\\\":\\\"OSRELWin5.0.0\\\"}\",\"globalPerfData\":\"{\\\"saveItems\\\":[],\\\"truePortedFromGraphicData\\\":true,\\\"portedVersion\\\":\\\"OSRELWin5.0.0\\\",\\\"volatileUpgradeVersion\\\":0,\\\"portedFromGraphicData\\\":false}\",\"miniMapConfig\":1,\"enableCameraSlope\":true,\"enableCameraCombatLock\":true,\"completionPkg\":false,\"completionPlayGoPkg\":false,\"onlyPlayWithPSPlayer\":false,\"needPlayGoFullPkgPatch\":false,\"resinNotification\":true,\"exploreNotification\":true,\"volumeGlobal\":10,\"volumeSFX\":10,\"volumeMusic\":10,\"volumeVoice\":10,\"audioAPI\":-1,\"audioDynamicRange\":0,\"audioOutput\":0,\"_audioSuccessInit\":true,\"enableAudioChangeAndroidMinimumBufferCapacity\":true,\"audioAndroidMiniumBufferCapacity\":2048,\"vibrationLevel\":0,\"vibrationIntensity\":3,\"usingNewVibrationSetting\":true,\"motionBlur\":true,\"gyroAiming\":false,\"gyroHorMoveSpeedIndex\":2,\"gyroVerMoveSpeedIndex\":2,\"gyroHorReverse\":false,\"gyroVerReverse\":false,\"gyroRotateType\":0,\"gyroExcludeRightStickVerInput\":false,\"firstHDRSetting\":true,\"maxLuminosity\":0.0,\"uiPaperWhite\":0.0,\"scenePaperWhite\":0.0,\"gammaValue\":2.200000047683716,\"enableHDR\":false,\"_overrideControllerMapKeyList\":[],\"_overrideControllerMapValueList\":[],\"rewiredMapMigrateRecord\":[],\"rewiredDisableKeyboard\":false,\"rewiredEnableKeyboard\":false,\"rewiredEnableEDS\":false,\"disableRewiredDelayInit\":false,\"disableRewiredInitProtection\":false,\"conflictKeyBindingElementId\":[],\"conflictKeyBindingActionId\":[],\"lastSeenPreDownloadTime\":0,\"lastSeenSettingResourceTabScriptVersion\":\"\",\"enableEffectAssembleInEditor\":true,\"forceDisableQuestResourceManagement\":false,\"needReportQuestResourceDeleteStatusFiles\":false,\"disableTeamPageBackgroundSwitch\":false,\"disableHttpDns\":false,\"mtrCached\":false,\"mtrIsOpen\":false,\"mtrMaxTTL\":32,\"mtrTimeOut\":5000,\"mtrTraceCount\":5,\"mtrAbortTimeOutCount\":3,\"mtrAutoTraceInterval\":0,\"mtrTraceCDEachReason\":600,\"mtrTimeInterval\":1000,\"mtrBanReasons\":[],\"_customDataKeyList\":[],\"_customDataValueList\":[],\"_serializedCodeSwitches\":[],\"urlCheckCached\":false,\"urlCheckIsOpen\":false,\"urlCheckAllIP\":false,\"urlCheckTimeOut\":5000,\"urlCheckSueecssTraceCount\":5,\"urlCheckErrorTraceCount\":30,\"urlCheckAbortTimeOutCount\":3,\"urlCheckTimeInterval\":1000,\"urlCheckCDEachReason\":600,\"urlCheckBanReasons\":[],\"mtrUseOldWinVersion\":false,\"greyTestDeviceUniqueId\":\"\",\"muteAudioOnAppMinimized\":false,\"disableFallbackControllerType\":false,\"lastShowDoorProgress\":-1.0,\"globalPerfSettingVersion\":2}";
+
         #endregion
 
         #region Properties
-        //in need of help,,
+        //in need of help,
         //Using guide from https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format
         //Thanks Myp3a!
 
@@ -344,22 +348,22 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new ArgumentNullException($"Cannot load {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                object value = RegistryRoot.GetValue(_ValueName) ?? throw new ArgumentNullException($"Cannot find registry key {_ValueName}");
+                if (RegistryRoot == null) throw new ArgumentNullException($"Cannot load {ValueName} since RegistryKey is unexpectedly not initialized!");
+                object value = RegistryRoot.GetValue(ValueName) ?? throw new ArgumentNullException($"Cannot find registry key {ValueName}");
 
                 ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DUMPGIJSON
                 // Dump GeneralData as raw string
-                LogWriteLine($"RAW Genshin Settings: {_ValueName}\r\n" +
+                LogWriteLine($"RAW Genshin Settings: {ValueName}\r\n" +
                              $"{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
 
                 // Dump GeneralData as indented JSON output using GeneralData properties
-                LogWriteLine($"Deserialized Genshin Settings: {_ValueName}\r\n{byteStr
+                LogWriteLine($"Deserialized Genshin Settings: {ValueName}\r\n{byteStr
                     .Deserialize(GenshinSettingsJsonContext.Default.GeneralData)
                     .Serialize(GenshinSettingsJsonContext.Default.GeneralData, false, true)}", LogType.Debug, true);
 #endif
 #if DEBUG
-                LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
+                LogWriteLine($"Loaded Genshin Settings: {ValueName}", LogType.Debug, true);
 #else
                 LogWriteLine($"Loaded Genshin Settings", LogType.Default, true);
 #endif
@@ -371,16 +375,16 @@ namespace CollapseLauncher.GameSettings.Genshin
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}, Default fallback data is used!" +
+                LogWriteLine($"Failed while reading {ValueName}, Default fallback data is used!" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}!\r\nFallback default value is used.\r\n\r\n" +
+                    $"Failed when reading game settings {ValueName}!\r\nFallback default value is used.\r\n\r\n" +
                     $"Unless you have never opened the game (fresh installation), please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n\r\n" +
                     $"{ex}", ex));
 
-                GeneralData data = _generalDataDefault.Deserialize(GenshinSettingsJsonContext.Default.GeneralData) ?? new GeneralData();
+                GeneralData data = GeneralDataDefault.Deserialize(GenshinSettingsJsonContext.Default.GeneralData) ?? new GeneralData();
                 data.graphicsData   = GraphicsData.Load(data._graphicsData!);
                 data.globalPerfData = GlobalPerfData.Load(data._globalPerfData!, data.graphicsData)!;
                 return data;
@@ -391,7 +395,7 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 _graphicsData = graphicsData.Create(globalPerfData);
                 _globalPerfData = globalPerfData.Save();
@@ -399,13 +403,13 @@ namespace CollapseLauncher.GameSettings.Genshin
                 string data = this.Serialize(GenshinSettingsJsonContext.Default.GeneralData);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DUMPGIJSON
                 //Dump saved GeneralData JSON from Collapse as indented output
-                LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{this.Serialize(GenshinSettingsJsonContext.Default.GeneralData, false, true)}", LogType.Debug, true);
+                LogWriteLine($"Saved Genshin Settings: {ValueName}\r\n{this.Serialize(GenshinSettingsJsonContext.Default.GeneralData, false, true)}", LogType.Debug, true);
 #endif
 #if DEBUG
-                LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
+                LogWriteLine($"Saved Genshin Settings: {ValueName}" +
                     $"\r\n      Text Language        : {deviceLanguageType}" +
                     $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
                     $"\r\n      Audio - Master Volume: {volumeGlobal}" +
@@ -424,7 +428,7 @@ namespace CollapseLauncher.GameSettings.Genshin
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception("Failed to save Genshin settings, please report them to GitHub issues!", ex));
             }
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
@@ -6,40 +6,29 @@ using System.Collections.Generic;
 using System.Linq;
 using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
+// ReSharper disable StringLiteralTypo
 
 namespace CollapseLauncher.GameSettings.Genshin
 {
-    internal class PerfDataItem
+    internal class PerfDataItem(int entryType, int index, string itemVersion)
     {
         #region Properties
-        public int entryType { get; set; }
-        public int index { get; set; }
-        public string itemVersion { get; set; }
-        #endregion
+        public int    entryType   { get; set; } = entryType;
+        public int    index       { get; set; } = index;
+        public string itemVersion { get; set; } = itemVersion;
 
-        #region Methods
-        public PerfDataItem(int entryType, int index, string itemVersion)
-        {
-            this.entryType = entryType;
-            this.index = index;
-            this.itemVersion = itemVersion;
-        }
         #endregion
     }
 
-    internal class GenshinKeyValuePair
+    internal class GenshinKeyValuePair(int key, int value)
     {
         #region Properties
-        public int key { get; set; }
-        public int value { get; set; }
-        #endregion
+        public int key   { get; set; } = key;
+        public int value { get; set; } = value;
 
-        #region Methods
-        public GenshinKeyValuePair(int Key, int Value)
-        {
-            key = Key;
-            value = Value;
-        }
         #endregion
     }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
@@ -2,6 +2,8 @@ using CollapseLauncher.GameSettings.Genshin.Context;
 using Hi3Helper;
 using System.Collections.Generic;
 using static Hi3Helper.Logger;
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
 
 namespace CollapseLauncher.GameSettings.Genshin
 {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/ScreenManager.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/ScreenManager.cs
@@ -11,6 +11,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Genshin
@@ -18,10 +19,10 @@ namespace CollapseLauncher.GameSettings.Genshin
     internal class ScreenManager : BaseScreenSettingData, IGameSettingsValue<ScreenManager>
     {
         #region Fields
-        private const           string _ValueNameScreenManagerWidth      = "Screenmanager Resolution Width_h182942802";
-        private const           string _ValueNameScreenManagerHeight     = "Screenmanager Resolution Height_h2627697771";
-        private const           string _ValueNameScreenManagerFullscreen = "Screenmanager Is Fullscreen mode_h3981298716";
-        private static readonly Size   currentRes                        = ScreenProp.CurrentResolution;
+        private const           string ValueNameScreenManagerWidth      = "Screenmanager Resolution Width_h182942802";
+        private const           string ValueNameScreenManagerHeight     = "Screenmanager Resolution Height_h2627697771";
+        private const           string ValueNameScreenManagerFullscreen = "Screenmanager Is Fullscreen mode_h3981298716";
+        private static readonly Size   CurrentRes                        = ScreenProp.CurrentResolution;
         #endregion
 
         #region Properties
@@ -35,8 +36,8 @@ namespace CollapseLauncher.GameSettings.Genshin
             get => new(width, height);
             set
             {
-                width = value.Width < 64 ? currentRes.Width : value.Width;
-                height = value.Height < 64 ? currentRes.Height : value.Height;
+                width = value.Width < 64 ? CurrentRes.Width : value.Width;
+                height = value.Height < 64 ? CurrentRes.Height : value.Height;
             }
         }
 
@@ -51,12 +52,10 @@ namespace CollapseLauncher.GameSettings.Genshin
             set
             {
                 string[] size = value.Split('x');
-                int w;
-                int h;
-                if (!int.TryParse(size[0], out w) || !int.TryParse(size[1], out h))
+                if (!int.TryParse(size[0], out var w) || !int.TryParse(size[1], out var h))
                 {
-                    width = currentRes.Width;
-                    height = currentRes.Height;
+                    width = CurrentRes.Width;
+                    height = CurrentRes.Height;
                 }
                 else
                 {
@@ -71,14 +70,14 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// Range: 0 - int.MaxValue<br/>
         /// Default: Your screen width
         /// </summary>
-        public override int width { get; set; } = currentRes.Width;
+        public override int width { get; set; } = CurrentRes.Width;
 
         /// <summary>
         /// This defines "<c>Game Resolution</c>'s Height" combobox In-game settings -> Video.<br/><br/>
         /// Range: 0 - int.MaxValue<br/>
         /// Default: Your screen Height
         /// </summary>
-        public override int height { get; set; } = currentRes.Height;
+        public override int height { get; set; } = CurrentRes.Height;
 
         /// <summary>
         /// This defines "<c>Fullscreen</c>" checkbox In-game settings -> Video.<br/><br/>
@@ -110,18 +109,18 @@ namespace CollapseLauncher.GameSettings.Genshin
             {
                 if (RegistryRoot == null) throw new NullReferenceException("Cannot load Genshin Screen Manager settings as RegistryKey is unexpectedly not initialized!");
 
-                object? valueWidth = RegistryRoot.GetValue(_ValueNameScreenManagerWidth, null);
-                object? valueHeight = RegistryRoot.GetValue(_ValueNameScreenManagerHeight, null);
-                object? valueFullscreen = RegistryRoot.GetValue(_ValueNameScreenManagerFullscreen, null);
+                object? valueWidth = RegistryRoot.GetValue(ValueNameScreenManagerWidth, null);
+                object? valueHeight = RegistryRoot.GetValue(ValueNameScreenManagerHeight, null);
+                object? valueFullscreen = RegistryRoot.GetValue(ValueNameScreenManagerFullscreen, null);
                 if (valueWidth != null && valueHeight != null && valueFullscreen != null)
                 {
                     int width = (int)valueWidth;
                     int height = (int)valueHeight;
                     int fullscreen = (int)valueFullscreen;
 #if DEBUG
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueNameScreenManagerWidth} : {width}", LogType.Debug, true);
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueNameScreenManagerHeight} : {height}", LogType.Debug, true);
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueNameScreenManagerFullscreen} : {fullscreen}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Genshin Settings: {ValueNameScreenManagerWidth} : {width}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Genshin Settings: {ValueNameScreenManagerHeight} : {height}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Genshin Settings: {ValueNameScreenManagerFullscreen} : {fullscreen}", LogType.Debug, true);
 #endif
                     return new ScreenManager { width = width, height = height, fullscreen = fullscreen };
                 }
@@ -145,13 +144,13 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                RegistryRoot?.SetValue(_ValueNameScreenManagerFullscreen, fullscreen, RegistryValueKind.DWord);
-                RegistryRoot?.SetValue(_ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
-                RegistryRoot?.SetValue(_ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
+                RegistryRoot?.SetValue(ValueNameScreenManagerFullscreen, fullscreen, RegistryValueKind.DWord);
+                RegistryRoot?.SetValue(ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
+                RegistryRoot?.SetValue(ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved Genshin Settings: {_ValueNameScreenManagerFullscreen} : {RegistryRoot?.GetValue(_ValueNameScreenManagerFullscreen, null)}", LogType.Debug, true);
-                LogWriteLine($"Saved Genshin Settings: {_ValueNameScreenManagerWidth} : {RegistryRoot?.GetValue(_ValueNameScreenManagerWidth, null)}", LogType.Debug, true);
-                LogWriteLine($"Saved Genshin Settings: {_ValueNameScreenManagerHeight} : {RegistryRoot?.GetValue(_ValueNameScreenManagerHeight, null)}", LogType.Debug, true);
+                LogWriteLine($"Saved Genshin Settings: {ValueNameScreenManagerFullscreen} : {RegistryRoot?.GetValue(ValueNameScreenManagerFullscreen, null)}", LogType.Debug, true);
+                LogWriteLine($"Saved Genshin Settings: {ValueNameScreenManagerWidth} : {RegistryRoot?.GetValue(ValueNameScreenManagerWidth, null)}", LogType.Debug, true);
+                LogWriteLine($"Saved Genshin Settings: {ValueNameScreenManagerHeight} : {RegistryRoot?.GetValue(ValueNameScreenManagerHeight, null)}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/VisibleBackground.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/VisibleBackground.cs
@@ -8,6 +8,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Genshin
@@ -15,7 +16,7 @@ namespace CollapseLauncher.GameSettings.Genshin
     internal class VisibleBackground
     {
         #region Fields
-        private const string _ValueName = "UnityVisibleBackground_h3203912122";
+        private const string ValueName = "UnityVisibleBackground_h3203912122";
         #endregion
 
         #region Properties
@@ -38,26 +39,26 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} since RegistryRoot is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} since RegistryRoot is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int borderless = (int)value;
 #if DEBUG
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Genshin Settings: {ValueName} : {value}", LogType.Debug, true);
 #endif 
                     return new VisibleBackground { borderless = borderless };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -68,16 +69,16 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, borderless, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, borderless, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved Genshin Settings: {_ValueName} : {borderless}", LogType.Debug, true);
+                LogWriteLine($"Saved Genshin Settings: {ValueName} : {borderless}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/WindowsHDR.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/WindowsHDR.cs
@@ -8,6 +8,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Genshin
@@ -15,7 +16,7 @@ namespace CollapseLauncher.GameSettings.Genshin
     internal class WindowsHDR
     {
         #region Fields
-        private const string _ValueName = "WINDOWS_HDR_ON_h3132281285";
+        private const string ValueName = "WINDOWS_HDR_ON_h3132281285";
         #endregion
 
         #region Properties
@@ -38,26 +39,26 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} since RegistryRoot is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} since RegistryRoot is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int hdr = (int)value;
 #if DEBUG
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Genshin Settings: {ValueName} : {value}", LogType.Debug, true);
 #endif 
                     return new WindowsHDR { HDR = hdr };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -68,16 +69,16 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, HDR, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, HDR, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved Genshin Settings: {_ValueName} : {HDR}", LogType.Debug, true);
+                LogWriteLine($"Saved Genshin Settings: {ValueName} : {HDR}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/Settings.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/Settings.cs
@@ -1,5 +1,6 @@
 ﻿using CollapseLauncher.GameSettings.Base;
 using CollapseLauncher.Interfaces;
+// ReSharper disable IdentifierTypo
 
 namespace CollapseLauncher.GameSettings.Genshin
 {
@@ -9,8 +10,8 @@ namespace CollapseLauncher.GameSettings.Genshin
         public VisibleBackground     SettingVisibleBackground { get; set; }
         public WindowsHDR            SettingsWindowsHDR       { get; set; }
 
-        public GenshinSettings(IGameVersion GameVersionManager)
-            : base(GameVersionManager)
+        public GenshinSettings(IGameVersion gameVersionManager)
+            : base(gameVersionManager)
         {
             // Initialize and Load Settings
             InitializeSettings();

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/GraphicsGrade.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/GraphicsGrade.cs
@@ -15,7 +15,7 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class GraphicsGrade : IGameSettingsValue<GraphicsGrade>
     {
         #region Fields
-        private const string _ValueName = "GENERAL_DATA_V2_GraphicsGrade_h1073342808";
+        private const string ValueName = "GENERAL_DATA_V2_GraphicsGrade_h1073342808";
         #endregion
         
         #region Enum
@@ -38,14 +38,14 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     SelectGraphicsGrade graphicsGrade = (SelectGraphicsGrade)value;
                     #if DEBUG
-                    LogWriteLine($"Loaded HI3 Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded HI3 Settings: {ValueName} : {value}", LogType.Debug, true);
                     #endif
 
                     return new GraphicsGrade { GraphicsGradeInt = graphicsGrade };
@@ -53,12 +53,12 @@ namespace CollapseLauncher.GameSettings.Honkai
             }
             catch ( Exception ex )
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                                 $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                                 $"\r\n  If the issue persist, please report it on GitHub" +
                                 $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                            $"Failed when reading game settings {_ValueName}\r\n" +
+                            $"Failed when reading game settings {ValueName}\r\n" +
                             $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                             $"{ex}", ex));
             }
@@ -70,18 +70,18 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
                 LogWriteLine("(HI3 GSP) Forcing GraphicsGrade to Custom!", LogType.Warning, true);
                 GraphicsGradeInt = SelectGraphicsGrade.Custom;
-                RegistryRoot.SetValue(_ValueName, GraphicsGradeInt, RegistryValueKind.DWord);
+                RegistryRoot.SetValue(ValueName, GraphicsGradeInt, RegistryValueKind.DWord);
                 #if DEBUG
-                LogWriteLine($"Saved HI3 Settings: {_ValueName} : {GraphicsGradeInt}", LogType.Debug, true);
+                LogWriteLine($"Saved HI3 Settings: {ValueName} : {GraphicsGradeInt}", LogType.Debug, true);
                 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalAudioSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalAudioSetting.cs
@@ -13,6 +13,8 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Honkai
@@ -20,22 +22,13 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class PersonalAudioSetting : IGameSettingsValue<PersonalAudioSetting>
     {
         #region Fields
-        private const    string                     _ValueName = "GENERAL_DATA_V2_PersonalAudioSetting_h3869048096";
-        private readonly PersonalAudioSettingVolume _VolumeValue;
-        private          int                        _MasterVolume      = 100;
-        private          int                        _BGMVolume         = 100;
-        private          int                        _SoundEffectVolume = 100;
-        private          int                        _VoiceVolume       = 100;
-        private          int                        _ElfVolume         = 100;
-        private          int                        _CGVolumeV2        = 100;
+        private const    string                     ValueName    = "GENERAL_DATA_V2_PersonalAudioSetting_h3869048096";
+        private readonly PersonalAudioSettingVolume _volumeValue = PersonalAudioSettingVolume.Load();
 
-        public PersonalAudioSetting()
-        {
-            _VolumeValue = PersonalAudioSettingVolume.Load();
-        }
         #endregion
 
         #region Properties
+
         /// <summary>
         /// This defines "<c>Master Volume</c>" slider In-game settings -> Audio.<br/><br/>
         /// Range: 0 - 100<br/>
@@ -43,13 +36,13 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public int MasterVolume
         {
-            get => _MasterVolume;
+            get;
             set
             {
-                _MasterVolume = value;
-                _VolumeValue.MasterVolumeValue = value;
+                field                          = value;
+                _volumeValue.MasterVolumeValue = value;
             }
-        }
+        } = 100;
 
         /// <summary>
         /// This defines "<c>BGM</c>" slider In-game settings -> Audio -> Volume Balance.<br/><br/>
@@ -58,13 +51,13 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public int BGMVolume
         {
-            get => _BGMVolume;
+            get;
             set
             {
-                _BGMVolume = value;
-                _VolumeValue.BGMVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
+                field                       = value;
+                _volumeValue.BGMVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
             }
-        }
+        } = 100;
 
         /// <summary>
         /// This defines "<c>SFX</c>" slider In-game settings -> Audio -> Volume Balance.<br/><br/>
@@ -73,13 +66,13 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public int SoundEffectVolume
         {
-            get => _SoundEffectVolume;
+            get;
             set
             {
-                _SoundEffectVolume = value;
-                _VolumeValue.SoundEffectVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
+                field                               = value;
+                _volumeValue.SoundEffectVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
             }
-        }
+        } = 100;
 
         /// <summary>
         /// This defines "<c>Voice Acting</c>" slider In-game settings -> Audio -> Volume Balance.<br/><br/>
@@ -88,13 +81,13 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public int VoiceVolume
         {
-            get => _VoiceVolume;
+            get;
             set
             {
-                _VoiceVolume = value;
-                _VolumeValue.VoiceVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
+                field                         = value;
+                _volumeValue.VoiceVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
             }
-        }
+        } = 100;
 
         /// <summary>
         /// This defines "<c>ELF VO</c>" slider In-game settings -> Audio -> Volume Balance.<br/><br/>
@@ -103,13 +96,13 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public int ElfVolume
         {
-            get => _ElfVolume;
+            get;
             set
             {
-                _ElfVolume = value;
-                _VolumeValue.ElfVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
+                field                       = value;
+                _volumeValue.ElfVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 3.0f);
             }
-        }
+        } = 100;
 
         /// <summary>
         /// This defines "<c>CG</c>" slider In-game settings -> Audio -> Volume Balance.<br/><br/>
@@ -118,13 +111,13 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public int CGVolumeV2
         {
-            get => _CGVolumeV2;
+            get;
             set
             {
-                _CGVolumeV2 = value;
-                _VolumeValue.CGVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 1.8f);
+                field                      = value;
+                _volumeValue.CGVolumeValue = ConvertRangeValue(0.0f, 100.0f, value, 0.0f, 1.8f);
             }
-        }
+        } = 100;
 
         /// <summary>
         /// This defines "<c>Mute</c>" switch In-game settings -> Audio.<br/><br/>
@@ -140,7 +133,7 @@ namespace CollapseLauncher.GameSettings.Honkai
         public string CVLanguage { get; set; } = "Japanese";
 
         /// <summary>
-        /// This defines "<c>Voice-over</c>" radiobox In-game settings -> Audio.<br/><br/>
+        /// This defines "<c>Voice-over</c>" radio box In-game settings -> Audio.<br/><br/>
         /// Values:<br/>
         ///     - 1 = Japanese<br/>
         ///     - 0 = Chinese(PRC)<br/><br/>
@@ -182,27 +175,27 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
+                    LogWriteLine($"Loaded HI3 Settings: {ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
 #endif
                     return byteStr.Deserialize(HonkaiSettingsJsonContext.Default.PersonalAudioSetting) ?? new PersonalAudioSetting();
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -214,21 +207,21 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(HonkaiSettingsJsonContext.Default.PersonalAudioSetting);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+                LogWriteLine($"Saved HI3 Settings: {ValueName}\r\n{data}", LogType.Debug, true);
 #endif
-                _VolumeValue.Save();
+                _volumeValue.Save();
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalAudioSettingVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalAudioSettingVolume.cs
@@ -11,6 +11,8 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Honkai
@@ -18,7 +20,7 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class PersonalAudioSettingVolume : IGameSettingsValue<PersonalAudioSettingVolume>
     {
         #region Fields
-        private const string _ValueName = "GENERAL_DATA_V2_PersonalAudioSettingVolume_h600615720";
+        private const string ValueName = "GENERAL_DATA_V2_PersonalAudioSettingVolume_h600615720";
         #endregion
 
         #region Properties
@@ -76,27 +78,27 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+                    LogWriteLine($"Loaded HI3 Settings: {ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
 #endif
                     return byteStr.Deserialize(HonkaiSettingsJsonContext.Default.PersonalAudioSettingVolume) ?? new PersonalAudioSettingVolume();
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -107,20 +109,20 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(HonkaiSettingsJsonContext.Default.PersonalAudioSettingVolume);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+                LogWriteLine($"Saved HI3 Settings: {ValueName}\r\n{data}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalGraphicsSettingV2.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalGraphicsSettingV2.cs
@@ -20,9 +20,8 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class PersonalGraphicsSettingV2 : IGameSettingsValue<PersonalGraphicsSettingV2>
     {
         #region Fields
-        private const string _ValueName = "GENERAL_DATA_V2_PersonalGraphicsSettingV2_h3480068519";
-        private short _TargetFrameRateForInLevel = 60;
-        private short _TargetFrameRateForOthers = 60;
+        private const string ValueName                = "GENERAL_DATA_V2_PersonalGraphicsSettingV2_h3480068519";
+
         #endregion
 
         #region Properties
@@ -47,9 +46,9 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public short TargetFrameRateForInLevel
         {
-            get => _TargetFrameRateForInLevel;
-            set => _TargetFrameRateForInLevel = value < 1 ? _TargetFrameRateForInLevel : value;
-        }
+            get;
+            set => field = value < 1 ? field : value;
+        } = 60;
 
         /// <summary>
         /// This defines "<c>FPS out of combat</c>" combobox In-game settings -> Video.<br/>
@@ -58,9 +57,9 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// </summary>
         public short TargetFrameRateForOthers
         {
-            get => _TargetFrameRateForOthers;
-            set => _TargetFrameRateForOthers = value < 1 ? _TargetFrameRateForOthers : value;
-        }
+            get;
+            set => field = value < 1 ? field : value;
+        } = 60;
 
         /// <summary>
         /// This defines "<c>Reflection</c>" combobox In-game settings -> Video.<br/>
@@ -185,27 +184,27 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
+                    LogWriteLine($"Loaded HI3 Settings: {ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
 #endif
                     return byteStr.Deserialize(HonkaiSettingsJsonContext.Default.PersonalGraphicsSettingV2) ?? new PersonalGraphicsSettingV2();
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -217,20 +216,20 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(HonkaiSettingsJsonContext.Default.PersonalGraphicsSettingV2);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+                LogWriteLine($"Saved HI3 Settings: {ValueName}\r\n{data}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
                 SentryHelper.ExceptionHandler(ex, SentryHelper.ExceptionType.UnhandledOther);
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PhysicsSimulation.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PhysicsSimulation.cs
@@ -16,7 +16,7 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class PhysicsSimulation : IGameSettingsValue<PhysicsSimulation>
     {
         #region Fields
-        private const string _ValueName = "GENERAL_DATA_V2_UsePhysicsSimulation_h1109146915";
+        private const string ValueName = "GENERAL_DATA_V2_UsePhysicsSimulation_h1109146915";
         #endregion
 
         #region Properties
@@ -38,14 +38,14 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int physicsSimulation = (int)value;
                     #if DEBUG
-                    LogWriteLine($"Loaded HI3 Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded HI3 Settings: {ValueName} : {value}", LogType.Debug, true);
                     #endif
 
                     return new PhysicsSimulation { UsePhysicsSimulation = physicsSimulation };
@@ -53,12 +53,12 @@ namespace CollapseLauncher.GameSettings.Honkai
             }
             catch ( Exception ex )
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                                 $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                                 $"\r\n  If the issue persist, please report it on GitHub" +
                                 $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                            $"Failed when reading game settings {_ValueName}\r\n" +
+                            $"Failed when reading game settings {ValueName}\r\n" +
                             $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                             $"{ex}", ex));
             }
@@ -70,16 +70,16 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, UsePhysicsSimulation, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, UsePhysicsSimulation, RegistryValueKind.DWord);
                 #if DEBUG
-                LogWriteLine($"Saved HI3 Settings: {_ValueName} : {UsePhysicsSimulation}", LogType.Debug, true);
+                LogWriteLine($"Saved HI3 Settings: {ValueName} : {UsePhysicsSimulation}", LogType.Debug, true);
                 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/Preset.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/Preset.cs
@@ -20,27 +20,25 @@ namespace CollapseLauncher.GameSettings
     {
 #nullable enable
         #region Fields
-        private          string                  CurrentPresetName = PresetConst.DefaultPresetName;
-        private readonly Dictionary<string, T1>? _Presets;
+        private          string                  _currentPresetName = PresetConst.DefaultPresetName;
+
         #endregion
 
         #region Properties
+
         /// <summary>
         /// The preset of the given settings
         /// </summary>
         public Dictionary<string, T1>? Presets
         {
-            get
-            {
-                return _Presets;
-            }
+            get;
             init
             {
-                _Presets?.Clear();
-                _Presets = value;
-#nullable disable
-                _Presets?.Add(PresetConst.DefaultPresetName, default);
-#nullable enable
+                field?.Clear();
+                field = value;
+            #nullable disable
+                field?.Add(PresetConst.DefaultPresetName, default);
+            #nullable enable
             }
         }
 
@@ -51,9 +49,9 @@ namespace CollapseLauncher.GameSettings
         #endregion
 
         #region Methods
-        public Preset(string presetJSONPath, JsonTypeInfo<Dictionary<string, T1>?> jsonType)
+        public Preset(string presetJsonPath, JsonTypeInfo<Dictionary<string, T1>?> jsonType)
         {
-            using FileStream fs = new FileStream(presetJSONPath, FileMode.Open, FileAccess.Read);
+            using FileStream fs = new FileStream(presetJsonPath, FileMode.Open, FileAccess.Read);
             Presets    = fs.Deserialize(jsonType);
             PresetKeys = GetPresetKeys();
         }
@@ -69,10 +67,6 @@ namespace CollapseLauncher.GameSettings
             string presetPath = Path.Combine(AppExecutableDir, $@"Assets\Presets\{gameType}\", $"{typeof(T1).Name}.json");
             return new Preset<T1, TObjectType>(presetPath, jsonType);
         }
-
-        /// <param name="key">The key of the preset</param>
-        /// <returns>Returns a boolean to check whether the key exists. Otherwise, false if key doesn't exist or preset is <c>null</c></returns>
-        public bool IsPresetKeyExist(string key) => Presets?.ContainsKey(key) ?? false;
 
         /// <param name="key">The key of the preset</param>
         /// <returns>Returns a value of the preset by its key</returns>
@@ -115,11 +109,11 @@ namespace CollapseLauncher.GameSettings
 
                 if (foundPreset.HasValue)
                 {
-                    CurrentPresetName = foundPreset.Value.Key;
+                    _currentPresetName = foundPreset.Value.Key;
                 }
                 return;
             }
-            CurrentPresetName = PresetConst.DefaultPresetName;
+            _currentPresetName = PresetConst.DefaultPresetName;
         }
 
         /// <returns>Get the current preset key name. If it doesn't match, then return the <c>DefaultPresetName</c></returns>
@@ -153,7 +147,7 @@ namespace CollapseLauncher.GameSettings
             string presetRegistryName = $"Preset_{typeof(T1).Name}";
             if (RegistryRoot == null) throw new NullReferenceException($"Cannot save preset name of {typeof(T1).Name} since RegistryKey is unexpectedly not initialized!");
 
-            RegistryRoot.SetValue(presetRegistryName, CurrentPresetName, RegistryValueKind.String);
+            RegistryRoot.SetValue(presetRegistryName, _currentPresetName, RegistryValueKind.String);
         }
         #endregion
     }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/ScreenSettingData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/ScreenSettingData.cs
@@ -22,11 +22,11 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class ScreenSettingData : BaseScreenSettingData, IGameSettingsValue<ScreenSettingData>
     {
         #region Fields
-        private const           string _ValueName                        = "GENERAL_DATA_V2_ScreenSettingData_h1916288658";
-        private const           string _ValueNameScreenManagerFullscreen = "Screenmanager Is Fullscreen mode_h3981298716";
-        private const           string _ValueNameScreenManagerWidth      = "Screenmanager Resolution Width_h182942802";
-        private const           string _ValueNameScreenManagerHeight     = "Screenmanager Resolution Height_h2627697771";
-        private static readonly Size   currentRes                        = ScreenProp.CurrentResolution;
+        private const           string ValueName                        = "GENERAL_DATA_V2_ScreenSettingData_h1916288658";
+        private const           string ValueNameScreenManagerFullscreen = "Screenmanager Is Fullscreen mode_h3981298716";
+        private const           string ValueNameScreenManagerWidth      = "Screenmanager Resolution Width_h182942802";
+        private const           string ValueNameScreenManagerHeight     = "Screenmanager Resolution Height_h2627697771";
+        private static readonly Size   CurrentRes                        = ScreenProp.CurrentResolution;
         #endregion
 
         #region Properties
@@ -41,8 +41,8 @@ namespace CollapseLauncher.GameSettings.Honkai
             get => new(width, height);
             set
             {
-                width = value.Width < 64 ? currentRes.Width : value.Width;
-                height = value.Height < 64 ? currentRes.Height : value.Height;
+                width = value.Width < 64 ? CurrentRes.Width : value.Width;
+                height = value.Height < 64 ? CurrentRes.Height : value.Height;
             }
         }
 
@@ -58,12 +58,10 @@ namespace CollapseLauncher.GameSettings.Honkai
             set
             {
                 string[] size = value.Split('x');
-                int w;
-                int h;
-                if (!int.TryParse(size[0], out w) || !int.TryParse(size[1], out h))
+                if (!int.TryParse(size[0], out var w) || !int.TryParse(size[1], out var h))
                 {
-                    width = currentRes.Width;
-                    height = currentRes.Height;
+                    width = CurrentRes.Width;
+                    height = CurrentRes.Height;
                 }
                 else
                 {
@@ -78,14 +76,14 @@ namespace CollapseLauncher.GameSettings.Honkai
         /// Range: 0 - int.MaxValue<br/>
         /// Default: Your screen width
         /// </summary>
-        public override int width { get; set; } = currentRes.Width;
+        public override int width { get; set; } = CurrentRes.Width;
 
         /// <summary>
         /// This defines "<c>Game Resolution</c>'s Height" combobox In-game settings -> Video.<br/><br/>
         /// Range: 0 - int.MaxValue<br/>
         /// Default: Your screen Height
         /// </summary>
-        public override int height { get; set; } = currentRes.Height;
+        public override int height { get; set; } = CurrentRes.Height;
 
         /// <summary>
         /// This defines "<c>Fullscreen</c>" checkbox In-game settings -> Video.<br/><br/>
@@ -100,27 +98,27 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
+                    LogWriteLine($"Loaded HI3 Settings: {ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
 #endif
                     return byteStr.Deserialize(HonkaiSettingsJsonContext.Default.ScreenSettingData) ?? new ScreenSettingData();
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -132,29 +130,29 @@ namespace CollapseLauncher.GameSettings.Honkai
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(HonkaiSettingsJsonContext.Default.ScreenSettingData);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+                LogWriteLine($"Saved HI3 Settings: {ValueName}\r\n{data}", LogType.Debug, true);
 #endif
                 SaveIndividualRegistry();
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 
         private void SaveIndividualRegistry()
         {
-            RegistryRoot?.SetValue(_ValueNameScreenManagerFullscreen, isfullScreen ? 1 : 0, RegistryValueKind.DWord);
-            RegistryRoot?.SetValue(_ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
-            RegistryRoot?.SetValue(_ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
+            RegistryRoot?.SetValue(ValueNameScreenManagerFullscreen, isfullScreen ? 1 : 0, RegistryValueKind.DWord);
+            RegistryRoot?.SetValue(ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
+            RegistryRoot?.SetValue(ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
         }
 
         public override bool Equals(object? comparedTo) => comparedTo is ScreenSettingData toThis && TypeExtensions.IsInstancePropertyEqual(this, toThis);

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/Settings.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/Settings.cs
@@ -10,7 +10,7 @@ namespace CollapseLauncher.GameSettings.Honkai
     internal class HonkaiSettings : SettingsBase
     {
         #region PresetProperties
-        public Preset<PersonalGraphicsSettingV2, HonkaiSettingsJsonContext> Preset_SettingsGraphics { get; set; }
+        public Preset<PersonalGraphicsSettingV2, HonkaiSettingsJsonContext> PresetSettingsGraphics { get; set; }
         #endregion
 
         #region SettingProperties
@@ -20,8 +20,8 @@ namespace CollapseLauncher.GameSettings.Honkai
         public GraphicsGrade             SettingsGraphicsGrade  { get; set; }
         #endregion
 
-        public HonkaiSettings(IGameVersion GameVersionManager)
-            : base(GameVersionManager)
+        public HonkaiSettings(IGameVersion gameVersionManager)
+            : base(gameVersionManager)
         {
             // Initialize and Load Settings
             InitializeSettings();
@@ -38,7 +38,7 @@ namespace CollapseLauncher.GameSettings.Honkai
             base.InitializeSettings();
 
             // Load Preset
-            Preset_SettingsGraphics = Preset<PersonalGraphicsSettingV2, HonkaiSettingsJsonContext>.LoadPreset(GameNameType.Honkai, HonkaiSettingsJsonContext.Default.DictionaryStringPersonalGraphicsSettingV2);
+            PresetSettingsGraphics = Preset<PersonalGraphicsSettingV2, HonkaiSettingsJsonContext>.LoadPreset(GameNameType.Honkai, HonkaiSettingsJsonContext.Default.DictionaryStringPersonalGraphicsSettingV2);
         }
 
         public override void ReloadSettings() => InitializeSettings();
@@ -54,7 +54,7 @@ namespace CollapseLauncher.GameSettings.Honkai
             base.SaveSettings();
 
             // Save Preset
-            Preset_SettingsGraphics.SaveChanges();
+            PresetSettingsGraphics.SaveChanges();
         }
 
         public override IGameSettingsUniversal AsIGameSettingsUniversal() => this;

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/BGMVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/BGMVolume.cs
@@ -9,6 +9,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.StarRail
@@ -16,7 +17,7 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class BGMVolume : IGameSettingsValue<BGMVolume>
     {
         #region Fields
-        private const string _ValueName = "AudioSettings_BGMVolume_h240914409";
+        private const string ValueName = "AudioSettings_BGMVolume_h240914409";
         #endregion
 
         #region Properties
@@ -35,26 +36,26 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int bgmVolume = (int)value;
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName} : {value}", LogType.Debug, true);
 #endif
                     return new BGMVolume { BGMVol = bgmVolume };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -65,16 +66,16 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, BGMVol, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, BGMVol, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {BGMVol}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName} : {BGMVol}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
 
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalAudioLanguage.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalAudioLanguage.cs
@@ -17,7 +17,7 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class LocalAudioLanguage : IGameSettingsValue<LocalAudioLanguage>
     {
         #region Fields
-        private const string _ValueName = "LanguageSettings_LocalAudioLanguage_h882585060";
+        private const string ValueName = "LanguageSettings_LocalAudioLanguage_h882585060";
         #endregion
 
         #region Properties
@@ -61,26 +61,26 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
-                    string _localAudioLang = Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1);
+                    string localAudioLang = Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1);
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
 #endif
-                    return new LocalAudioLanguage { LocalAudioLang = _localAudioLang };
+                    return new LocalAudioLanguage { LocalAudioLang = localAudioLang };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -91,18 +91,18 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
                 string data = LocalAudioLang + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {data}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName} : {data}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
 
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalTextLanguage.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalTextLanguage.cs
@@ -17,7 +17,7 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class LocalTextLanguage : IGameSettingsValue<LocalTextLanguage>
     {
         #region Fields
-        private const string _ValueName = "LanguageSettings_LocalTextLanguage_h2764291023";
+        private const string ValueName = "LanguageSettings_LocalTextLanguage_h2764291023";
         #endregion
 
         #region Properties
@@ -79,22 +79,22 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
-                    string _localTextLang = Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1);
+                    string localTextLang = Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1);
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
 #endif
-                    return new LocalTextLanguage { LocalTextLang = _localTextLang };
+                    return new LocalTextLanguage { LocalTextLang = localTextLang };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to read {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed while reading {ValueName}\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to read {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
             return new LocalTextLanguage();
         }
@@ -103,22 +103,22 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
                 string data = LocalTextLang + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {data}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName} : {data}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/MasterVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/MasterVolume.cs
@@ -16,7 +16,7 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class MasterVolume : IGameSettingsValue<MasterVolume>
     {
         #region Fields
-        private const string _ValueName = "AudioSettings_MasterVolume_h1622207037";
+        private const string ValueName = "AudioSettings_MasterVolume_h1622207037";
         #endregion
 
         #region Properties
@@ -35,26 +35,26 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int masterVolume = (int)value;
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName} : {value}", LogType.Debug, true);
 #endif
                     return new MasterVolume { MasterVol = masterVolume };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -65,16 +65,16 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, MasterVol, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, MasterVol, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {MasterVol}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName} : {MasterVol}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
 
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/Model.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/Model.cs
@@ -13,6 +13,8 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.StarRail
@@ -53,25 +55,25 @@ namespace CollapseLauncher.GameSettings.StarRail
     {
         #region Fields
 
-        public const  string _ValueName       = "GraphicsSettings_Model_h2986158309";
-        private const string _GraphicsQuality = "GraphicsSettings_GraphicsQuality_h523255858";
+        public const  string ValueName       = "GraphicsSettings_Model_h2986158309";
+        private const string GraphicsQuality = "GraphicsSettings_GraphicsQuality_h523255858";
         
-        public static readonly int[]                FPSIndex        = [30, 60, 120];
-        public const           int                  FPSDefaultIndex = 1; // 60 in FPSIndex[]
-        public static          Dictionary<int, int> FPSIndexDict    = GenerateStaticFPSIndexDict();
-        private static Dictionary<int, int> GenerateStaticFPSIndexDict()
+        public static readonly int[]                FpsIndex        = [30, 60, 120];
+        public const           int                  FpsDefaultIndex = 1; // 60 in FPSIndex[]
+        public static          Dictionary<int, int> FpsIndexDict    = GenerateStaticFpsIndexDict();
+        private static Dictionary<int, int> GenerateStaticFpsIndexDict()
         {
             Dictionary<int, int> ret = new();
-            for (int i = 0; i < FPSIndex.Length; i++)
+            for (int i = 0; i < FpsIndex.Length; i++)
             {
-                ret.Add(FPSIndex[i], i);
+                ret.Add(FpsIndex[i], i);
             }
             return ret;
         }
         #endregion
 
         #region Presets
-        private static readonly Model _VeryLowPreset = new()
+        private static readonly Model VeryLowPreset = new()
         {
             FPS                      = 60,
             EnableVSync              = false,
@@ -88,10 +90,9 @@ namespace CollapseLauncher.GameSettings.StarRail
             EnableMetalFXSU          = false,
             EnableHalfResTransparent = false,
             EnableSelfShadow         = 2
-            
         };
 
-        private static readonly Model _LowPreset = new()
+        private static readonly Model LowPreset = new()
         {
             FPS                      = 60,
             EnableVSync              = true,
@@ -110,7 +111,7 @@ namespace CollapseLauncher.GameSettings.StarRail
             EnableSelfShadow         = 2
         };
 
-        private static readonly Model _MediumPreset = new()
+        private static readonly Model MediumPreset = new()
         {
             FPS                      = 60,
             EnableVSync              = true,
@@ -129,7 +130,7 @@ namespace CollapseLauncher.GameSettings.StarRail
             EnableSelfShadow         = 2
         };
 
-        private static readonly Model _HighPreset = new()
+        private static readonly Model HighPreset = new()
         {
             FPS                      = 60,
             EnableVSync              = true,
@@ -148,7 +149,7 @@ namespace CollapseLauncher.GameSettings.StarRail
             EnableSelfShadow         = 1
         };
 
-        private static readonly Model _VeryHighPreset = new()
+        private static readonly Model VeryHighPreset = new()
         {
             FPS                      = 60,
             EnableVSync              = true,
@@ -174,7 +175,7 @@ namespace CollapseLauncher.GameSettings.StarRail
         /// Options: 30, 60, 120 (EXPERIMENTAL) <br/>
         /// Default: 60 (or depends on FPSDefaultIndex and FPSIndex content)
         /// </summary>
-        public int FPS { get; set; } = FPSIndex[FPSDefaultIndex];
+        public int FPS { get; set; } = FpsIndex[FpsDefaultIndex];
 
         /// <summary>
         /// This defines "<c>V-Sync</c>" combobox In-game settings. <br/>
@@ -287,27 +288,27 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_GraphicsQuality} RegistryKey is unexpectedly not initialized!");
-                var graphicsQuality = (Quality)RegistryRoot.GetValue(_GraphicsQuality, Quality.Medium);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {GraphicsQuality} RegistryKey is unexpectedly not initialized!");
+                var graphicsQuality = (Quality)RegistryRoot.GetValue(GraphicsQuality, Quality.Medium);
                 return graphicsQuality switch
                 {
                     Quality.Custom => LoadCustom(),
-                    Quality.VeryLow => _VeryLowPreset,
-                    Quality.Low => _LowPreset,
-                    Quality.Medium => _MediumPreset,
-                    Quality.High => _HighPreset,
-                    Quality.VeryHigh => _VeryHighPreset,
+                    Quality.VeryLow => VeryLowPreset,
+                    Quality.Low => LowPreset,
+                    Quality.Medium => MediumPreset,
+                    Quality.High => HighPreset,
+                    Quality.VeryHigh => VeryHighPreset,
                     _ => new Model()
                 };
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_GraphicsQuality}" +
+                LogWriteLine($"Failed while reading {GraphicsQuality}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_GraphicsQuality}\r\n" +
+                    $"Failed when reading game settings {GraphicsQuality}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -319,14 +320,14 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
 #endif
 
                     return byteStr.Deserialize(StarRailSettingsJsonContext.Default.Model) ?? new Model();
@@ -334,24 +335,24 @@ namespace CollapseLauncher.GameSettings.StarRail
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
 
-            return _MediumPreset;
+            return MediumPreset;
         }
 
         public void Save()
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
                 
                 if (StarRailGameSettingsPage.CheckAbTest())
                 {
@@ -360,19 +361,19 @@ namespace CollapseLauncher.GameSettings.StarRail
                     return;
                 }
 
-                RegistryRoot.SetValue(_GraphicsQuality, Quality.Custom, RegistryValueKind.DWord);
+                RegistryRoot.SetValue(GraphicsQuality, Quality.Custom, RegistryValueKind.DWord);
 
                 string data = this.Serialize(StarRailSettingsJsonContext.Default.Model);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName}\r\n{data}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
                 SentryHelper.ExceptionHandler(ex, SentryHelper.ExceptionType.UnhandledOther);
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/PCResolution.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/PCResolution.cs
@@ -15,6 +15,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.StarRail
@@ -22,11 +23,11 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class PCResolution : BaseScreenSettingData, IGameSettingsValue<PCResolution>
     {
         #region Fields
-        private const           string _ValueName                        = "GraphicsSettings_PCResolution_h431323223";
-        private const           string _ValueNameScreenManagerWidth      = "Screenmanager Resolution Width_h182942802";
-        private const           string _ValueNameScreenManagerHeight     = "Screenmanager Resolution Height_h2627697771";
-        private const           string _ValueNameScreenManagerFullscreen = "Screenmanager Fullscreen mode_h3630240806";
-        private static readonly Size   currentRes                        = ScreenProp.CurrentResolution;
+        private const           string ValueName                        = "GraphicsSettings_PCResolution_h431323223";
+        private const           string ValueNameScreenManagerWidth      = "Screenmanager Resolution Width_h182942802";
+        private const           string ValueNameScreenManagerHeight     = "Screenmanager Resolution Height_h2627697771";
+        private const           string ValueNameScreenManagerFullscreen = "Screenmanager Fullscreen mode_h3630240806";
+        private static readonly Size   CurrentRes                       = ScreenProp.CurrentResolution;
         #endregion
 
         #region Properties
@@ -41,8 +42,8 @@ namespace CollapseLauncher.GameSettings.StarRail
             get => new(width, height);
             set
             {
-                width = value.Width < 64 ? currentRes.Width : value.Width;
-                height = value.Height < 64 ? currentRes.Height : value.Height;
+                width = value.Width < 64 ? CurrentRes.Width : value.Width;
+                height = value.Height < 64 ? CurrentRes.Height : value.Height;
             }
         }
 
@@ -58,12 +59,10 @@ namespace CollapseLauncher.GameSettings.StarRail
             set
             {
                 string[] size = value.Split('x');
-                int w;
-                int h;
-                if (!int.TryParse(size[0], out w) || !int.TryParse(size[1], out h))
+                if (!int.TryParse(size[0], out var w) || !int.TryParse(size[1], out var h))
                 {
-                    width = currentRes.Width;
-                    height = currentRes.Height;
+                    width = CurrentRes.Width;
+                    height = CurrentRes.Height;
                 }
                 else
                 {
@@ -78,14 +77,14 @@ namespace CollapseLauncher.GameSettings.StarRail
         /// Range: 0 - int.MaxValue<br/>
         /// Default: Your screen width
         /// </summary>
-        public override int width { get; set; } = currentRes.Width;
+        public override int width { get; set; } = CurrentRes.Width;
 
         /// <summary>
         /// This defines "<c>Game Resolution</c>'s Height" combobox In-game settings -> Video.<br/><br/>
         /// Range: 0 - int.MaxValue<br/>
         /// Default: Your screen Height
         /// </summary>
-        public override int height { get; set; } = currentRes.Height;
+        public override int height { get; set; } = CurrentRes.Height;
 
         /// <summary>
         /// This defines "<c>Fullscreen</c>" checkbox In-game settings -> Video.<br/><br/>
@@ -110,27 +109,27 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName}\r\n{Encoding.UTF8.GetString(byteStr.TrimEnd((byte)0))}", LogType.Debug, true);
 #endif
                     return byteStr.Deserialize(StarRailSettingsJsonContext.Default.PCResolution) ?? new PCResolution();
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -142,33 +141,33 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(StarRailSettingsJsonContext.Default.PCResolution);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName}\r\n{data}", LogType.Debug, true);
 #endif
                 SaveIndividualRegistry();
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 
         private void SaveIndividualRegistry()
         {
-            RegistryRoot?.SetValue(_ValueNameScreenManagerFullscreen, isfullScreen ? 1 : 3, RegistryValueKind.DWord);
-            RegistryRoot?.SetValue(_ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
-            RegistryRoot?.SetValue(_ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
+            RegistryRoot?.SetValue(ValueNameScreenManagerFullscreen, isfullScreen ? 1 : 3, RegistryValueKind.DWord);
+            RegistryRoot?.SetValue(ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
+            RegistryRoot?.SetValue(ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
 #if DEBUG
-            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerFullscreen} : {RegistryRoot?.GetValue(_ValueNameScreenManagerFullscreen, null)}", LogType.Debug, true);
-            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerWidth} : {RegistryRoot?.GetValue(_ValueNameScreenManagerWidth, null)}", LogType.Debug, true);
-            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerHeight} : {RegistryRoot?.GetValue(_ValueNameScreenManagerHeight, null)}", LogType.Debug, true);
+            LogWriteLine($"Saved StarRail Settings: {ValueNameScreenManagerFullscreen} : {RegistryRoot?.GetValue(ValueNameScreenManagerFullscreen, null)}", LogType.Debug, true);
+            LogWriteLine($"Saved StarRail Settings: {ValueNameScreenManagerWidth} : {RegistryRoot?.GetValue(ValueNameScreenManagerWidth, null)}", LogType.Debug, true);
+            LogWriteLine($"Saved StarRail Settings: {ValueNameScreenManagerHeight} : {RegistryRoot?.GetValue(ValueNameScreenManagerHeight, null)}", LogType.Debug, true);
 #endif
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/SFXVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/SFXVolume.cs
@@ -9,6 +9,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.StarRail
@@ -16,7 +17,7 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class SFXVolume : IGameSettingsValue<SFXVolume>
     {
         #region Fields
-        private const string _ValueName = "AudioSettings_SFXVolume_h2753520268";
+        private const string ValueName = "AudioSettings_SFXVolume_h2753520268";
         #endregion
 
         #region Properties
@@ -35,26 +36,26 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int sfxVolume = (int)value;
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName} : {value}", LogType.Debug, true);
 #endif
                     return new SFXVolume { SFXVol = sfxVolume };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -65,16 +66,16 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, SFXVol, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, SFXVol, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {SFXVol}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName} : {SFXVol}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
 
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/VOVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/VOVolume.cs
@@ -9,6 +9,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.StarRail
@@ -16,7 +17,7 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class VOVolume : IGameSettingsValue<VOVolume>
     {
         #region Fields
-        private const string _ValueName = "AudioSettings_VOVolume_h805685304";
+        private const string ValueName = "AudioSettings_VOVolume_h805685304";
         #endregion
 
         #region Properties
@@ -35,26 +36,26 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
                 if (value != null)
                 {
                     int voVolume = (int)value;
 #if DEBUG
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+                    LogWriteLine($"Loaded StarRail Settings: {ValueName} : {value}", LogType.Debug, true);
 #endif
                     return new VOVolume { VOVol = voVolume };
                 }
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}" +
+                LogWriteLine($"Failed while reading {ValueName}" +
                              $"\r\n  Please open the game and change any Graphics Settings, then close normally. After that you can use this feature." +
                              $"\r\n  If the issue persist, please report it on GitHub" +
                              $"\r\n{ex}", LogType.Error, true);
                 ErrorSender.SendException(new Exception(
-                    $"Failed when reading game settings {_ValueName}\r\n" +
+                    $"Failed when reading game settings {ValueName}\r\n" +
                     $"Please open the game and change any graphics settings, then safely close the game. If the problem persist, report the issue on our GitHub\r\n" +
                     $"{ex}", ex));
             }
@@ -65,16 +66,16 @@ namespace CollapseLauncher.GameSettings.StarRail
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-                RegistryRoot.SetValue(_ValueName, VOVol, RegistryValueKind.DWord);
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
+                RegistryRoot.SetValue(ValueName, VOVol, RegistryValueKind.DWord);
 #if DEBUG
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {VOVol}", LogType.Debug, true);
+                LogWriteLine($"Saved StarRail Settings: {ValueName} : {VOVol}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
 
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/Settings.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/Settings.cs
@@ -7,15 +7,15 @@ namespace CollapseLauncher.GameSettings.StarRail
     internal class StarRailSettings : SettingsBase
     {
         public Model GraphicsSettings { get; set; }
-        public BGMVolume AudioSettings_BGM { get; set; }
-        public MasterVolume AudioSettings_Master { get; set; }
-        public SFXVolume AudioSettings_SFX { get; set; }
-        public VOVolume AudioSettings_VO { get; set; }
+        public BGMVolume AudioSettingsBgm { get; set; }
+        public MasterVolume AudioSettingsMaster { get; set; }
+        public SFXVolume AudioSettingsSfx { get; set; }
+        public VOVolume AudioSettingsVo { get; set; }
         public LocalAudioLanguage AudioLanguage { get; set; }
         public LocalTextLanguage TextLanguage { get; set; }
 
-        public StarRailSettings(IGameVersion GameVersionManager)
-            : base(GameVersionManager)
+        public StarRailSettings(IGameVersion gameVersionManager)
+            : base(gameVersionManager)
         {
             // Initialize and Load Settings
             InitializeSettings();
@@ -31,10 +31,10 @@ namespace CollapseLauncher.GameSettings.StarRail
         public override void ReloadSettings()
         {
             // Load rest of the settings for GSP
-            AudioSettings_BGM    = BGMVolume.Load();
-            AudioSettings_Master = MasterVolume.Load();
-            AudioSettings_SFX    = SFXVolume.Load();
-            AudioSettings_VO     = VOVolume.Load();
+            AudioSettingsBgm    = BGMVolume.Load();
+            AudioSettingsMaster = MasterVolume.Load();
+            AudioSettingsSfx    = SFXVolume.Load();
+            AudioSettingsVo     = VOVolume.Load();
             AudioLanguage        = LocalAudioLanguage.Load();
             TextLanguage         = LocalTextLanguage.Load();
             GraphicsSettings     = Model.Load();
@@ -48,10 +48,10 @@ namespace CollapseLauncher.GameSettings.StarRail
             base.SaveSettings();
             GraphicsSettings?.Save();
             SettingsScreen?.Save();
-            AudioSettings_BGM?.Save();
-            AudioSettings_Master?.Save();
-            AudioSettings_SFX?.Save();
-            AudioSettings_VO?.Save();
+            AudioSettingsBgm?.Save();
+            AudioSettingsMaster?.Save();
+            AudioSettingsSfx?.Save();
+            AudioSettingsVo?.Save();
             AudioLanguage?.Save();
             TextLanguage?.Save();
         }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseMiscSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseMiscSetting.cs
@@ -11,6 +11,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantArgumentDefaultValue
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Universal
@@ -18,13 +19,9 @@ namespace CollapseLauncher.GameSettings.Universal
     internal class CollapseMiscSetting : IGameSettingsValue<CollapseMiscSetting>
     {
         #region Fields
-        private const string _ValueName = "CollapseLauncher_Misc";
+        private const string ValueName = "CollapseLauncher_Misc";
 
-        private bool _UseCustomArguments = true;
-        
-        private bool _UseCustomRegionBG  = false;
-
-        private static bool _IsDeserializing;
+        private static bool _isDeserializing;
         #endregion
 
         #region Properties
@@ -40,14 +37,14 @@ namespace CollapseLauncher.GameSettings.Universal
         /// </summary>
         public bool UseCustomArguments
         {
-            get => _UseCustomArguments;
+            get;
             set
             {
-                _UseCustomArguments = value;
+                field = value;
                 // Stop saving if Load() is not yet done.
-                if (!_IsDeserializing) Save();
+                if (!_isDeserializing) Save();
             }
-        }
+        } = true;
 
         /// <summary>
         /// This defines if Advanced Game Settings should be shown in respective GSP and used.<br/><br/>
@@ -100,20 +97,19 @@ namespace CollapseLauncher.GameSettings.Universal
         /// </summary>
         public bool UseCustomRegionBG
         {
-            get => _UseCustomRegionBG;
+            get;
             set
             {
-                _UseCustomRegionBG = value;
-                if (!_IsDeserializing) Save();
+                field = value;
+                if (!_isDeserializing) Save();
             }
-        }
+        } = false;
 
-#nullable enable
+    #nullable enable
         /// <summary>
         /// The path of the custom BG for each region
         /// </summary>
         public string? CustomRegionBGPath { get; set; }
-#nullable restore
 
         /// <summary>
         /// Determines if the game playtime should be synced to the database
@@ -128,15 +124,15 @@ namespace CollapseLauncher.GameSettings.Universal
         #endregion
 
         #region Methods
-#nullable enable
+
         public static CollapseMiscSetting Load()
         {
             try
             {
-                _IsDeserializing = true;
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                _isDeserializing = true;
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
@@ -149,12 +145,12 @@ namespace CollapseLauncher.GameSettings.Universal
             }
             catch ( Exception ex )
             {
-                LogWriteLine($"Failed while reading {_ValueName}\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to read {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed while reading {ValueName}\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to read {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
             finally
             {
-                _IsDeserializing = false;
+                _isDeserializing = false;
             }
 
             return new CollapseMiscSetting();
@@ -164,19 +160,19 @@ namespace CollapseLauncher.GameSettings.Universal
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(UniversalSettingsJsonContext.Default.CollapseMiscSetting, true);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 #if DEBUG
                 LogWriteLine($"Saved Collapse Misc Settings:\r\n{data}", LogType.Debug, true);
 #endif
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
@@ -10,6 +10,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable RedundantDefaultMemberInitializer
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable InconsistentNaming
 
 #pragma warning disable CS0659
 namespace CollapseLauncher.GameSettings.Universal
@@ -17,7 +18,7 @@ namespace CollapseLauncher.GameSettings.Universal
     internal class CollapseScreenSetting : IGameSettingsValue<CollapseScreenSetting>
     {
         #region Fields
-        private const string _ValueName = "CollapseLauncher_ScreenSetting";
+        private const string ValueName = "CollapseLauncher_ScreenSetting";
         #endregion
 
         #region Properties
@@ -65,9 +66,9 @@ namespace CollapseLauncher.GameSettings.Universal
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 
-                object? value = RegistryRoot.GetValue(_ValueName, null);
+                object? value = RegistryRoot.GetValue(ValueName, null);
 
                 if (value != null)
                 {
@@ -80,8 +81,8 @@ namespace CollapseLauncher.GameSettings.Universal
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to read {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed while reading {ValueName}\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to read {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
 
             return new CollapseScreenSetting();
@@ -91,19 +92,19 @@ namespace CollapseLauncher.GameSettings.Universal
         {
             try
             {
-                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 
                 string data = this.Serialize(UniversalSettingsJsonContext.Default.CollapseScreenSetting);
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 #if DEBUG
                 LogWriteLine($"Saved Collapse Screen Settings:\r\n{data}", LogType.Debug, true);
 #endif
-                RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+                RegistryRoot.SetValue(ValueName, dataByte, RegistryValueKind.Binary);
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
-                SentryHelper.ExceptionHandler(new Exception($"Failed to save {_ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
+                SentryHelper.ExceptionHandler(new Exception($"Failed to save {ValueName}!", ex), SentryHelper.ExceptionType.UnhandledOther);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CustomArgs.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CustomArgs.cs
@@ -14,23 +14,25 @@ namespace CollapseLauncher.GameSettings.Universal
     public class CustomArgs : IGameSettingsValue<CustomArgs>
     {
         #region Fields
-        private const string _ValueName = "CollapseLauncher_CustomArgs";
-        private string _CustomArgumentValue = "";
+        private const string ValueName = "CollapseLauncher_CustomArgs";
+
         #endregion
 
         #region Properties
+
         /// <summary>
         /// Default: (empty)
         /// </summary>
         public string CustomArgumentValue
         {
-            get => _CustomArgumentValue;
+            get;
             set
             {
-                _CustomArgumentValue = value;
+                field = value;
                 Save();
             }
-        }
+        } = "";
+
         #endregion
 
         #region Methods
@@ -39,15 +41,15 @@ namespace CollapseLauncher.GameSettings.Universal
         {
             try
             {
-                if (SettingsBase.RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
+                if (SettingsBase.RegistryRoot == null) throw new NullReferenceException($"Cannot load {ValueName} RegistryKey is unexpectedly not initialized!");
 #if DEBUG
-                LogWriteLine($"Loaded Collapse Custom Argument Settings:\r\n{(string?)SettingsBase.RegistryRoot.GetValue(_ValueName, null) ?? ""}", LogType.Debug, true);
+                LogWriteLine($"Loaded Collapse Custom Argument Settings:\r\n{(string?)SettingsBase.RegistryRoot.GetValue(ValueName, null) ?? ""}", LogType.Debug, true);
 #endif
-                return new CustomArgs { CustomArgumentValue = (string?)SettingsBase.RegistryRoot.GetValue(_ValueName, null) ?? "" };
+                return new CustomArgs { CustomArgumentValue = (string?)SettingsBase.RegistryRoot.GetValue(ValueName, null) ?? "" };
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while reading {_ValueName}\r\n{ex}", LogType.Error, true);
+                LogWriteLine($"Failed while reading {ValueName}\r\n{ex}", LogType.Error, true);
                 throw;
             }
         }
@@ -56,15 +58,15 @@ namespace CollapseLauncher.GameSettings.Universal
         {
             try
             {
-                if (SettingsBase.RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
+                if (SettingsBase.RegistryRoot == null) throw new NullReferenceException($"Cannot save {ValueName} since RegistryKey is unexpectedly not initialized!");
 #if DEBUG
                 LogWriteLine($"Saved Collapse Custom Argument Settings:\r\n{CustomArgumentValue}", LogType.Debug, true);
 #endif
-                SettingsBase.RegistryRoot.SetValue(_ValueName, CustomArgumentValue, RegistryValueKind.String);
+                SettingsBase.RegistryRoot.SetValue(ValueName, CustomArgumentValue, RegistryValueKind.String);
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed to save {_ValueName}!\r\n{ex}", LogType.Error, true);
+                LogWriteLine($"Failed to save {ValueName}!\r\n{ex}", LogType.Error, true);
             }
         }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Enums.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Enums.cs
@@ -1,4 +1,5 @@
 // ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 namespace CollapseLauncher.GameSettings.Zenless.Enums;
 
 /// <summary>

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
@@ -7,6 +7,9 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
+// ReSharper disable InconsistentNaming
+// ReSharper disable StringLiteralTypo
 
 #nullable enable
 namespace CollapseLauncher.GameSettings.Zenless

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/RegistryClass/ScreenManager.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/RegistryClass/ScreenManager.cs
@@ -10,6 +10,7 @@ using static CollapseLauncher.GameSettings.Base.SettingsBase;
 using static Hi3Helper.Logger;
 // ReSharper disable NonReadonlyMemberInGetHashCode
 // ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.GameSettings.Zenless
 {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Settings.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Settings.cs
@@ -4,6 +4,7 @@ using CollapseLauncher.GameVersioning;
 using CollapseLauncher.Interfaces;
 using System;
 using System.Diagnostics;
+// ReSharper disable InconsistentNaming
 
 // ReSharper disable CheckNamespace
 
@@ -36,7 +37,7 @@ namespace CollapseLauncher.GameSettings.Zenless
         public GeneralData GeneralData { get; set; }
         #endregion
 
-        public ZenlessSettings(IGameVersion GameVersionManager) : base(GameVersionManager)
+        public ZenlessSettings(IGameVersion gameVersionManager) : base(gameVersionManager)
         {
             // Initialize magic
             _ = MagicReDo;

--- a/CollapseLauncher/Classes/GameManagement/Versioning/Extension.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/Extension.cs
@@ -8,7 +8,7 @@ namespace CollapseLauncher.GameManagement.Versioning
         /// Casting the IGameVersion as its origin or another version class.
         /// </summary>
         /// <typeparam name="TCast">The type of version class to cast</typeparam>
-        /// <returns>The version class to get casted</returns>
+        /// <returns>The version class to get cast</returns>
         internal static TCast CastAs<TCast>(this IGameVersion versionCheck)
             where TCast : GameVersionBase, IGameVersion => (TCast)versionCheck;
     }

--- a/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.GameState.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.GameState.cs
@@ -224,8 +224,7 @@ namespace CollapseLauncher.GameManagement.Versioning
             }
 
             // Check all the pattern and return based on the condition
-            return VendorTypeProp.GameName == GamePreset.InternalGameNameInConfig && execFileInfo.Exists &&
-                   execFileInfo.Length > 1 << 16;
+            return VendorTypeProp.GameName == GamePreset.InternalGameNameInConfig && execFileInfo is { Exists: true, Length: > 1 << 16 };
         }
 
         protected virtual bool IsTryParseIniVersionExist(string iniPath)

--- a/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.IniConfig.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.IniConfig.cs
@@ -21,9 +21,9 @@ namespace CollapseLauncher.GameManagement.Versioning
         #endregion
 
         #region Constants
-        private const string cps = "cps";
-        private const string channel = "channel";
-        private const string sub_channel = "sub_channel";
+        private const string Cps = "cps";
+        private const string Channel = "channel";
+        private const string SubChannel = "sub_channel";
         
         private const string ConfigFileName = "config.ini";
         #endregion
@@ -38,9 +38,9 @@ namespace CollapseLauncher.GameManagement.Versioning
 
         protected virtual IniSection DefaultIniProfile => new()
             {
-                { cps, new IniValue(GamePreset.LauncherCPSType) },
-                { channel, new IniValue(DefaultGameChannelID) },
-                { sub_channel, new IniValue(DefaultGameSubChannelID) },
+                { Cps, new IniValue(GamePreset.LauncherCPSType) },
+                { Channel, new IniValue(DefaultGameChannelID) },
+                { SubChannel, new IniValue(DefaultGameSubChannelID) },
                 { "game_install_path", new IniValue(DefaultGameDirPath.Replace('\\', '/')) },
                 { "game_start_name", new IniValue(GamePreset.GameExecutableName) },
                 { "is_first_exit", new IniValue(false) },

--- a/CollapseLauncher/Classes/GameManagement/Versioning/Genshin/VersionCheck.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/Genshin/VersionCheck.cs
@@ -29,14 +29,15 @@ namespace CollapseLauncher.GameVersioning
         {
             string? basePath = base.TryFindGamePathFromExecutableAndConfig(path, executableName);
 
-            // Try detect the CN and Bilibili client location by overriding the executable name argument
-            if (string.IsNullOrEmpty(basePath))
+            // Try to detect the CN and Bilibili client location by overriding the executable name argument
+            if (!string.IsNullOrEmpty(basePath))
             {
-                executableName = AlternativeExecName;
-                return base.TryFindGamePathFromExecutableAndConfig(path, executableName);
+                return basePath;
             }
 
-            return basePath;
+            executableName = AlternativeExecName;
+            return base.TryFindGamePathFromExecutableAndConfig(path, executableName);
+
         }
 
         protected override bool IsExecutableFileExist(string? executableName)

--- a/CollapseLauncher/Classes/GameManagement/Versioning/Honkai/VersionCheck.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/Honkai/VersionCheck.cs
@@ -1,6 +1,7 @@
 using CollapseLauncher.GameManagement.Versioning;
 using System;
 // ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.GameVersioning
 {
@@ -11,12 +12,12 @@ namespace CollapseLauncher.GameVersioning
         : GameVersionBase(gameRegionProp, gameName, gameRegion)
     {
         #region Statics
-        private static readonly Version senadinaVersion = new(7, 3, 0);
+        private static readonly Version SenadinaVersion = new(7, 3, 0);
         #endregion
 
         #region Public properties
-        public bool IsCurrentSenadinaVersion { get => GameVersionAPI?.ToVersion() >= senadinaVersion; }
-        public bool IsPreloadSenadinaVersion { get => GameVersionAPIPreload.HasValue && GameVersionAPIPreload.Value.ToVersion() >= senadinaVersion; }
+        public bool IsCurrentSenadinaVersion { get => GameVersionAPI?.ToVersion() >= SenadinaVersion; }
+        public bool IsPreloadSenadinaVersion { get => GameVersionAPIPreload.HasValue && GameVersionAPIPreload.Value.ToVersion() >= SenadinaVersion; }
         #endregion
 
         public override bool IsGameHasDeltaPatch() => GameDeltaPatchProp != null;

--- a/CollapseLauncher/Classes/GameManagement/Versioning/StarRail/VersionCheck.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/StarRail/VersionCheck.cs
@@ -52,7 +52,7 @@ namespace CollapseLauncher.GameVersioning
 
         public override bool IsGameHasDeltaPatch() => GameDeltaPatchProp != null;
 
-        public override DeltaPatchProperty GetDeltaPatchInfo() => GameDeltaPatchProp == null ? null : GameDeltaPatchProp;
+        public override DeltaPatchProperty GetDeltaPatchInfo() => GameDeltaPatchProp;
 
 #nullable enable
         public void InitializeProtoId()

--- a/CollapseLauncher/Classes/GameManagement/Versioning/Zenless/VersionCheck.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/Zenless/VersionCheck.cs
@@ -57,7 +57,7 @@ namespace CollapseLauncher.GameVersioning
                 if (!DataCooker.IsServeV3Data(keyUtf8Base64))
                     goto QuitFail;
 
-                // Enjoy the meal (i guess?)
+                // Enjoy the meal (I guess?)
                 DataCooker.GetServeV3DataSize(keyUtf8Base64, out long servedCompressedSize, out long servedDecompressedSize);
                 Span<byte> outServeData = keyUtf8Base64.AsSpan(keyFromBase64Len, (int)servedDecompressedSize);
                 DataCooker.ServeV3Data(keyUtf8Base64.AsSpan(0, keyFromBase64Len), outServeData, (int)servedCompressedSize, (int)servedDecompressedSize, out int dataWritten);

--- a/CollapseLauncher/Classes/GamePresetProperty.cs
+++ b/CollapseLauncher/Classes/GamePresetProperty.cs
@@ -19,6 +19,7 @@ using Microsoft.UI.Xaml;
 using System;
 using System.IO;
 using System.Diagnostics.CodeAnalysis;
+// ReSharper disable UnusedMember.Global
 
 // ReSharper disable CheckNamespace
 // ReSharper disable PartialTypeWithSinglePart

--- a/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
+++ b/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
@@ -346,14 +346,12 @@ namespace CollapseLauncher.Helper.Background
                 EnsureCurrentImageRegistered();
                 EnsureCurrentMediaPlayerRegistered();
 
-                _loaderMediaPlayer ??= new MediaPlayerLoader(
-                                                             _parentUI!,
+                _loaderMediaPlayer ??= new MediaPlayerLoader(_parentUI!,
                                                              _bgAcrylicMask!, _bgOverlayTitleBar!,
                                                              _parentBgMediaPlayerBackgroundGrid!,
                                                              _bgMediaPlayerBackground);
 
-                _loaderStillImage ??= new StillImageLoader(
-                                                           _parentUI!,
+                _loaderStillImage ??= new StillImageLoader(_parentUI!,
                                                            _bgAcrylicMask!, _bgOverlayTitleBar!,
                                                            _parentBgImageBackgroundGrid!,
                                                            _bgImageBackground, _bgImageBackgroundLast);

--- a/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
+++ b/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
@@ -18,6 +18,7 @@ using ImageUI = Microsoft.UI.Xaml.Controls.Image;
 // ReSharper disable GrammarMistakeInComment
 // ReSharper disable SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
 // ReSharper disable SwitchStatementMissingSomeEnumCasesNoDefault
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.Background
@@ -87,25 +88,6 @@ namespace CollapseLauncher.Helper.Background
                                                                                BoundedCapacity = 1,
                                                                                TaskScheduler = TaskScheduler.Current
                                                                            });
-        internal ActionBlock<Action> SharedActionBlockQueueChange = new(static action =>
-                                                                        {
-                                                                            try
-                                                                            {
-                                                                                _parentUI?.DispatcherQueue.TryEnqueue(() => action());
-                                                                            }
-                                                                            catch (Exception ex)
-                                                                            {
-                                                                                _parentUI?.DispatcherQueue.TryEnqueue(() =>
-                                                                                                                          ErrorSender.SendException(ex));
-                                                                            }
-                                                                        },
-                                                                        new ExecutionDataflowBlockOptions
-                                                                        {
-                                                                            EnsureOrdered = true,
-                                                                            MaxMessagesPerTask = 1,
-                                                                            MaxDegreeOfParallelism = 1,
-                                                                            BoundedCapacity = 1
-                                                                        });
 
         /// <summary>
         ///     Attach and register the <see cref="Grid" /> of the page to be assigned with background utility.

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/IBackgroundMediaLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/IBackgroundMediaLoader.cs
@@ -1,10 +1,11 @@
-﻿#nullable enable
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Threading;
-    using System.Threading.Tasks;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+// ReSharper disable UnusedMemberInSuper.Global
 
-    namespace CollapseLauncher.Helper.Background.Loaders
+#nullable enable
+namespace CollapseLauncher.Helper.Background.Loaders
 {
     [SuppressMessage("ReSharper", "IdentifierTypo")]
     [SuppressMessage("ReSharper", "PossibleNullReferenceException")]

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -327,6 +327,11 @@ namespace CollapseLauncher.Helper.Background.Loaders
 
         private void FrameGrabberEvent(MediaPlayer mediaPlayer, object args)
         {
+            if (_isCanvasCurrentlyDrawing == 1)
+            {
+                return;
+            }
+
             CanvasDrawingSession? drawingSession = null;
             try
             {
@@ -334,6 +339,7 @@ namespace CollapseLauncher.Helper.Background.Loaders
                 mediaPlayer.CopyFrameToVideoSurface(_currentCanvasBitmap);
                 drawingSession = _currentCanvasVirtualImageSource?.CreateDrawingSession(_currentDefaultColor, _currentCanvasDrawArea);
                 drawingSession?.DrawImage(_currentCanvasBitmap);
+                _currentCanvasVirtualImageSource?.SuspendDrawingSession(drawingSession);
             }
             catch
         #if DEBUG

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -305,9 +305,11 @@ namespace CollapseLauncher.Helper.Background.Loaders
         {
             StorageFile                storageFile = await GetFileAsStorageFile(file);
             using StorageItemThumbnail thumbnail   = await storageFile.GetThumbnailAsync(ThumbnailMode.VideosView);
-            await using Stream         stream      = thumbnail.AsStream();
 
-            await ColorPaletteUtility.ApplyAccentColor(ParentUI, stream.AsRandomAccessStream(), string.Empty, false,
+            await ColorPaletteUtility.ApplyAccentColor(ParentUI,
+                                                       thumbnail,
+                                                       string.Empty,
+                                                       false,
                                                        true);
         }
 

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -10,7 +10,6 @@ using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.Region;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.UI.Xaml;
-using Microsoft.UI;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -147,7 +147,7 @@ namespace CollapseLauncher.Helper.Background.Loaders
                     _currentImage.Visibility = Visibility.Visible;
                     App.ToggleBlurBackdrop();
                 }
-                else if (_currentImage != null)
+                else
                 {
                     _currentImage.Visibility = Visibility.Collapsed;
                 }
@@ -273,13 +273,14 @@ namespace CollapseLauncher.Helper.Background.Loaders
             byte[] temporaryBuffer = ArrayPool<byte>.Shared.Rent(widthInt * heightInt * 4);
             try
             {
-                _currentCanvasBitmap ??= CanvasBitmap.CreateFromBytes(_currentCanvasDevice,
-                                                                      temporaryBuffer,
-                                                                      widthInt,
-                                                                      heightInt,
-                                                                      Windows.Graphics.DirectX.DirectXPixelFormat.B8G8R8A8UIntNormalized,
-                                                                      CanvasBaseDpi,
-                                                                      CanvasAlphaMode.Ignore);
+                _currentCanvasBitmap ??= CanvasBitmap
+                    .CreateFromBytes(_currentCanvasDevice,
+                                     temporaryBuffer,
+                                     widthInt,
+                                     heightInt,
+                                     Windows.Graphics.DirectX.DirectXPixelFormat.B8G8R8A8UIntNormalized,
+                                     CanvasBaseDpi,
+                                     CanvasAlphaMode.Ignore);
             }
             finally
             {
@@ -357,11 +358,12 @@ namespace CollapseLauncher.Helper.Background.Loaders
             StorageFile                storageFile = await GetFileAsStorageFile(file);
             using StorageItemThumbnail thumbnail   = await storageFile.GetThumbnailAsync(ThumbnailMode.VideosView);
 
-            await ColorPaletteUtility.ApplyAccentColor(ParentUI,
-                                                       thumbnail,
-                                                       string.Empty,
-                                                       false,
-                                                       true);
+            await ColorPaletteUtility
+                .ApplyAccentColor(ParentUI,
+                                  thumbnail,
+                                  string.Empty,
+                                  false,
+                                  true);
         }
 
         private static async Task<StorageFile> GetFileAsStorageFile(string filePath)

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -302,12 +302,12 @@ namespace CollapseLauncher.Helper.Background.Loaders
         {
             ReadOnlySpan<byte> dashSignature = "ftypdash"u8;
 
-            byte[] buffer = new byte[64];
+            Span<byte> buffer = stackalloc byte[64];
             stream.ReadExactly(buffer);
 
             try
             {
-                if (buffer.AsSpan(4).StartsWith(dashSignature))
+                if (buffer.StartsWith(dashSignature))
                     throw new FormatException("The video format is in \"MPEG-DASH\" format, which is unsupported.");
             }
             finally
@@ -338,10 +338,10 @@ namespace CollapseLauncher.Helper.Background.Loaders
         {
             lock (_currentLock)
             {
-                if (_currentCanvasVirtualImageSource is null)
-                {
-                    return;
-                }
+                    if (_currentCanvasVirtualImageSource is null)
+                    {
+                        return;
+                    }
 
                 if (_currentCanvasDrawingSession is not null)
                 {

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -265,10 +265,8 @@ namespace CollapseLauncher.Helper.Background.Loaders
             {
                 lock (_currentLock)
                 {
-                    while (_currentCanvasDrawingSession is not null)
-                    {
-                        Thread.Sleep(100);
-                    }
+                    _currentCanvasDrawingSession?.Dispose();
+                    Interlocked.Exchange(ref _currentCanvasDrawingSession, null);
                 }
             }
 

--- a/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
+++ b/CollapseLauncher/Classes/Helper/Background/Loaders/MediaPlayerLoader.cs
@@ -230,7 +230,7 @@ namespace CollapseLauncher.Helper.Background.Loaders
             catch
             {
                 DisposeMediaModules();
-                // await BackgroundMediaUtility.AssignDefaultImage(CurrentMediaImage);
+                await BackgroundMediaUtility.AssignDefaultImage(_currentImage);
                 throw;
             }
             finally

--- a/CollapseLauncher/Classes/Helper/Hash.FileStream.cs
+++ b/CollapseLauncher/Classes/Helper/Hash.FileStream.cs
@@ -18,9 +18,9 @@ namespace CollapseLauncher.Helper
         /// </summary>
         /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
         /// <param name="filePath">The path of the file to compute the hash for.</param>
-        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
         /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
         public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
             string            filePath,
@@ -28,16 +28,39 @@ namespace CollapseLauncher.Helper
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
             where T : HashAlgorithm =>
-            GetCryptoHashAsync<T>(() => File.OpenRead(filePath), hmacKey, readProgress, token);
+            GetCryptoHashAsync<T>(() => File.OpenRead(filePath), hmacKey, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the cryptographic hash of a file specified by its path.
+        /// </summary>
+        /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
+        /// <param name="filePath">The path of the file to compute the hash for.</param>
+        /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
+            string            filePath,
+            byte[]?           hmacKey,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
+            where T : HashAlgorithm =>
+            GetCryptoHashAsync<T>(() => File.OpenRead(filePath), hmacKey, readProgress, isLongRunning, token);
 
         /// <summary>
         /// Asynchronously computes the cryptographic hash of a file specified by a <see cref="FileInfo"/> object.
         /// </summary>
         /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
         /// <param name="fileInfo">The <see cref="FileInfo"/> object representing the file to compute the hash for.</param>
-        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
         /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
         public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
             FileInfo          fileInfo,
@@ -45,34 +68,87 @@ namespace CollapseLauncher.Helper
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
             where T : HashAlgorithm =>
-            GetCryptoHashAsync<T>(fileInfo.OpenRead, hmacKey, readProgress, token);
+            GetCryptoHashAsync<T>(fileInfo.OpenRead, hmacKey, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the cryptographic hash of a file specified by a <see cref="FileInfo"/> object.
+        /// </summary>
+        /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
+        /// <param name="fileInfo">The <see cref="FileInfo"/> object representing the file to compute the hash for.</param>
+        /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
+            FileInfo          fileInfo,
+            byte[]?           hmacKey,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
+            where T : HashAlgorithm =>
+            GetCryptoHashAsync<T>(fileInfo.OpenRead, hmacKey, readProgress, isLongRunning, token);
 
         /// <summary>
         /// Asynchronously computes the cryptographic hash of a stream.
         /// </summary>
         /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
         /// <param name="stream">The stream to compute the hash for.</param>
-        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
         /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
         public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
             Stream            stream,
             byte[]?           hmacKey      = null,
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
+            where T : HashAlgorithm =>
+            GetCryptoHashAsync<T>(stream, hmacKey, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the cryptographic hash of a stream.
+        /// </summary>
+        /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
+        /// <param name="stream">The stream to compute the hash for.</param>
+        /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
+            Stream            stream,
+            byte[]?           hmacKey,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
             where T : HashAlgorithm
         {
             // Create a new task from factory, assign a synchronous method to it with detached thread.
             Task<byte[]> task = Task<byte[]>
                                .Factory
-                               .StartNew(() => GetCryptoHash<T>(stream, hmacKey, readProgress, token),
+                               .StartNew(Impl,
+                                         (stream, hmacKey, readProgress, token),
                                          token,
-                                         TaskCreationOptions.DenyChildAttach,
+                                         isLongRunning ? TaskCreationOptions.LongRunning : TaskCreationOptions.DenyChildAttach,
                                          TaskScheduler.Default);
 
             // Create awaitable returnable-task
             return task.ConfigureAwait(false);
+
+            static byte[] Impl(object? state)
+            {
+                (Stream stream, byte[]? hmacKey, Action<int>? readProgress, CancellationToken token) = ((Stream, byte[]?, Action<int>?, CancellationToken))state!;
+                return GetCryptoHash<T>(stream, hmacKey, readProgress, token);
+            }
         }
 
         /// <summary>
@@ -80,31 +156,58 @@ namespace CollapseLauncher.Helper
         /// </summary>
         /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
         /// <param name="streamDelegate">A delegate function which returns the stream to compute the hash for.</param>
-        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
         /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
         public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
             Func<Stream>      streamDelegate,
             byte[]?           hmacKey      = null,
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
+            where T : HashAlgorithm =>
+            GetCryptoHashAsync<T>(streamDelegate, hmacKey, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the cryptographic hash of a stream.
+        /// </summary>
+        /// <typeparam name="T">The type of the hash algorithm to use. Must inherit from <see cref="HashAlgorithm"/>.</typeparam>
+        /// <param name="streamDelegate">A delegate function which returns the stream to compute the hash for.</param>
+        /// <param name="hmacKey">The key to use for HMAC-based hash algorithms. If null, a standard hash algorithm is used.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
+            Func<Stream>      streamDelegate,
+            byte[]?           hmacKey,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
             where T : HashAlgorithm
         {
             // Create a new task from factory, assign a synchronous method to it with detached thread.
             Task<byte[]> task = Task<byte[]>
                                .Factory
-                               .StartNew(() =>
-                                         {
-                                             using Stream stream = streamDelegate();
-                                             return GetCryptoHash<T>(stream, hmacKey, readProgress, token);
-                                         },
+                               .StartNew(Impl,
+                                         (streamDelegate, hmacKey, readProgress, token),
                                          token,
-                                         TaskCreationOptions.DenyChildAttach,
+                                         isLongRunning ? TaskCreationOptions.LongRunning : TaskCreationOptions.DenyChildAttach,
                                          TaskScheduler.Default);
 
             // Create awaitable returnable-task
             return task.ConfigureAwait(false);
+
+            static byte[] Impl(object? state)
+            {
+                (Func<Stream> streamDelegate, byte[]? hmacKey, Action<int>? readProgress, CancellationToken token) = ((Func<Stream>, byte[]?, Action<int>?, CancellationToken))state!;
+                using Stream stream = streamDelegate();
+                return GetCryptoHash<T>(stream, hmacKey, readProgress, token);
+            }
         }
 
         /// <summary>
@@ -231,7 +334,28 @@ namespace CollapseLauncher.Helper
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
             where T : NonCryptographicHashAlgorithm, new() =>
-            GetHashAsync<T>(() => File.OpenRead(filePath), readProgress, token);
+            GetHashAsync<T>(() => File.OpenRead(filePath), readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the non-cryptographic hash of a file specified by its path.
+        /// </summary>
+        /// <typeparam name="T">The type of the non-cryptographic hash algorithm to use. Must inherit from <see cref="NonCryptographicHashAlgorithm"/> and have a parameterless constructor.</typeparam>
+        /// <param name="filePath">The path of the file to compute the hash for.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetHashAsync<T>(
+            string            filePath,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
+            where T : NonCryptographicHashAlgorithm, new() =>
+            GetHashAsync<T>(() => File.OpenRead(filePath), readProgress, isLongRunning, token);
 
         /// <summary>
         /// Asynchronously computes the non-cryptographic hash of a file specified by a <see cref="FileInfo"/> object.
@@ -246,7 +370,28 @@ namespace CollapseLauncher.Helper
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
             where T : NonCryptographicHashAlgorithm, new() =>
-            GetHashAsync<T>(fileInfo.OpenRead, readProgress, token);
+            GetHashAsync<T>(fileInfo.OpenRead, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the non-cryptographic hash of a file specified by a <see cref="FileInfo"/> object.
+        /// </summary>
+        /// <typeparam name="T">The type of the non-cryptographic hash algorithm to use. Must inherit from <see cref="NonCryptographicHashAlgorithm"/> and have a parameterless constructor.</typeparam>
+        /// <param name="fileInfo">The <see cref="FileInfo"/> object representing the file to compute the hash for.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetHashAsync<T>(
+            FileInfo          fileInfo,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
+            where T : NonCryptographicHashAlgorithm, new() =>
+            GetHashAsync<T>(fileInfo.OpenRead, readProgress, isLongRunning, token);
 
         /// <summary>
         /// Asynchronously computes the non-cryptographic hash of a stream.
@@ -260,18 +405,46 @@ namespace CollapseLauncher.Helper
             Stream            stream,
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
+            where T : NonCryptographicHashAlgorithm, new() =>
+            GetHashAsync<T>(stream, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the non-cryptographic hash of a stream.
+        /// </summary>
+        /// <typeparam name="T">The type of the non-cryptographic hash algorithm to use. Must inherit from <see cref="NonCryptographicHashAlgorithm"/> and have a parameterless constructor.</typeparam>
+        /// <param name="stream">The stream to compute the hash for.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetHashAsync<T>(
+            Stream            stream,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
             where T : NonCryptographicHashAlgorithm, new()
         {
             // Create a new task from factory, assign a synchronous method to it with detached thread.
             Task<byte[]> task = Task<byte[]>
                                .Factory
-                               .StartNew(() => GetHash<T>(stream, readProgress, token),
+                               .StartNew(Impl,
+                                         (stream, readProgress, token),
                                          token,
-                                         TaskCreationOptions.DenyChildAttach,
+                                         isLongRunning ? TaskCreationOptions.LongRunning : TaskCreationOptions.DenyChildAttach,
                                          TaskScheduler.Default);
 
             // Create awaitable returnable-task
             return task.ConfigureAwait(false);
+
+            static byte[] Impl(object? state)
+            {
+                (Stream stream, Action<int>? readProgress, CancellationToken token) = ((Stream, Action<int>?, CancellationToken))state!;
+                return GetHash<T>(stream, readProgress, token);
+            }
         }
 
         /// <summary>
@@ -286,22 +459,47 @@ namespace CollapseLauncher.Helper
             Func<Stream>      streamDelegate,
             Action<int>?      readProgress = null,
             CancellationToken token        = default)
+            where T : NonCryptographicHashAlgorithm, new() =>
+            GetHashAsync<T>(streamDelegate, readProgress, false, token);
+
+        /// <summary>
+        /// Asynchronously computes the non-cryptographic hash of a stream.
+        /// </summary>
+        /// <typeparam name="T">The type of the non-cryptographic hash algorithm to use. Must inherit from <see cref="NonCryptographicHashAlgorithm"/> and have a parameterless constructor.</typeparam>
+        /// <param name="streamDelegate">A delegate function which returns the stream to compute the hash for.</param>
+        /// <param name="readProgress">An action to report the read progress.</param>
+        /// <param name="isLongRunning">
+        /// Define where the async method should run for hashing big files.<br/>
+        /// This to hint the default TaskScheduler to allow more hashing threads to be running at the same time.<br/>
+        /// Set to <c>true</c> if the data stream is big, otherwise <c>false</c> for small data stream.
+        /// </param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the computed hash as a byte array.</returns>
+        public static ConfiguredTaskAwaitable<byte[]> GetHashAsync<T>(
+            Func<Stream>      streamDelegate,
+            Action<int>?      readProgress,
+            bool              isLongRunning,
+            CancellationToken token)
             where T : NonCryptographicHashAlgorithm, new()
         {
             // Create a new task from factory, assign a synchronous method to it with detached thread.
             Task<byte[]> task = Task<byte[]>
                                .Factory
-                               .StartNew(() =>
-                                         {
-                                             using Stream stream = streamDelegate();
-                                             return GetHash<T>(stream, readProgress, token);
-                                         },
+                               .StartNew(Impl,
+                                         (streamDelegate, readProgress, token),
                                          token,
-                                         TaskCreationOptions.DenyChildAttach,
+                                         isLongRunning ? TaskCreationOptions.LongRunning : TaskCreationOptions.DenyChildAttach,
                                          TaskScheduler.Default);
 
             // Create awaitable returnable-task
             return task.ConfigureAwait(false);
+
+            static byte[] Impl(object? state)
+            {
+                (Func<Stream> streamDelegate, Action<int>? readProgress, CancellationToken token) = ((Func<Stream>, Action<int>?, CancellationToken))state!;
+                using Stream stream = streamDelegate();
+                return GetHash<T>(stream, readProgress, token);
+            }
         }
 
         /// <summary>

--- a/CollapseLauncher/Classes/Helper/Hash.FileStream.cs
+++ b/CollapseLauncher/Classes/Helper/Hash.FileStream.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 // ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper

--- a/CollapseLauncher/Classes/Helper/Hash.StringAndBytes.cs
+++ b/CollapseLauncher/Classes/Helper/Hash.StringAndBytes.cs
@@ -3,6 +3,7 @@ using System.IO.Hashing;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper

--- a/CollapseLauncher/Classes/Helper/Hash.StringAndBytes.cs
+++ b/CollapseLauncher/Classes/Helper/Hash.StringAndBytes.cs
@@ -52,10 +52,11 @@ namespace CollapseLauncher.Helper
             where T : NonCryptographicHashAlgorithm
         {
             // Get the shared hash algorithm and the thread lock instance
-            ref Tuple<NonCryptographicHashAlgorithm?, Lock> hash = ref GetSharedHash<T>();
+            ref (NonCryptographicHashAlgorithm? Hash, Lock Lock) hash = ref GetSharedHash<T>();
 
             // Allocate the return buffer and calculate the hash from the source span
-            byte[] hashBytesReturn = new byte[hash.Item1!.HashLengthInBytes];
+            int    hashLenInBytes  = hash.Hash!.HashLengthInBytes;
+            byte[] hashBytesReturn = new byte[hashLenInBytes];
             if (!TryGetHashFromBytes<T>(ref hash!, source, hashBytesReturn, out _))
             {
                 throw new InvalidOperationException("Failed to get the hash.");
@@ -75,11 +76,12 @@ namespace CollapseLauncher.Helper
             where T : NonCryptographicHashAlgorithm
         {
             // Get the shared hash algorithm and the thread lock instance
-            ref Tuple<NonCryptographicHashAlgorithm?, Lock> hash = ref GetSharedHash<T>();
+            ref (NonCryptographicHashAlgorithm? Hash, Lock Lock) hash = ref GetSharedHash<T>();
 
             // Allocate the hash buffer to be written to
-            Span<byte> hashBuffer = stackalloc byte[hash.Item1!.HashLengthInBytes];
-            Span<char> hashCharBuffer = stackalloc char[hash.Item1.HashLengthInBytes * 2];
+            int        hashLenInBytes = hash.Hash!.HashLengthInBytes;
+            Span<byte> hashBuffer     = stackalloc byte[hashLenInBytes];
+            Span<char> hashCharBuffer = stackalloc char[hashLenInBytes * 2];
 
             // Compute the hash and reset
             if (!TryGetHashFromBytes<T>(ref hash!, source, hashBuffer, out _))
@@ -107,20 +109,20 @@ namespace CollapseLauncher.Helper
         /// <param name="hashBytesWritten">The length of how much bytes is the hash written to the <paramref name="destination"/>.</param>
         /// <returns>True if it's successfully calculate the hash, False as failed.</returns>
         public static bool TryGetHashFromBytes<T>(
-            ref Tuple<NonCryptographicHashAlgorithm, Lock> hashSource,
-            ReadOnlySpan<byte> source,
-            Span<byte> destination,
-            out int hashBytesWritten)
+            ref (NonCryptographicHashAlgorithm Hash, Lock Lock) hashSource,
+            ReadOnlySpan<byte>                                  source,
+            Span<byte>                                          destination,
+            out int                                             hashBytesWritten)
             where T : NonCryptographicHashAlgorithm
         {
             // Lock the thread and append the span to the hash algorithm
-            lock (hashSource.Item2)
+            lock (hashSource.Lock)
             {
                 // Append and calculate the hash of the span
-                hashSource.Item1.Append(source);
+                hashSource.Hash.Append(source);
 
                 // Return the bool as success or not, then reset the hash while writing the hash bytes to destination span.
-                return hashSource.Item1.TryGetHashAndReset(destination, out hashBytesWritten);
+                return hashSource.Hash.TryGetHashAndReset(destination, out hashBytesWritten);
             }
         }
         #endregion
@@ -168,10 +170,11 @@ namespace CollapseLauncher.Helper
             where T : HashAlgorithm
         {
             // Get the shared hash algorithm and the thread lock instance
-            ref Tuple<HashAlgorithm?, Lock> hash = ref GetSharedCryptoHash<T>();
+            ref (HashAlgorithm? Hash, Lock Lock) hash = ref GetSharedCryptoHash<T>();
 
             // Allocate the return buffer and calculate the hash from the source span
-            byte[] hashBytesReturn = new byte[hash.Item1!.HashSize];
+            int    hashLenInBytes  = hash.Hash!.HashSize;
+            byte[] hashBytesReturn = new byte[hashLenInBytes];
             if (!TryGetCryptoHashFromBytes<T>(ref hash!, source, hashBytesReturn, out _))
             {
                 throw new InvalidOperationException("Failed to get the hash.");
@@ -191,11 +194,12 @@ namespace CollapseLauncher.Helper
             where T : HashAlgorithm
         {
             // Get the shared hash algorithm and the thread lock instance
-            ref Tuple<HashAlgorithm?, Lock> hash = ref GetSharedCryptoHash<T>();
+            ref (HashAlgorithm? Hash, Lock Lock) hash = ref GetSharedCryptoHash<T>();
 
             // Allocate the hash buffer to be written to
-            Span<byte> hashBuffer = stackalloc byte[hash.Item1!.HashSize];
-            Span<char> hashCharBuffer = stackalloc char[hash.Item1.HashSize * 2];
+            int        hashLenInBytes = hash.Hash!.HashSize;
+            Span<byte> hashBuffer     = stackalloc byte[hashLenInBytes];
+            Span<char> hashCharBuffer = stackalloc char[hashLenInBytes * 2];
 
             // Compute the hash and reset
             if (!TryGetCryptoHashFromBytes<T>(ref hash!, source, hashBuffer, out _))
@@ -223,20 +227,20 @@ namespace CollapseLauncher.Helper
         /// <param name="hashBytesWritten">The length of how much bytes is the hash written to the <paramref name="destination"/>.</param>
         /// <returns>True if it's successfully calculate the hash, False as failed.</returns>
         public static bool TryGetCryptoHashFromBytes<T>(
-            ref Tuple<HashAlgorithm, Lock> hashSource,
-            ReadOnlySpan<byte> source,
-            Span<byte> destination,
-            out int hashBytesWritten)
+            ref (HashAlgorithm Hash, Lock Lock) hashSource,
+            ReadOnlySpan<byte>                  source,
+            Span<byte>                          destination,
+            out int                             hashBytesWritten)
             where T : HashAlgorithm
         {
             // Lock the thread and compute the hash of the span
-            lock (hashSource.Item2)
+            lock (hashSource.Lock)
             {
                 // Reset the hash instance state.
-                hashSource.Item1.Initialize();
+                hashSource.Hash.Initialize();
 
                 // Compute the source bytes and return the success state
-                return hashSource.Item1.TryComputeHash(source, destination, out hashBytesWritten);
+                return hashSource.Hash.TryComputeHash(source, destination, out hashBytesWritten);
             }
         }
         #endregion

--- a/CollapseLauncher/Classes/Helper/Hash.cs
+++ b/CollapseLauncher/Classes/Helper/Hash.cs
@@ -34,26 +34,26 @@ namespace CollapseLauncher.Helper
             { typeof(HMACSHA3_512).GetHashCode(), key => new HMACSHA3_512(key) }
         };
 
-        private static readonly Dictionary<int, Tuple<HashAlgorithm?, Lock>> CryptoHashDictShared = new()
+        private static readonly Dictionary<int, (HashAlgorithm?, Lock)> CryptoHashDictShared = new()
         {
-            { typeof(MD5).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(MD5.Create), new Lock()) },
-            { typeof(SHA1).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA1.Create), new Lock()) },
-            { typeof(SHA256).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA256.Create), new Lock()) },
-            { typeof(SHA384).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA384.Create), new Lock()) },
-            { typeof(SHA512).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA512.Create), new Lock()) },
-            { typeof(SHA3_256).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA3_256.Create), new Lock()) },
-            { typeof(SHA3_384).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA3_384.Create), new Lock()) },
-            { typeof(SHA3_512).GetHashCode(), new Tuple<HashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(SHA3_512.Create), new Lock()) }
+            { typeof(MD5).GetHashCode(), (CreateHashAndNullIfUnsupported(MD5.Create), new Lock()) },
+            { typeof(SHA1).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA1.Create), new Lock()) },
+            { typeof(SHA256).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA256.Create), new Lock()) },
+            { typeof(SHA384).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA384.Create), new Lock()) },
+            { typeof(SHA512).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA512.Create), new Lock()) },
+            { typeof(SHA3_256).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA3_256.Create), new Lock()) },
+            { typeof(SHA3_384).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA3_384.Create), new Lock()) },
+            { typeof(SHA3_512).GetHashCode(), (CreateHashAndNullIfUnsupported(SHA3_512.Create), new Lock()) }
         };
 
-        private static readonly Dictionary<int, Tuple<NonCryptographicHashAlgorithm?, Lock>> HashDictShared = new()
+        private static readonly Dictionary<int, (NonCryptographicHashAlgorithm?, Lock)> HashDictShared = new()
         {
-            { typeof(Crc32).GetHashCode(), new Tuple<NonCryptographicHashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(() => new Crc32()), new Lock()) },
-            { typeof(Crc64).GetHashCode(), new Tuple<NonCryptographicHashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(() => new Crc64()), new Lock()) },
-            { typeof(XxHash3).GetHashCode(), new Tuple<NonCryptographicHashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(() => new XxHash3()), new Lock()) },
-            { typeof(XxHash32).GetHashCode(), new Tuple<NonCryptographicHashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(() => new XxHash32()), new Lock()) },
-            { typeof(XxHash64).GetHashCode(), new Tuple<NonCryptographicHashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(() => new XxHash64()), new Lock()) },
-            { typeof(XxHash128).GetHashCode(), new Tuple<NonCryptographicHashAlgorithm?, Lock>(CreateHashAndNullIfUnsupported(() => new XxHash128()), new Lock()) }
+            { typeof(Crc32).GetHashCode(), (CreateHashAndNullIfUnsupported(() => new Crc32()), new Lock()) },
+            { typeof(Crc64).GetHashCode(), (CreateHashAndNullIfUnsupported(() => new Crc64()), new Lock()) },
+            { typeof(XxHash3).GetHashCode(), (CreateHashAndNullIfUnsupported(() => new XxHash3()), new Lock()) },
+            { typeof(XxHash32).GetHashCode(), (CreateHashAndNullIfUnsupported(() => new XxHash32()), new Lock()) },
+            { typeof(XxHash64).GetHashCode(), (CreateHashAndNullIfUnsupported(() => new XxHash64()), new Lock()) },
+            { typeof(XxHash128).GetHashCode(), (CreateHashAndNullIfUnsupported(() => new XxHash128()), new Lock()) }
         };
 
         private static T? CreateHashAndNullIfUnsupported<T>(Func<T> delegateCreate)
@@ -82,12 +82,6 @@ namespace CollapseLauncher.Helper
             ref Func<HashAlgorithm> createHashDelegate = ref CollectionsMarshal
                 .GetValueRefOrNullRef(CryptoHashDict, typeof(T).GetHashCode());
 
-            // If the delegate is null, then throw an exception
-            if (createHashDelegate == null)
-            {
-                throw new NotSupportedException($"Cannot create hash algorithm instance from {typeof(T)}.");
-            }
-
             // Create the hash algorithm instance
             return createHashDelegate();
         }
@@ -105,12 +99,6 @@ namespace CollapseLauncher.Helper
             // Try to get the hash create method from the dictionary
             ref Func<byte[], HashAlgorithm> createHashDelegate = ref CollectionsMarshal
                 .GetValueRefOrNullRef(CryptoHmacHashDict, typeof(T).GetHashCode());
-
-            // If the delegate is null, then throw an exception
-            if (createHashDelegate == null)
-            {
-                throw new NotSupportedException($"Cannot create HMAC-based hash algorithm instance from {typeof(T)}.");
-            }
 
             // Create the hash algorithm instance
             return createHashDelegate(key);
@@ -130,18 +118,12 @@ namespace CollapseLauncher.Helper
         /// <typeparam name="T">The type of the non-cryptographic hash algorithm to use.</typeparam>
         /// <returns>A tuple of the non-cryptographic hash algorithm and the thread <see cref="Lock"/> instance.</returns>
         /// <exception cref="NotSupportedException">Thrown when the specified non-cryptographic hash algorithm type is not supported.</exception>
-        public static ref Tuple<NonCryptographicHashAlgorithm?, Lock> GetSharedHash<T>()
+        public static ref (NonCryptographicHashAlgorithm? Hash, Lock Lock) GetSharedHash<T>()
             where T : NonCryptographicHashAlgorithm
         {
             // Get reference from the dictionary
-            ref Tuple<NonCryptographicHashAlgorithm?, Lock> hash = ref CollectionsMarshal
+            ref (NonCryptographicHashAlgorithm? Hash, Lock Lock) hash = ref CollectionsMarshal
                .GetValueRefOrNullRef(HashDictShared, typeof(T).GetHashCode());
-
-            // If the tuple is null, then throw an exception
-            if (hash == null || hash.Item1 == null)
-            {
-                throw new NotSupportedException($"Cannot create HMAC-based hash algorithm instance from {typeof(T)}.");
-            }
 
             // Return the tuple reference
             return ref hash;
@@ -153,18 +135,12 @@ namespace CollapseLauncher.Helper
         /// <typeparam name="T">The type of the cryptographic hash algorithm to use.</typeparam>
         /// <returns>A tuple of the cryptographic hash algorithm and the thread <see cref="Lock"/> instance.</returns>
         /// <exception cref="NotSupportedException">Thrown when the specified cryptographic hash algorithm type is not supported.</exception>
-        public static ref Tuple<HashAlgorithm?, Lock> GetSharedCryptoHash<T>()
+        public static ref (HashAlgorithm? Hash, Lock Lock) GetSharedCryptoHash<T>()
             where T : HashAlgorithm
         {
             // Get reference from the dictionary
-            ref Tuple<HashAlgorithm?, Lock> hash = ref CollectionsMarshal
+            ref (HashAlgorithm? Hash, Lock Lock) hash = ref CollectionsMarshal
                .GetValueRefOrNullRef(CryptoHashDictShared, typeof(T).GetHashCode());
-
-            // If the tuple is null, then throw an exception
-            if (hash == null || hash.Item1 == null)
-            {
-                throw new NotSupportedException($"Cannot create HMAC-based hash algorithm instance from {typeof(T)}.");
-            }
 
             // Return the tuple reference
             return ref hash;

--- a/CollapseLauncher/Classes/Helper/HttpClientBuilder.cs
+++ b/CollapseLauncher/Classes/Helper/HttpClientBuilder.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 // ReSharper disable StringLiteralTypo
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper

--- a/CollapseLauncher/Classes/Helper/Image/ImageLoaderHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Image/ImageLoaderHelper.cs
@@ -51,11 +51,6 @@ namespace CollapseLauncher.Helper.Image
                 { "Video formats", string.Join(';', BackgroundMediaUtility.SupportedMediaPlayerExt.Select(x => $"*{x}")) }
             };
 
-        internal static readonly Dictionary<string, string> SupportedStaticImageFormats = new()
-            {
-                { "Image formats", string.Join(';', BackgroundMediaUtility.SupportedImageExt.Select(x => $"*{x}")) }
-            };
-
         #region Waifu2X
         private static Waifu2X _waifu2X;
         private static Waifu2XStatus _cachedStatus = Waifu2XStatus.NotInitialized;
@@ -425,7 +420,7 @@ namespace CollapseLauncher.Helper.Image
             string outputFileName = Path.GetFileName(fileInfo.FullName);
 
 #nullable enable
-            // Try get a hash from filename if the checkIsHashable set to true and the file does exist
+            // Try to get a hash from filename if the checkIsHashable set to true and the file does exist
             if (checkIsHashable && fileInfo.Exists && TryGetMd5HashFromFilename(outputFileName, out byte[]? hashFromFilename))
             {
                 // Open the file and check for the hash
@@ -472,7 +467,7 @@ namespace CollapseLauncher.Helper.Image
             if (string.IsNullOrEmpty(fileName))
                 return false;
 
-            // Assign range and try get the split
+            // Assign range and try to get the split
             Span<Range> range = stackalloc Range[4];
             ReadOnlySpan<char> fileNameSpan = fileName.AsSpan();
             int len = fileNameSpan.Split(range, '_', StringSplitOptions.RemoveEmptyEntries);
@@ -482,14 +477,14 @@ namespace CollapseLauncher.Helper.Image
             if (len != 2)
                 return false;
 
-            // Try get the span of the hash
+            // Try to get the span of the hash
             ReadOnlySpan<char> hashSpan = fileNameSpan[range[0]];
 
-            // If the hashSpan is empty or the length is not even or it's not a MD5 Hex (32 chars), then return false
+            // If the hashSpan is empty or the length is not even, or it's not a MD5 Hex (32 chars), then return false
             if (hashSpan.IsEmpty || hashSpan.Length % 2 != 0 || hashSpan.Length != 32)
                 return false;
 
-            // Try decode hash hex to find out if the string is actually a hex
+            // Try to decode hash hex to find out if the string is actually a hex
             Span<byte> dummy = stackalloc byte[16];
             if (!HexTool.TryHexToBytesUnsafe(hashSpan, dummy))
                 return false;

--- a/CollapseLauncher/Classes/Helper/Image/Waifu2X.cs
+++ b/CollapseLauncher/Classes/Helper/Image/Waifu2X.cs
@@ -12,6 +12,7 @@ using static CollapseLauncher.Helper.Image.Waifu2X;
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable StringLiteralTypo
 // ReSharper disable SwitchStatementHandlesSomeKnownEnumValuesWithDefault
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.Helper.Image
 {

--- a/CollapseLauncher/Classes/Helper/JsonConverter/Extension.cs
+++ b/CollapseLauncher/Classes/Helper/JsonConverter/Extension.cs
@@ -129,107 +129,17 @@ namespace CollapseLauncher.Helper.JsonConverter
 
         internal static class JsonConstants
         {
-            public const byte OpenBrace = (byte)'{';
-            public const byte CloseBrace = (byte)'}';
-            public const byte OpenBracket = (byte)'[';
-            public const byte CloseBracket = (byte)']';
-            public const byte Space = (byte)' ';
-            public const byte CarriageReturn = (byte)'\r';
-            public const byte LineFeed = (byte)'\n';
-            public const byte Tab = (byte)'\t';
-            public const byte ListSeparator = (byte)',';
-            public const byte KeyValueSeparator = (byte)':';
-            public const byte Quote = (byte)'"';
-            public const byte BackSlash = (byte)'\\';
-            public const byte Slash = (byte)'/';
-            public const byte BackSpace = (byte)'\b';
-            public const byte FormFeed = (byte)'\f';
-            public const byte Asterisk = (byte)'*';
-            public const byte Colon = (byte)':';
-            public const byte Period = (byte)'.';
-            public const byte Plus = (byte)'+';
-            public const byte Hyphen = (byte)'-';
-            public const byte UtcOffsetToken = (byte)'Z';
-            public const byte TimePrefix = (byte)'T';
-
-            public const string NewLineLineFeed = "\n";
-            public const string NewLineCarriageReturnLineFeed = "\r\n";
-
-            // \u2028 and \u2029 are considered respectively line and paragraph separators
-            // UTF-8 representation for them is E2, 80, A8/A9
-            public const byte StartingByteOfNonStandardSeparator = 0xE2;
-
-            public static ReadOnlySpan<byte> Utf8Bom => [0xEF, 0xBB, 0xBF];
-            public static ReadOnlySpan<byte> TrueValue => "true"u8;
-            public static ReadOnlySpan<byte> FalseValue => "false"u8;
-            public static ReadOnlySpan<byte> NullValue => "null"u8;
-
-            public static ReadOnlySpan<byte> NaNValue => "NaN"u8;
-            public static ReadOnlySpan<byte> PositiveInfinityValue => "Infinity"u8;
-            public static ReadOnlySpan<byte> NegativeInfinityValue => "-Infinity"u8;
-
-            // Used to search for the end of a number
-            public static ReadOnlySpan<byte> Delimiters => ",}] \n\r\t/"u8;
-
-            // Explicitly skipping ReverseSolidus since that is handled separately
-            public static ReadOnlySpan<byte> EscapableChars => "\"nrt/ubf"u8;
-
-            public const int RemoveFlagsBitMask = 0x7FFFFFFF;
-
-            // In the worst case, an ASCII character represented as a single utf-8 byte could expand 6x when escaped.
-            // For example: '+' becomes '\u0043'
-            // Escaping surrogate pairs (represented by 3 or 4 utf-8 bytes) would expand to 12 bytes (which is still <= 6x).
-            // The same factor applies to utf-16 characters.
-            public const int MaxExpansionFactorWhileEscaping = 6;
-
-            // In the worst case, a single UTF-16 character could be expanded to 3 UTF-8 bytes.
-            // Only surrogate pairs expand to 4 UTF-8 bytes but that is a transformation of 2 UTF-16 characters going to 4 UTF-8 bytes (factor of 2).
-            // All other UTF-16 characters can be represented by either 1 or 2 UTF-8 bytes.
-            public const int MaxExpansionFactorWhileTranscoding = 3;
-
-            // When transcoding from UTF8 -> UTF16, the byte count threshold where we rent from the array pool before performing a normal alloc.
-            public const long ArrayPoolMaxSizeBeforeUsingNormalAlloc =
-#if NET6_0_OR_GREATER
-                1024 * 1024 * 1024; // ArrayPool limit increased in .NET 6
-#else
-            1024 * 1024;
-#endif
-
-            // The maximum number of characters allowed when writing raw UTF-16 JSON. This is the maximum length that we can guarantee can
-            // be safely transcoded to UTF-8 and fit within an integer-length span, given the max expansion factor of a single character (3).
-            public const int MaxUtf16RawValueLength = int.MaxValue / MaxExpansionFactorWhileTranscoding;
-
-            public const int MaxEscapedTokenSize = 1_000_000_000;   // Max size for already escaped value.
-            public const int MaxUnescapedTokenSize = MaxEscapedTokenSize / MaxExpansionFactorWhileEscaping;  // 166_666_666 bytes
-            public const int MaxCharacterTokenSize = MaxEscapedTokenSize / MaxExpansionFactorWhileEscaping; // 166_666_666 characters
-
-            public const int MaximumFormatBooleanLength = 5;
-            public const int MaximumFormatInt64Length = 20;   // 19 + sign (i.e. -9223372036854775808)
-            public const int MaximumFormatUInt32Length = 10;  // i.e. 4294967295
-            public const int MaximumFormatUInt64Length = 20;  // i.e. 18446744073709551615
-            public const int MaximumFormatDoubleLength = 128;  // default (i.e. 'G'), using 128 (rather than say 32) to be future-proof.
-            public const int MaximumFormatSingleLength = 128;  // default (i.e. 'G'), using 128 (rather than say 32) to be future-proof.
-            public const int MaximumFormatDecimalLength = 31; // default (i.e. 'G')
-            public const int MaximumFormatGuidLength = 36;    // default (i.e. 'D'), 8 + 4 + 4 + 4 + 12 + 4 for the hyphens (e.g. 094ffa0a-0442-494d-b452-04003fa755cc)
-            public const int MaximumEscapedGuidLength = MaxExpansionFactorWhileEscaping * MaximumFormatGuidLength;
-            public const int MaximumFormatDateTimeLength = 27;    // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000
-            public const int MaximumFormatDateTimeOffsetLength = 33;  // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000-07:00
-            public const int MaxDateTimeUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.
-            public const int DateTimeNumFractionDigits = 7;  // TimeSpan and DateTime formats allow exactly up to many digits for specifying the fraction after the seconds.
-            public const int MaxDateTimeFraction = 9_999_999;  // The largest fraction expressible by TimeSpan and DateTime formats
-            public const int DateTimeParseNumFractionDigits = 16; // The maximum number of fraction digits the Json DateTime parser allows
-            public const int MaximumDateTimeOffsetParseLength = MaximumFormatDateTimeOffsetLength +
-                (DateTimeParseNumFractionDigits - DateTimeNumFractionDigits); // Like StandardFormat 'O' for DateTimeOffset, but allowing 9 additional (up to 16) fraction digits.
-            public const int MinimumDateTimeParseLength = 10; // YYYY-MM-DD
-            public const int MaximumEscapedDateTimeOffsetParseLength = MaxExpansionFactorWhileEscaping * MaximumDateTimeOffsetParseLength;
-
-            public const int MaximumLiteralLength = 5; // Must be able to fit null, true, & false.
-
-            // Encoding Helpers
-            public const char HighSurrogateStart = '\ud800';
-            public const char HighSurrogateEnd = '\udbff';
-            public const char LowSurrogateStart = '\udc00';
-            public const char LowSurrogateEnd = '\udfff';
+            public const byte Space             = (byte)' ';
+            public const byte CarriageReturn    = (byte)'\r';
+            public const byte LineFeed          = (byte)'\n';
+            public const byte Tab               = (byte)'\t';
+            public const byte Quote             = (byte)'"';
+            public const byte BackSlash         = (byte)'\\';
+            public const byte Slash             = (byte)'/';
+            public const byte BackSpace         = (byte)'\b';
+            public const byte FormFeed          = (byte)'\f';
+            public const byte Colon             = (byte)':';
+            public const byte Plus              = (byte)'+';
 
             public const int UnicodePlane01StartValue = 0x10000;
             public const int HighSurrogateStartValue = 0xD800;
@@ -238,17 +148,7 @@ namespace CollapseLauncher.Helper.JsonConverter
             public const int LowSurrogateEndValue = 0xDFFF;
             public const int BitShiftBy10 = 0x400;
 
-            // The maximum number of parameters a constructor can have where it can be considered
-            // for a path on deserialization where we don't box the constructor arguments.
-            public const int UnboxedParameterCountThreshold = 4;
-
-            // Two space characters is the default indentation.
-            public const char DefaultIndentCharacter = ' ';
-            public const char TabIndentCharacter = '\t';
             public const int DefaultIndentSize = 2;
-            public const int MinimumIndentSize = 0;
-            public const int MaximumIndentSize = 127; // If this value is changed, the impact on the options masking used in the JsonWriterOptions struct must be checked carefully.
-
         }
 
         /// <summary>
@@ -413,10 +313,10 @@ namespace CollapseLauncher.Helper.JsonConverter
                 }
             }
 
-        Success:
+            Success:
             return true;
 
-        DestinationTooShort:
+            DestinationTooShort:
             return false;
         }
 

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
@@ -66,16 +66,16 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
             ApiResourceHttpClient = apiResourceHttpBuilder.Create();
         }
 
-        public static ILauncherApi CreateApiInstance(PresetConfig presetConfig, string gameName, string gameRegion)
-            => new HoYoPlayLauncherApiLoader(presetConfig, gameName, gameRegion);
+        public static HoYoPlayLauncherApiLoader CreateApiInstance(PresetConfig presetConfig, string gameName, string gameRegion)
+            => new(presetConfig, gameName, gameRegion);
 
-        protected override async Task LoadLauncherGameResource(ActionOnTimeOutRetry? onTimeoutRoutine, CancellationToken token)
+        protected override Task LoadLauncherGameResource(ActionOnTimeOutRetry? onTimeoutRoutine, CancellationToken token)
         {
-            ActionTimeoutValueTaskCallback<HoYoPlayLauncherResources?> hypResourceResponseCallback =
-                async innerToken => await ApiGeneralHttpClient.GetFromJsonAsync(
-                    PresetConfig?.LauncherResourceURL,
-                    HoYoPlayLauncherResourcesJsonContext.Default.HoYoPlayLauncherResources,
-                    innerToken);
+            ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherResources?> hypResourceResponseCallback =
+                innerToken => ApiGeneralHttpClient.GetFromJsonAsync(PresetConfig?.LauncherResourceURL,
+                                                                    HoYoPlayLauncherResourcesJsonContext.Default.HoYoPlayLauncherResources,
+                                                                    innerToken)
+                                                  .ConfigureAwait(false);
 
             // Assign as 3 Task array
             Task[] tasks = [
@@ -90,35 +90,48 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
             HoYoPlayLauncherResources? hypSdkResource = null;
 
             tasks[0] = hypResourceResponseCallback
-                .WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep, ExecutionTimeoutAttempt, onTimeoutRoutine, token)
-                .AsTaskAndDoAction(result => hypResourceResponse = result);
+                .WaitForRetryAsync(ExecutionTimeout,
+                                   ExecutionTimeoutStep,
+                                   ExecutionTimeoutAttempt,
+                                   onTimeoutRoutine,
+                                   token)
+                .ContinueWith(async result => hypResourceResponse = await result, token);
 
             if (!string.IsNullOrEmpty(PresetConfig?.LauncherPluginURL) && (PresetConfig.IsPluginUpdateEnabled ?? false))
             {
-                ActionTimeoutValueTaskCallback<HoYoPlayLauncherResources?> hypPluginResourceCallback =
-                    async innerToken =>
-                        await ApiGeneralHttpClient.GetFromJsonAsync(
-                            PresetConfig?.LauncherPluginURL,
-                            HoYoPlayLauncherResourcesJsonContext.Default.HoYoPlayLauncherResources,
-                            innerToken);
+                ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherResources?> hypPluginResourceCallback =
+                    innerToken => ApiGeneralHttpClient
+                       .GetFromJsonAsync(PresetConfig?.LauncherPluginURL,
+                                         HoYoPlayLauncherResourcesJsonContext.Default.HoYoPlayLauncherResources,
+                                         innerToken)
+                       .ConfigureAwait(false);
 
                 tasks[1] = hypPluginResourceCallback
-                    .WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep, ExecutionTimeoutAttempt, onTimeoutRoutine, token)
-                    .AsTaskAndDoAction(result => hypPluginResource = result);
+                    .WaitForRetryAsync(ExecutionTimeout,
+                                       ExecutionTimeoutStep,
+                                       ExecutionTimeoutAttempt,
+                                       onTimeoutRoutine,
+                                       token)
+                    .ContinueWith(async result => hypPluginResource = await result, token);
             }
 
             if (!string.IsNullOrEmpty(PresetConfig?.LauncherGameChannelSDKURL))
             {
-                ActionTimeoutValueTaskCallback<HoYoPlayLauncherResources?> hypSdkResourceCallback =
-                    async innerToken =>
-                        await ApiGeneralHttpClient.GetFromJsonAsync(
-                            PresetConfig?.LauncherGameChannelSDKURL,
-                            HoYoPlayLauncherResourcesJsonContext.Default.HoYoPlayLauncherResources,
-                            innerToken);
+                ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherResources?> hypSdkResourceCallback =
+                    innerToken =>
+                        ApiGeneralHttpClient
+                        .GetFromJsonAsync(PresetConfig?.LauncherGameChannelSDKURL,
+                                          HoYoPlayLauncherResourcesJsonContext.Default.HoYoPlayLauncherResources,
+                                          innerToken)
+                        .ConfigureAwait(false);
 
                 tasks[2] = hypSdkResourceCallback
-                    .WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep, ExecutionTimeoutAttempt, onTimeoutRoutine, token)
-                    .AsTaskAndDoAction(result => hypSdkResource = result);
+                    .WaitForRetryAsync(ExecutionTimeout,
+                                       ExecutionTimeoutStep,
+                                       ExecutionTimeoutAttempt,
+                                       onTimeoutRoutine,
+                                       token)
+                    .ContinueWith(async result => hypSdkResource = await result, token);
             }
 
             RegionResourceLatest sophonResourceCurrentPackage = new RegionResourceLatest();
@@ -133,15 +146,22 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
             };
 
             // Await all callbacks
-            await Task.WhenAll(tasks);
+            return Task.WhenAll(tasks)
+                .ContinueWith(AfterExecute, token);
 
-            ConvertPluginResources(ref sophonResourceData, hypPluginResource);
-            ConvertSdkResources(ref sophonResourceData, hypSdkResource);
-            ConvertPackageResources(sophonResourceData, hypResourceResponse?.Data?.LauncherPackages);
+            async Task AfterExecute(Task action)
+            {
+                // Run action
+                await action.ConfigureAwait(false);
 
-            LauncherGameResource = sophonResourcePropRoot;
+                ConvertPluginResources(ref sophonResourceData, hypPluginResource);
+                ConvertSdkResources(ref sophonResourceData, hypSdkResource);
+                ConvertPackageResources(sophonResourceData, hypResourceResponse?.Data?.LauncherPackages);
 
-            PerformDebugRoutines();
+                LauncherGameResource = sophonResourcePropRoot;
+
+                PerformDebugRoutines();
+            }
         }
 
         #region Convert Sdk Resources
@@ -368,7 +388,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
         }
         #endregion
 
-        protected override async Task LoadLauncherNews(ActionOnTimeOutRetry? onTimeoutRoutine, CancellationToken token)
+        protected override Task LoadLauncherNews(ActionOnTimeOutRetry? onTimeoutRoutine, CancellationToken token)
         {
             bool isUseMultiLang = PresetConfig?.LauncherSpriteURLMultiLang ?? false;
 
@@ -376,46 +396,63 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
             string launcherSpriteUrl = string.Format(PresetConfig?.LauncherSpriteURL!, localeCode);
             string launcherNewsUrl = string.Format(PresetConfig?.LauncherNewsURL!, localeCode);
 
-            ActionTimeoutValueTaskCallback<HoYoPlayLauncherNews?> hypLauncherBackgroundCallback =
-                async innerToken =>
-                    await ApiResourceHttpClient.GetFromJsonAsync(
-                        launcherSpriteUrl,
-                        HoYoPlayLauncherNewsJsonContext.Default.HoYoPlayLauncherNews,
-                        innerToken);
+            ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherNews?> hypLauncherBackgroundCallback =
+                innerToken =>
+                    ApiResourceHttpClient.GetFromJsonAsync(launcherSpriteUrl,
+                                                           HoYoPlayLauncherNewsJsonContext.Default.HoYoPlayLauncherNews,
+                                                           innerToken)
+                                         .ConfigureAwait(false);
 
-            ActionTimeoutValueTaskCallback<HoYoPlayLauncherNews?> hypLauncherNewsCallback =
-                async innerToken =>
-                    await ApiResourceHttpClient.GetFromJsonAsync(
-                        launcherNewsUrl,
-                        HoYoPlayLauncherNewsJsonContext.Default.HoYoPlayLauncherNews,
-                        innerToken);
+            ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherNews?> hypLauncherNewsCallback =
+                innerToken =>
+                    ApiResourceHttpClient.GetFromJsonAsync(launcherNewsUrl,
+                                                           HoYoPlayLauncherNewsJsonContext.Default.HoYoPlayLauncherNews,
+                                                           innerToken)
+                                         .ConfigureAwait(false);
 
             HoYoPlayLauncherNews? hypLauncherBackground = null;
             HoYoPlayLauncherNews? hypLauncherNews = null;
 
             // Load both in parallel
             Task[] tasks = [
-                hypLauncherBackgroundCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).AsTaskAndDoAction(result => hypLauncherBackground = result),
-                hypLauncherNewsCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token).AsTaskAndDoAction(result => hypLauncherNews = result)
+                hypLauncherBackgroundCallback
+                    .WaitForRetryAsync(ExecutionTimeout,
+                                       ExecutionTimeoutStep,
+                                       ExecutionTimeoutAttempt,
+                                       onTimeoutRoutine,
+                                       token)
+                    .ContinueWith(async result => hypLauncherBackground = await result, token),
+                hypLauncherNewsCallback
+                    .WaitForRetryAsync(ExecutionTimeout,
+                                       ExecutionTimeoutStep,
+                                       ExecutionTimeoutAttempt,
+                                       onTimeoutRoutine,
+                                       token)
+                    .ContinueWith(async result => hypLauncherNews = await result, token)
                 ];
 
             // Await the result
-            await Task.WhenAll(tasks);
+            return Task.WhenAll(tasks)
+                .ContinueWith(AfterExecute, token);
 
-            // Merge background image
-            if (hypLauncherBackground?.Data?.GameInfoList != null && hypLauncherNews?.Data != null)
-                hypLauncherNews.Data.GameInfoList = hypLauncherBackground.Data?.GameInfoList;
+            async Task AfterExecute(Task action)
+            {
+                // Run action
+                await action.ConfigureAwait(false);
 
-            LauncherGameNews? sophonLauncherNewsRoot = null;
-            EnsureInitializeSophonLauncherNews(ref sophonLauncherNewsRoot);
-            ConvertLauncherBackground(ref sophonLauncherNewsRoot, hypLauncherNews?.Data);
-            ConvertLauncherNews(ref sophonLauncherNewsRoot, hypLauncherNews?.Data);
-            ConvertLauncherSocialMedia(ref sophonLauncherNewsRoot, hypLauncherNews?.Data);
+                // Merge background image
+                if (hypLauncherBackground?.Data?.GameInfoList != null && hypLauncherNews?.Data != null)
+                    hypLauncherNews.Data.GameInfoList = hypLauncherBackground.Data?.GameInfoList;
 
-            LauncherGameNews = sophonLauncherNewsRoot;
-            LauncherGameNews?.Content?.InjectDownloadableItemCancelToken(this, token);
+                LauncherGameNews? sophonLauncherNewsRoot = null;
+                EnsureInitializeSophonLauncherNews(ref sophonLauncherNewsRoot);
+                ConvertLauncherBackground(ref sophonLauncherNewsRoot, hypLauncherNews?.Data);
+                ConvertLauncherNews(ref sophonLauncherNewsRoot, hypLauncherNews?.Data);
+                ConvertLauncherSocialMedia(ref sophonLauncherNewsRoot, hypLauncherNews?.Data);
+
+                LauncherGameNews = sophonLauncherNewsRoot;
+                LauncherGameNews?.Content?.InjectDownloadableItemCancelToken(this, token);
+            }
         }
 
         #region Convert Launcher News
@@ -514,12 +551,12 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
         }
         #endregion
 
-        protected override async Task LoadLauncherGameInfo(ActionOnTimeOutRetry? onTimeoutRoutine, CancellationToken token)
+        protected override Task LoadLauncherGameInfo(ActionOnTimeOutRetry? onTimeoutRoutine, CancellationToken token)
         {
             if (PresetConfig?.LauncherGameInfoDisplayURL == null)
             {
                 LauncherGameInfoField = new HoYoPlayGameInfoField();
-                return;
+                return Task.CompletedTask;
             }
 
             bool isUseMultiLang = PresetConfig?.LauncherSpriteURLMultiLang ?? false;
@@ -527,23 +564,31 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
             string localeCode = isUseMultiLang ? Locale.Lang.LanguageID.ToLower() : PresetConfig?.LauncherSpriteURLMultiLangFallback!;
             string launcherGameInfoUrl = string.Format(PresetConfig?.LauncherGameInfoDisplayURL!, localeCode);
 
-            ActionTimeoutValueTaskCallback<HoYoPlayLauncherGameInfo?> hypLauncherGameInfoCallback =
-                async innerToken =>
-                    await ApiResourceHttpClient.GetFromJsonAsync(
-                        launcherGameInfoUrl,
-                        HoYoPlayLauncherGameInfoJsonContext.Default.HoYoPlayLauncherGameInfo,
-                        innerToken);
+            ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherGameInfo?> hypLauncherGameInfoCallback =
+                innerToken =>
+                    ApiResourceHttpClient.GetFromJsonAsync(launcherGameInfoUrl,
+                                                           HoYoPlayLauncherGameInfoJsonContext.Default.HoYoPlayLauncherGameInfo,
+                                                           innerToken)
+                                         .ConfigureAwait(false);
 
-            HoYoPlayLauncherGameInfo? hypLauncherGameInfo = await hypLauncherGameInfoCallback.WaitForRetryAsync(ExecutionTimeout, ExecutionTimeoutStep,
-                                                           ExecutionTimeoutAttempt, onTimeoutRoutine, token);
+            return hypLauncherGameInfoCallback
+                  .WaitForRetryAsync(ExecutionTimeout,
+                                     ExecutionTimeoutStep,
+                                     ExecutionTimeoutAttempt,
+                                     onTimeoutRoutine,
+                                     token)
+                  .ContinueWith(async action =>
+                                {
+                                    HoYoPlayLauncherGameInfo? hypLauncherGameInfo = await action;
 
-            HoYoPlayGameInfoField? sophonLauncherGameInfoRoot = new HoYoPlayGameInfoField();
-            if (hypLauncherGameInfo != null)
-            {
-                ConvertGameInfoResources(ref sophonLauncherGameInfoRoot, hypLauncherGameInfo.GameInfoData);
+                                    HoYoPlayGameInfoField? sophonLauncherGameInfoRoot = new HoYoPlayGameInfoField();
+                                    if (hypLauncherGameInfo != null)
+                                    {
+                                        ConvertGameInfoResources(ref sophonLauncherGameInfoRoot, hypLauncherGameInfo.GameInfoData);
 
-                LauncherGameInfoField = sophonLauncherGameInfoRoot ?? new HoYoPlayGameInfoField();
-            }
+                                        LauncherGameInfoField = sophonLauncherGameInfoRoot ?? new HoYoPlayGameInfoField();
+                                    }
+                                }, token);
         }
 
         #region Convert Game Info Resources

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
@@ -1,5 +1,5 @@
 using CollapseLauncher.Extension;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using CollapseLauncher.Helper.Metadata;
 using Hi3Helper;
 using Microsoft.Win32;

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
@@ -1,4 +1,4 @@
-﻿using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+﻿using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 // ReSharper disable StringLiteralTypo

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 // ReSharper disable StringLiteralTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherNews.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherNews.cs
@@ -1,5 +1,5 @@
 ﻿using CollapseLauncher.Helper.JsonConverter;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherNews.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherNews.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 // ReSharper disable StringLiteralTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherResource.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherResource.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 // ReSharper disable StringLiteralTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+// ReSharper disable UnusedMemberInSuper.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
@@ -23,8 +23,8 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
         LauncherGameNews? LauncherGameNews { get; }
         HttpClient? ApiGeneralHttpClient { get; }
         HttpClient? ApiResourceHttpClient { get; }
-        Task<bool> LoadAsync(OnLoadAction? beforeLoadRoutine = null, OnLoadAction? afterLoadRoutine = null,
-            ActionOnTimeOutRetry? onTimeoutRoutine = null, ErrorLoadRoutineDelegate? errorLoadRoutine = null,
-            CancellationToken token = default);
+        Task<bool> LoadAsync(OnLoadAction? beforeLoadRoutine = null, OnLoadTaskAction?         afterLoadRoutine = null,
+            ActionOnTimeOutRetry?          onTimeoutRoutine  = null, ErrorLoadRoutineDelegate? errorLoadRoutine = null,
+            CancellationToken              token             = default);
     }
 }

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
@@ -23,8 +23,8 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
         LauncherGameNews? LauncherGameNews { get; }
         HttpClient? ApiGeneralHttpClient { get; }
         HttpClient? ApiResourceHttpClient { get; }
-        Task<bool> LoadAsync(OnLoadAction? beforeLoadRoutine = null, OnLoadTaskAction?         afterLoadRoutine = null,
-            ActionOnTimeOutRetry?          onTimeoutRoutine  = null, ErrorLoadRoutineDelegate? errorLoadRoutine = null,
-            CancellationToken              token             = default);
+        Task<bool> LoadAsync(OnLoadTaskAction? beforeLoadRoutine = null, OnLoadTaskAction? afterLoadRoutine = null,
+                             ActionOnTimeOutRetry? onTimeoutRoutine = null, ErrorLoadRoutineDelegate? errorLoadRoutine = null,
+                             CancellationToken token = default);
     }
 }

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
@@ -1,6 +1,6 @@
 ﻿using CollapseLauncher.Extension;
 using CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using System;
 using System.Net.Http;
 using System.Threading;

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -1,6 +1,6 @@
 using CollapseLauncher.Extension;
 using CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using CollapseLauncher.Helper.Metadata;
 using Hi3Helper;
 using Microsoft.Win32;

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -23,9 +23,7 @@ using System.Runtime.CompilerServices;
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader
 {
-    public delegate void OnLoadAction(CancellationToken token);
     public delegate Task OnLoadTaskAction(CancellationToken token);
-
     public delegate void ErrorLoadRoutineDelegate(Exception ex);
 
     internal partial class LauncherApiBase : ILauncherApi
@@ -116,11 +114,11 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
             ApiResourceHttpClient = apiResourceHttpBuilder.Create();
         }
 
-        public async Task<bool> LoadAsync(OnLoadAction?         beforeLoadRoutine, OnLoadTaskAction?         afterLoadRoutine,
+        public async Task<bool> LoadAsync(OnLoadTaskAction?     beforeLoadRoutine, OnLoadTaskAction?         afterLoadRoutine,
                                           ActionOnTimeOutRetry? onTimeoutRoutine,  ErrorLoadRoutineDelegate? errorLoadRoutine,
                                           CancellationToken     token)
         {
-            beforeLoadRoutine?.Invoke(token);
+            _ = beforeLoadRoutine?.Invoke(token) ?? Task.CompletedTask;
 
             try
             {
@@ -151,7 +149,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
         }
 
         protected virtual Task LoadLauncherGameResource(ActionOnTimeOutRetry? onTimeoutRoutine,
-                                                              CancellationToken token)
+                                                        CancellationToken token)
         {
             EnsurePresetConfigNotNull();
             EnsureResourceUrlNotNull();

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LauncherGameNews.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LauncherGameNews.cs
@@ -12,6 +12,7 @@ using WinRT;
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 // ReSharper disable StringLiteralTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.Helper.LauncherApiLoader.Legacy
 {

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LauncherGameNews.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LauncherGameNews.cs
@@ -13,7 +13,7 @@ using WinRT;
 // ReSharper disable InconsistentNaming
 // ReSharper disable StringLiteralTypo
 
-namespace CollapseLauncher.Helper.LauncherApiLoader.Sophon
+namespace CollapseLauncher.Helper.LauncherApiLoader.Legacy
 {
     [JsonConverter(typeof(JsonStringEnumConverter<LauncherGameNewsPostType>))]
     public enum LauncherGameNewsPostType

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LegacyLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LegacyLauncherApiLoader.cs
@@ -3,14 +3,14 @@
 // ReSharper disable PartialTypeWithSinglePart
 
 #nullable enable
-namespace CollapseLauncher.Helper.LauncherApiLoader.Sophon
+namespace CollapseLauncher.Helper.LauncherApiLoader.Legacy
 {
-    internal sealed partial class SophonLauncherApiLoader : LauncherApiBase
+    internal sealed partial class LegacyLauncherApiLoader : LauncherApiBase
     {
-        private SophonLauncherApiLoader(PresetConfig presetConfig, string gameName, string gameRegion)
+        private LegacyLauncherApiLoader(PresetConfig presetConfig, string gameName, string gameRegion)
             : base(presetConfig, gameName, gameRegion) { }
 
         public static ILauncherApi CreateApiInstance(PresetConfig presetConfig, string gameName, string gameRegion)
-            => new SophonLauncherApiLoader(presetConfig, gameName, gameRegion);
+            => new LegacyLauncherApiLoader(presetConfig, gameName, gameRegion);
     }
 }

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LegacyLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/Legacy/LegacyLauncherApiLoader.cs
@@ -10,7 +10,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.Legacy
         private LegacyLauncherApiLoader(PresetConfig presetConfig, string gameName, string gameRegion)
             : base(presetConfig, gameName, gameRegion) { }
 
-        public static ILauncherApi CreateApiInstance(PresetConfig presetConfig, string gameName, string gameRegion)
-            => new LegacyLauncherApiLoader(presetConfig, gameName, gameRegion);
+        public static LegacyLauncherApiLoader CreateApiInstance(PresetConfig presetConfig, string gameName, string gameRegion)
+            => new(presetConfig, gameName, gameRegion);
     }
 }

--- a/CollapseLauncher/Classes/Helper/Loading/LoadingMessageHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Loading/LoadingMessageHelper.cs
@@ -2,6 +2,7 @@
 using CollapseLauncher.Helper.Animation;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Animations;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -18,6 +19,7 @@ namespace CollapseLauncher.Helper.Loading
         internal static bool IsLoadingProgressIndeterminate = true;
         internal static bool IsCurrentlyShow;
         internal static List<RoutedEventHandler> CurrentActionButtonHandler = [];
+        internal static DispatcherQueue CurrentDispatcherQueue;
 
         /// <summary>
         /// Initialize the necessary <c>MainWindow</c> for spawning the loading frame overlay.
@@ -26,6 +28,8 @@ namespace CollapseLauncher.Helper.Loading
         {
             if (WindowUtility.CurrentWindow is MainWindow window)
                 CurrentMainWindow = window;
+
+            CurrentDispatcherQueue = CurrentMainWindow.DispatcherQueue;
         }
 
         /// <summary>
@@ -35,10 +39,13 @@ namespace CollapseLauncher.Helper.Loading
         /// <param name="subtitle">Set the subtitle of the loading frame. You can set the value to <c>null</c> to ignore the change of the subtitle or <c>string.Empty</c> to disable the subtitle</param>
         internal static void SetMessage(string title, string subtitle)
         {
-            if (title != null) CurrentMainWindow!.LoadingStatusTextTitle!.Text = title;
-            if (subtitle != null) CurrentMainWindow!.LoadingStatusTextSubtitle!.Text = subtitle;
+            CurrentDispatcherQueue.TryEnqueue(() =>
+            {
+                if (title != null) CurrentMainWindow.LoadingStatusTextTitle.Text = title;
+                if (subtitle != null) CurrentMainWindow.LoadingStatusTextSubtitle.Text = subtitle;
 
-            CurrentMainWindow!.LoadingStatusTextSeparator!.Visibility = title == string.Empty || subtitle == string.Empty ? Visibility.Collapsed : Visibility.Visible;
+                CurrentMainWindow.LoadingStatusTextSeparator.Visibility = title == string.Empty || subtitle == string.Empty ? Visibility.Collapsed : Visibility.Visible;
+            });
         }
 
         /// <summary>
@@ -47,7 +54,7 @@ namespace CollapseLauncher.Helper.Loading
         /// Note: If you would like to set the progress ring's value, make sure to set the <c>isProgressIndeterminate</c> to <c>true</c> with <c>SetProgressBarState()</c> method.
         /// </summary>
         /// <param name="value">Set the current value of the progress ring</param>
-        internal static void SetProgressBarValue(double value) => CurrentMainWindow!.LoadingStatusProgressRing!.Value = value;
+        internal static void SetProgressBarValue(double value) => CurrentDispatcherQueue.TryEnqueue(() => CurrentMainWindow.LoadingStatusProgressRing.Value = value);
 
         /// <summary>
         /// Set the state and the maximum value of the progress ring.
@@ -56,9 +63,12 @@ namespace CollapseLauncher.Helper.Loading
         /// <param name="isProgressIndeterminate">Set the state of the progress ring's indeterminate.</param>
         internal static void SetProgressBarState(double maxValue = 100d, bool isProgressIndeterminate = true)
         {
-            IsLoadingProgressIndeterminate = isProgressIndeterminate;
-            CurrentMainWindow!.LoadingStatusProgressRing!.Maximum = maxValue;
-            CurrentMainWindow!.LoadingStatusProgressRing!.IsIndeterminate = IsLoadingProgressIndeterminate;
+            CurrentDispatcherQueue.TryEnqueue(() =>
+            {
+                IsLoadingProgressIndeterminate = isProgressIndeterminate;
+                CurrentMainWindow.LoadingStatusProgressRing.Maximum = maxValue;
+                CurrentMainWindow.LoadingStatusProgressRing.IsIndeterminate = IsLoadingProgressIndeterminate;
+            });
         }
 
         /// <summary>
@@ -87,17 +97,17 @@ namespace CollapseLauncher.Helper.Loading
             if (IsCurrentlyShow) return;
 
             IsCurrentlyShow                                            = true;
-            CurrentMainWindow!.LoadingStatusGrid!.Visibility           = Visibility.Visible;
-            CurrentMainWindow!.LoadingStatusBackgroundGrid!.Visibility = Visibility.Visible;
+            CurrentMainWindow.LoadingStatusGrid.Visibility           = Visibility.Visible;
+            CurrentMainWindow.LoadingStatusBackgroundGrid.Visibility = Visibility.Visible;
 
             TimeSpan duration = TimeSpan.FromSeconds(0.25);
 
             await Task.WhenAll(
                                CurrentMainWindow.LoadingStatusBackgroundGrid.StartAnimation(duration,
-                                                                                            CurrentMainWindow.LoadingStatusBackgroundGrid.GetElementCompositor()!.CreateScalarKeyFrameAnimation("Opacity", 1, 0)),
+                                                                                            CurrentMainWindow.LoadingStatusBackgroundGrid.GetElementCompositor().CreateScalarKeyFrameAnimation("Opacity", 1, 0)),
                                CurrentMainWindow.LoadingStatusGrid.StartAnimation(duration,
-                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor()!.CreateVector3KeyFrameAnimation("Translation", new Vector3(0, 0, CurrentMainWindow.LoadingStatusGrid.Translation.Z), new Vector3(0, (float)(CurrentMainWindow.LoadingStatusGrid.ActualHeight + 16), CurrentMainWindow.LoadingStatusGrid.Translation.Z)),
-                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor()!.CreateScalarKeyFrameAnimation("Opacity", 1, 0))
+                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor().CreateVector3KeyFrameAnimation("Translation", new Vector3(0, 0, CurrentMainWindow.LoadingStatusGrid.Translation.Z), new Vector3(0, (float)(CurrentMainWindow.LoadingStatusGrid.ActualHeight + 16), CurrentMainWindow.LoadingStatusGrid.Translation.Z)),
+                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor().CreateScalarKeyFrameAnimation("Opacity", 1, 0))
                               );
         }
 
@@ -131,14 +141,14 @@ namespace CollapseLauncher.Helper.Loading
             TimeSpan duration = TimeSpan.FromSeconds(0.25);
             await Task.WhenAll(
                                CurrentMainWindow.LoadingStatusBackgroundGrid.StartAnimation(duration,
-                                                                                            CurrentMainWindow.LoadingStatusBackgroundGrid.GetElementCompositor()!.CreateScalarKeyFrameAnimation("Opacity", 0, 1)),
+                                                                                            CurrentMainWindow.LoadingStatusBackgroundGrid.GetElementCompositor().CreateScalarKeyFrameAnimation("Opacity", 0, 1)),
                                CurrentMainWindow.LoadingStatusGrid.StartAnimation(duration,
-                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor()!.CreateVector3KeyFrameAnimation("Translation", new Vector3(0, (float)(CurrentMainWindow.LoadingStatusGrid.ActualHeight + 16), CurrentMainWindow.LoadingStatusGrid.Translation.Z), new Vector3(0, 0, CurrentMainWindow.LoadingStatusGrid.Translation.Z)),
-                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor()!.CreateScalarKeyFrameAnimation("Opacity", 0, 1))
+                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor().CreateVector3KeyFrameAnimation("Translation", new Vector3(0, (float)(CurrentMainWindow.LoadingStatusGrid.ActualHeight + 16), CurrentMainWindow.LoadingStatusGrid.Translation.Z), new Vector3(0, 0, CurrentMainWindow.LoadingStatusGrid.Translation.Z)),
+                                                                                  CurrentMainWindow.LoadingStatusGrid.GetElementCompositor().CreateScalarKeyFrameAnimation("Opacity", 0, 1))
                               );
 
-            CurrentMainWindow.LoadingStatusGrid.Visibility            = Visibility.Collapsed;
-            CurrentMainWindow.LoadingStatusBackgroundGrid!.Visibility = Visibility.Collapsed;
+            CurrentMainWindow.LoadingStatusGrid.Visibility           = Visibility.Collapsed;
+            CurrentMainWindow.LoadingStatusBackgroundGrid.Visibility = Visibility.Collapsed;
             HideActionButton();
         }
 
@@ -155,34 +165,37 @@ namespace CollapseLauncher.Helper.Loading
         /// <param name="routedEvent">Set the event callback for the button's click event.</param>
         internal static void ShowActionButton(object buttonContent, string buttonIconGlyph = null, RoutedEventHandler routedEvent = null)
         {
-            if (routedEvent != null)
+            CurrentDispatcherQueue.TryEnqueue(() =>
             {
-                CurrentActionButtonHandler!.Add(routedEvent);
-                CurrentMainWindow!.LoadingStatusActionButton!.Click += routedEvent;
-            }
-
-            bool isHasIcon = !string.IsNullOrEmpty(buttonIconGlyph);
-            CurrentMainWindow!.LoadingStatusActionButtonIcon!.Visibility = isHasIcon ? Visibility.Visible : Visibility.Collapsed;
-            CurrentMainWindow!.LoadingStatusActionButton!.Visibility = Visibility.Visible;
-            if (isHasIcon) CurrentMainWindow.LoadingStatusActionButtonIcon.Glyph = buttonIconGlyph;
-
-            if (buttonContent is string buttonText)
-            {
-                TextBlock textBlock = new()
+                if (routedEvent != null)
                 {
-                    TextWrapping = TextWrapping.Wrap,
-                    TextAlignment = TextAlignment.Left,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Margin = new Thickness(0, isHasIcon ? -2 : 0, 0, 0)
-                };
-                textBlock.AddTextBlockLine(buttonText, FontWeights.SemiBold);
-                CurrentMainWindow.LoadingStatusActionButtonContentContainer!.Children!.Clear();
-                CurrentMainWindow.LoadingStatusActionButtonContentContainer!.AddElementToGridRowColumn(textBlock);
-                return;
-            }
+                    CurrentActionButtonHandler!.Add(routedEvent);
+                    CurrentMainWindow.LoadingStatusActionButton.Click += routedEvent;
+                }
 
-            CurrentMainWindow.LoadingStatusActionButtonContentContainer!.Children!.Clear();
-            CurrentMainWindow.LoadingStatusActionButtonContentContainer!.AddElementToGridRowColumn(buttonContent as FrameworkElement);
+                bool isHasIcon = !string.IsNullOrEmpty(buttonIconGlyph);
+                CurrentMainWindow.LoadingStatusActionButtonIcon.Visibility = isHasIcon ? Visibility.Visible : Visibility.Collapsed;
+                CurrentMainWindow.LoadingStatusActionButton.Visibility = Visibility.Visible;
+                if (isHasIcon) CurrentMainWindow.LoadingStatusActionButtonIcon.Glyph = buttonIconGlyph;
+
+                if (buttonContent is string buttonText)
+                {
+                    TextBlock textBlock = new()
+                    {
+                        TextWrapping = TextWrapping.Wrap,
+                        TextAlignment = TextAlignment.Left,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Margin = new Thickness(0, isHasIcon ? -2 : 0, 0, 0)
+                    };
+                    textBlock.AddTextBlockLine(buttonText, FontWeights.SemiBold);
+                    CurrentMainWindow.LoadingStatusActionButtonContentContainer.Children.Clear();
+                    CurrentMainWindow.LoadingStatusActionButtonContentContainer.AddElementToGridRowColumn(textBlock);
+                    return;
+                }
+
+                CurrentMainWindow.LoadingStatusActionButtonContentContainer.Children.Clear();
+                CurrentMainWindow.LoadingStatusActionButtonContentContainer.AddElementToGridRowColumn(buttonContent as FrameworkElement);
+            });
         }
 
         /// <summary>
@@ -190,15 +203,18 @@ namespace CollapseLauncher.Helper.Loading
         /// </summary>
         internal static void HideActionButton()
         {
-            if (CurrentActionButtonHandler!.Count > 0)
+            CurrentDispatcherQueue.TryEnqueue(() =>
             {
-                foreach (var t in CurrentActionButtonHandler)
-                    CurrentMainWindow!.LoadingStatusActionButton!.Click -= t;
+                if (CurrentActionButtonHandler.Count > 0)
+                {
+                    foreach (var t in CurrentActionButtonHandler)
+                        CurrentMainWindow.LoadingStatusActionButton.Click -= t;
 
-                CurrentActionButtonHandler.Clear();
-            }
+                    CurrentActionButtonHandler.Clear();
+                }
 
-            CurrentMainWindow!.LoadingStatusActionButton!.Visibility = Visibility.Collapsed;
+                CurrentMainWindow.LoadingStatusActionButton.Visibility = Visibility.Collapsed;
+            });
         }
     }
 }

--- a/CollapseLauncher/Classes/Helper/Metadata/DataCooker.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/DataCooker.cs
@@ -11,6 +11,7 @@ using System.Threading;
 
 // ReSharper disable IdentifierTypo
 using ZstdDecompressStream = ZstdNet.DecompressionStream;
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.Helper.Metadata
 {
@@ -27,7 +28,7 @@ namespace CollapseLauncher.Helper.Metadata
         private const int  AllowedBufferPoolSize = 1 << 20; // 1 MiB
 
         internal static         RSA  RsaInstance;
-        private static readonly Lock RsaDecryptLock = new Lock();
+        private static readonly Lock RsaDecryptLock = new();
 
         internal static string ServeV3Data(string data)
         {

--- a/CollapseLauncher/Classes/Helper/Metadata/GameDataVersion.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/GameDataVersion.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
     using System;
+// ReSharper disable UnusedMember.Global
 
     namespace CollapseLauncher.Helper.Metadata
 {

--- a/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
@@ -80,7 +80,7 @@ namespace CollapseLauncher.Helper.Metadata
 
         #endregion
 
-        internal static async ValueTask<PresetConfig?> GetMetadataConfig(string? gameName, string? gameRegion)
+        internal static async Task<PresetConfig?> GetMetadataConfig(string? gameName, string? gameRegion)
         {
             ArgumentException.ThrowIfNullOrEmpty(gameName);
             ArgumentException.ThrowIfNullOrEmpty(gameRegion);

--- a/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
@@ -10,9 +10,12 @@ using Hi3Helper.Shared.Region;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
 using System.IO;
 using System.IO.Hashing;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 // ReSharper disable SwitchStatementMissingSomeEnumCasesNoDefault
 // ReSharper disable ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
@@ -64,6 +67,8 @@ namespace CollapseLauncher.Helper.Metadata
 
         internal static MasterKeyConfig? CurrentMasterKey { get; private set; }
 
+        internal static Dictionary<string, MasterKeyConfig>? OtherMasterKeyConfigVault { get; private set; }
+
         #endregion
 
         #region Current Game Name and Max Region Counts
@@ -114,7 +119,10 @@ namespace CollapseLauncher.Helper.Metadata
                         {
                             // Get the current channel
                             string currentChannel = CurrentLauncherChannel;
-                            await LoadConfigInner(previousStamp, currentChannel);
+                            if (await LoadAndGetConfig(previousStamp, currentChannel) is PresetConfig presetConfig)
+                            {
+                                LauncherMetadataConfig?[gameName]?.Add(gameRegion, presetConfig);
+                            }
                         }
                     }
                     break;
@@ -190,7 +198,7 @@ namespace CollapseLauncher.Helper.Metadata
                 0;
         }
 
-        internal static async ValueTask Initialize(bool isCacheUpdateModeOnly = false, bool isShowLoadingMessage = true)
+        internal static async Task Initialize(bool isCacheUpdateModeOnly = false, bool isShowLoadingMessage = true)
         {
             if (isShowLoadingMessage)
             {
@@ -213,7 +221,7 @@ namespace CollapseLauncher.Helper.Metadata
             await InitializeConfig(currentChannel, isCacheUpdateModeOnly, isShowLoadingMessage);
         }
 
-        internal static async ValueTask InitializeStamp(string currentChannel, bool throwAfterRetry = false)
+        internal static async Task InitializeStamp(string currentChannel, bool throwAfterRetry = false)
         {
             string stampLocalFilePath = Path.Combine(LauncherMetadataFolder, LauncherMetadataStampPrefix);
             string stampRemoteFilePath = LauncherStampRemoteURLPath;
@@ -251,16 +259,17 @@ namespace CollapseLauncher.Helper.Metadata
                 if (LauncherMetadataStamp == null || LauncherMetadataStamp.Count == 0)
                     throw new FormatException("JSON response of the stamp is empty or null!");
 
-                // Load and add stamp into stamp dictionary
-                foreach (Stamp? stamp in LauncherMetadataStamp)
-                {
-                    if (stamp == null)
-                        continue;
+                // Get master key information first
+                AddItemBasedOnType(LauncherMetadataStamp, LauncherMetadataStampDictionary, MetadataType.MasterKey);
 
-                    string? gameName = string.IsNullOrEmpty(stamp.GameName) ? stamp.MetadataType.ToString() : stamp.GameName;
-                    string? gameRegion = string.IsNullOrEmpty(stamp.GameRegion) ? stamp.MetadataPath : stamp.GameRegion;
-                    LauncherMetadataStampDictionary?.Add($"{gameName} - {gameRegion}", stamp);
-                }
+                // Then Community Tools
+                AddItemBasedOnType(LauncherMetadataStamp, LauncherMetadataStampDictionary, MetadataType.CommunityTools);
+
+                // Then Game Preset Configs
+                AddItemBasedOnType(LauncherMetadataStamp, LauncherMetadataStampDictionary, MetadataType.PresetConfigV2);
+
+                // Last one, Unknown metadata
+                AddItemBasedOnType(LauncherMetadataStamp, LauncherMetadataStampDictionary, MetadataType.Unknown);
             }
             catch (Exception ex)
             {
@@ -296,11 +305,26 @@ namespace CollapseLauncher.Helper.Metadata
                     await stampLocalStream.DisposeAsync();
                 }
             }
+            return;
+
+            static void AddItemBasedOnType(IEnumerable<Stamp?> stamps, Dictionary<string, Stamp> dict, MetadataType metadataType)
+            {
+                // Load and add stamp into stamp dictionary
+                foreach (Stamp? stamp in stamps.Where(x => x?.MetadataType == metadataType))
+                {
+                    if (stamp == null)
+                        continue;
+
+                    string? gameName = string.IsNullOrEmpty(stamp.GameName) ? stamp.MetadataType.ToString() : stamp.GameName;
+                    string? gameRegion = string.IsNullOrEmpty(stamp.GameRegion) ? stamp.MetadataPath : stamp.GameRegion;
+                    dict?.Add($"{gameName} - {gameRegion}", stamp);
+                }
+            }
         }
 
-
-        internal static async ValueTask InitializeConfig(string currentChannel, bool isCacheUpdateModeOnly,
-                                                         bool isShowLoadingMessage)
+        internal static async Task InitializeConfig(string currentChannel,
+                                                    bool   isCacheUpdateModeOnly,
+                                                    bool   isShowLoadingMessage)
         {
             if (LauncherMetadataStamp == null)
             {
@@ -314,61 +338,158 @@ namespace CollapseLauncher.Helper.Metadata
 
             // Initialize the dictionary of the config
             LauncherMetadataConfig ??= [];
-
             LauncherMetadataConfig.Clear();
 
             // Initialize the game name region collection if it's null
             LauncherGameNameRegionCollection ??= [];
-
             LauncherGameNameRegionCollection.Clear();
 
-            // Find and iterate the master key first
-            Stamp? masterKeyStamp =
-                LauncherMetadataStamp.FirstOrDefault(x => x?.MetadataType == MetadataType.MasterKey);
-            if (masterKeyStamp == null)
-            {
-                throw new KeyNotFoundException("Master key information is not found in the stamp!");
-            }
-            await LoadConfigInner(masterKeyStamp, currentChannel, false, true);
+            // Initialize the game master key config vault
+            OtherMasterKeyConfigVault ??= [];
+            OtherMasterKeyConfigVault.Clear();
 
-            // Iterate the CommunityTools configs
-            Stamp? stampCommunityToolkit = LauncherMetadataStamp
-               .FirstOrDefault(x => x?.MetadataType == MetadataType.CommunityTools);
-            if (stampCommunityToolkit != null)
+            // Initialize the community tools properties
+            PageStatics.CommunityToolsProperty ??= new CommunityToolsProperty();
+            PageStatics.CommunityToolsProperty.Clear();
+
+            #region Master Key Loading
+            // Load master key config
+            bool isMasterKeyLoaded = false;
+            foreach (Stamp? stamp in LauncherMetadataStamp.Where(x => x?.MetadataType == MetadataType.MasterKey))
             {
-                await LoadConfigInner(stampCommunityToolkit, currentChannel);
+                if (stamp == null)
+                    continue;
+
+                object? masterKey = await LoadAndGetConfig(stamp, currentChannel, false, true);
+                if (masterKey is not MasterKeyConfig keyConfig)
+                    continue;
+
+                if (!isMasterKeyLoaded)
+                {
+                    CurrentMasterKey  = keyConfig;
+                    isMasterKeyLoaded = true;
+                }
+
+                _ = OtherMasterKeyConfigVault.TryAdd(stamp.MetadataPath ?? "", keyConfig);
             }
 
-            // Iterate the stamp and try to load the configs
-            int index = 1;
-            List<Stamp?> stampList = LauncherMetadataStamp
-                                   .Where(x => x?.MetadataType == MetadataType.PresetConfigV2)
-                                   .ToList();
-            foreach (var stamp in stampList.OfType<Stamp>())
+            // Throw if none of the master key is loaded
+            if (!isMasterKeyLoaded)
             {
+                throw new InvalidOperationException("No master key load operation has been executed!");
+            }
+            #endregion
+
+            #region Region Metadata Config Loading
+            ConcurrentDictionary<string, PresetConfig> loadedRegionMetadata = [];
+            List<Stamp?> regionMetadataStamps = LauncherMetadataStamp
+                                               .Where(x => x?.MetadataType == MetadataType.PresetConfigV2)
+                                               .ToList();
+
+            // Load metadata in parallel
+            int regionMetadataStampsCount = regionMetadataStamps.Count;
+            await Parallel.ForEachAsync(regionMetadataStamps
+                .Select(x => (x, loadedRegionMetadata))
+                .Index(),
+                LoadRegionMetadataConfig);
+
+            // Sort the metadata based on stamps order
+            foreach (Stamp? stamp in regionMetadataStamps)
+            {
+                if (stamp == null)
+                    continue;
+
+                string filePath = stamp.MetadataPath ?? "";
+                if (!loadedRegionMetadata.TryGetValue(filePath, out PresetConfig? presetConfig))
+                {
+                    continue;
+                }
+
+                string gameName   = stamp.GameName ?? "";
+                string gameRegion = stamp.GameRegion ?? "";
+
+                // Re-add the region dict into the game name map
+                if (!LauncherMetadataConfig.TryGetValue(gameName, out Dictionary<string, PresetConfig>? regionDict))
+                {
+                    LauncherMetadataConfig.Add(gameName, regionDict = []);
+                }
+
+                // Re-add the region preset config into its region dict
+                if (!(regionDict?.TryAdd(gameRegion, presetConfig) ?? false))
+                {
+                    continue;
+                }
+
+                // Re-add the region list into the game name map
+                if (!LauncherGameNameRegionCollection.TryGetValue(gameName, out List<string>? regionList))
+                {
+                    LauncherGameNameRegionCollection.Add(gameName, regionList = []);
+                }
+
+                // Re-add the region name into its region dict
+                regionList?.Add(gameRegion);
+            }
+
+            async ValueTask LoadRegionMetadataConfig((int, (Stamp?, ConcurrentDictionary<string, PresetConfig>)) state, CancellationToken token)
+            {
+                int                                        index            = state.Item1;
+                Stamp?                                     stamp            = state.Item2.Item1;
+                ConcurrentDictionary<string, PresetConfig> regionDictionary = state.Item2.Item2;
+
+                if (stamp == null || string.IsNullOrEmpty(stamp.GameName) || string.IsNullOrEmpty(stamp.GameRegion))
+                    return;
+
                 if (isShowLoadingMessage)
                 {
                     LoadingMessageHelper.SetMessage(Locale.Lang._MainPage.Initializing,
-                                                    $"{Locale.Lang._MainPage.LoadingGameConfiguration} [{index++}/{stampList?.Count}]: {InnerLauncherConfig.GetGameTitleRegionTranslationString(stamp.GameName, Locale.Lang._GameClientTitles)} - {InnerLauncherConfig.GetGameTitleRegionTranslationString(stamp.GameRegion, Locale.Lang._GameClientRegions)}");
+                                                    $"{Locale.Lang._MainPage.LoadingGameConfiguration} [{index}/{regionMetadataStampsCount}]: " +
+                                                    $"{InnerLauncherConfig.GetGameTitleRegionTranslationString(stamp.GameName, Locale.Lang._GameClientTitles)} - " +
+                                                    $"{InnerLauncherConfig.GetGameTitleRegionTranslationString(stamp.GameRegion, Locale.Lang._GameClientRegions)}");
                 }
 
-                await LoadConfigInner(stamp, currentChannel, false, false, isCacheUpdateModeOnly);
+                object? regionMetadataObject = await LoadAndGetConfig(stamp, currentChannel);
+                if (regionMetadataObject is PresetConfig presetConfig)
+                {
+                    // If the cache update mode is enabled and the config is not enabled, then skip
+                    if (isCacheUpdateModeOnly && (!presetConfig.IsCacheUpdateEnabled ?? false)) return;
+
+                    // Try to add the preset config map into the dictionary
+                    regionDictionary.TryAdd(stamp.MetadataPath ?? "", presetConfig);
+                }
             }
+            #endregion
+
+            #region Community Tools Config Loading
+            foreach (Stamp? stamp in LauncherMetadataStamp.Where(x => x?.MetadataType == MetadataType.CommunityTools))
+            {
+                if (stamp == null)
+                    continue;
+
+                object? communityTools = await LoadAndGetConfig(stamp, currentChannel);
+                if (communityTools is not CommunityToolsProperty communityToolsProperty)
+                    continue;
+
+                foreach (KeyValuePair<GameNameType, List<CommunityToolsEntry>> entry in communityToolsProperty.OfficialToolsDictionary ?? [])
+                {
+                    PageStatics.CommunityToolsProperty.OfficialToolsDictionary?.Add(entry.Key, entry.Value);
+                }
+
+                foreach (KeyValuePair<GameNameType, List<CommunityToolsEntry>> entry in communityToolsProperty.CommunityToolsDictionary ?? [])
+                {
+                    PageStatics.CommunityToolsProperty.CommunityToolsDictionary?.Add(entry.Key, entry.Value);
+                }
+            }
+            #endregion
 
             // Save the current count of game name and game regions
-            CurrentGameNameCount = LauncherMetadataConfig.Keys.Count;
+            CurrentGameNameCount      = LauncherMetadataConfig.Keys.Count;
             CurrentGameRegionMaxCount = LauncherMetadataConfig.Max(x => x.Value?.Count ?? 0);
         }
 
-        private static DateTime GetFileLastModifiedStampUtc(string configLocalFilePath)
-        {
-            FileInfo fileInfo = new FileInfo(configLocalFilePath);
-            return fileInfo.LastWriteTimeUtc;
-        }
-
-        internal static async ValueTask LoadConfigInner(Stamp stamp, string currentChannel,
-                                                        bool throwAfterRetry = false, bool allowDeserializeKey = false,
-                                                        bool isCacheUpdateModeOnly = false)
+        internal static async Task<object?> LoadAndGetConfig(Stamp  stamp,
+                                                             string currentChannel,
+                                                             bool   throwAfterRetry     = false,
+                                                             bool   allowDeserializeKey = false)
         {
             if (string.IsNullOrEmpty(stamp.MetadataPath))
             {
@@ -406,14 +527,13 @@ namespace CollapseLauncher.Helper.Metadata
                             MasterKeyConfig? keyConfig =
                                 await configLocalStream.DeserializeAsync(MesterKeyConfigJsonContext.Default.MasterKeyConfig);
 
-                            // Assign the key to instance property
-                            CurrentMasterKey = keyConfig ?? throw new InvalidDataException("Master key config seems to be empty!");
-                            break;
+                            // Return the key to instance property
+                            return keyConfig;
                         }
                     case MetadataType.CommunityTools:
                         {
-                            PageStatics.CommunityToolsProperty = await CommunityToolsProperty.LoadCommunityTools(configLocalStream);
-                            break;
+                            // Deserialize the community tools
+                            return await CommunityToolsProperty.LoadCommunityTools(configLocalStream);
                         }
                     case MetadataType.PresetConfigV2 when string.IsNullOrEmpty(stamp.GameName) || string.IsNullOrEmpty(stamp.GameRegion):
                         throw new NullReferenceException("Game name or region property inside the stamp is empty!");
@@ -422,58 +542,35 @@ namespace CollapseLauncher.Helper.Metadata
                         {
                             PresetConfig? presetConfig =
                                 await configLocalStream.DeserializeAsync(PresetConfigJsonContext.Default.PresetConfig);
-                            if (presetConfig != null)
-                            {
-                                if (isCacheUpdateModeOnly && (!presetConfig.IsCacheUpdateEnabled ?? false)) return;
 
-                                // Generate HashID and GameName
-                                string hashComposition = $"{stamp.LastUpdated} - {stamp.GameName} - {stamp.GameRegion}";
-                                byte[] hashBytes       = Hash.GetHashFromString<Crc32>(hashComposition);
-                                int    hashID          = BitConverter.ToInt32(hashBytes);
-                                
-                                presetConfig.HashID   = hashID;
-                                presetConfig.GameName = stamp.GameName;
-                                presetConfig.GameLauncherApi ??= presetConfig.LauncherType switch
-                                {
-                                    LauncherType.Sophon => LegacyLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
-                                    LauncherType.HoYoPlay => HoYoPlayLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
-                                    _ => throw new NotSupportedException($"Launcher type: {presetConfig.LauncherType} is not supported!")
-                                };
-
-                                // Dispose the file first
-                                await configLocalStream.DisposeAsync();
-
-                                // If the dictionary doesn't contain the dictionary of the game, then initialize it
-                                Dictionary<string, PresetConfig> presetConfigDict = new();
-                                if (!LauncherMetadataConfig?.ContainsKey(stamp.GameName) ?? false)
-                                    // Initialize and add the game preset config dictionary
-                                    // ReSharper disable once ConstantConditionalAccessQualifier
-                                    LauncherMetadataConfig?.Add(stamp.GameName, presetConfigDict);
-
-                                // If the game name region collection is not exist, create a new one
-                                if (!LauncherGameNameRegionCollection?.ContainsKey(stamp.GameName) ?? false)
-                                    // ReSharper disable once ConstantConditionalAccessQualifier
-                                    LauncherGameNameRegionCollection?.Add(stamp.GameName, []);
-
-                                // Add the game region name into collection
-                                if (!LauncherGameNameRegionCollection?[stamp.GameName]?.Contains(stamp.GameRegion) ?? false)
-                                    // ReSharper disable once ConstantConditionalAccessQualifier
-                                    LauncherGameNameRegionCollection?[stamp.GameName]?.Add(stamp.GameRegion);
-
-                                // If the game preset config dictionary doesn't have the game region, then add it.
-                                if (!LauncherMetadataConfig?[stamp.GameName]?.ContainsKey(stamp.GameRegion) ?? false)
-                                    // ReSharper disable once ConstantConditionalAccessQualifier
-                                    LauncherMetadataConfig?[stamp.GameName]?.Add(stamp.GameRegion, presetConfig);
-
-                                break;
-                            }
-                            else
+                            if (presetConfig == null)
                             {
                                 throw new InvalidDataException("Config seems to be empty!");
                             }
 
-                            // Ignore if the isCacheUpdateModeOnly is true and the config doesn't support cache update
+                            // Generate HashID and GameName
+                            string hashComposition = $"{stamp.LastUpdated} - {stamp.GameName} - {stamp.GameRegion}";
+                            byte[] hashBytes = Hash.GetHashFromString<Crc32>(hashComposition);
+                            int hashID = BitConverter.ToInt32(hashBytes);
+
+                            presetConfig.HashID = hashID;
+                            presetConfig.GameName = stamp.GameName;
+                            presetConfig.GameLauncherApi ??= presetConfig.LauncherType switch
+                            {
+                                LauncherType.Sophon => LegacyLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
+                                LauncherType.HoYoPlay => HoYoPlayLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
+                                _ => throw new NotSupportedException($"Launcher type: {presetConfig.LauncherType} is not supported!")
+                            };
+
+                            // Dispose the file first
+                            await configLocalStream.DisposeAsync();
+
+                            return presetConfig;
                         }
+                    case MetadataType.Unknown:
+                        throw new NotSupportedException($"Metadata type: {MetadataType.Unknown} is not supported!");
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(stamp), $"Cannot deserialize metadata as the type: {stamp.MetadataType} is unknown");
                 }
             }
             catch (Exception ex)
@@ -498,7 +595,7 @@ namespace CollapseLauncher.Helper.Metadata
                 if (File.Exists(configLocalFilePath))
                     File.Delete(configLocalFilePath);
 
-                await LoadConfigInner(stamp, currentChannel, true, allowDeserializeKey, isCacheUpdateModeOnly);
+                return await LoadAndGetConfig(stamp, currentChannel, true, allowDeserializeKey);
             }
             finally
             {
@@ -511,6 +608,12 @@ namespace CollapseLauncher.Helper.Metadata
                     stamp.LastModifiedTimeUtc = GetFileLastModifiedStampUtc(configLocalFilePath);
                 }
             }
+        }
+
+        private static DateTime GetFileLastModifiedStampUtc(string configLocalFilePath)
+        {
+            FileInfo fileInfo = new FileInfo(configLocalFilePath);
+            return fileInfo.LastWriteTimeUtc;
         }
 
         internal static async ValueTask<bool> IsMetadataHasUpdate()
@@ -736,17 +839,16 @@ namespace CollapseLauncher.Helper.Metadata
             return LauncherGameNameRegionCollection?.Keys.ToList();
         }
 
-        internal static List<string?>? GetGameRegionCollection(string gameName)
+        internal static List<string>? GetGameRegionCollection(string gameName)
         {
-            if (!(!LauncherGameNameRegionCollection?.ContainsKey(gameName) ?? false))
+            if (LauncherGameNameRegionCollection?.TryGetValue(gameName, out List<string>? hashSetRegion) ?? false)
             {
-                return LauncherGameNameRegionCollection?[gameName]!;
+                return hashSetRegion!;
             }
 
-            Logger.LogWriteLine($"Game region collection for name: \"{gameName}\" isn't exist!", LogType.Error,
-                                true);
+            string msg = $"Game region collection for name: \"{gameName}\" isn't exist!";
+            Logger.LogWriteLine(msg, LogType.Error, true);
             return null;
-
         }
 
         internal static int GetPreviousGameRegion(string? gameName)
@@ -756,7 +858,7 @@ namespace CollapseLauncher.Helper.Metadata
             string? gameRegion;
 
             // Get the region collection
-            List<string?>? gameRegionCollection = GetGameRegionCollection(gameName);
+            List<string>? gameRegionCollection = GetGameRegionCollection(gameName);
             gameRegionCollection ??= LauncherGameNameRegionCollection?.FirstOrDefault().Value!;
 
             // Throw if the collection is empty or null
@@ -776,7 +878,7 @@ namespace CollapseLauncher.Helper.Metadata
             // Get the last region and find the index inside the collection.
             // If not found, then set the region to the first.
             gameRegion = LauncherConfig.GetAppConfigValue(iniKeyName).ToString();
-            int indexOfGameRegion = gameRegionCollection.IndexOf(gameRegion);
+            int indexOfGameRegion = gameRegionCollection.IndexOf(gameRegion!);
             return indexOfGameRegion < 1 ? 0 : indexOfGameRegion;
         }
 

--- a/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
@@ -228,7 +228,6 @@ namespace CollapseLauncher.Helper.Metadata
 
             // Initialize and clear the stamp dictionary
             LauncherMetadataStampDictionary ??= new Dictionary<string, Stamp>();
-
             LauncherMetadataStampDictionary.Clear();
 
             FileStream? stampLocalStream = null;
@@ -351,6 +350,8 @@ namespace CollapseLauncher.Helper.Metadata
             // Initialize the community tools properties
             PageStatics.CommunityToolsProperty ??= new CommunityToolsProperty();
             PageStatics.CommunityToolsProperty.Clear();
+            PageStatics.CommunityToolsProperty.OfficialToolsDictionary?.Clear();
+            PageStatics.CommunityToolsProperty.CommunityToolsDictionary?.Clear();
 
             #region Master Key Loading
             // Load master key config
@@ -471,12 +472,12 @@ namespace CollapseLauncher.Helper.Metadata
 
                 foreach (KeyValuePair<GameNameType, List<CommunityToolsEntry>> entry in communityToolsProperty.OfficialToolsDictionary ?? [])
                 {
-                    PageStatics.CommunityToolsProperty.OfficialToolsDictionary?.Add(entry.Key, entry.Value);
+                    PageStatics.CommunityToolsProperty.OfficialToolsDictionary?.TryAdd(entry.Key, entry.Value);
                 }
 
                 foreach (KeyValuePair<GameNameType, List<CommunityToolsEntry>> entry in communityToolsProperty.CommunityToolsDictionary ?? [])
                 {
-                    PageStatics.CommunityToolsProperty.CommunityToolsDictionary?.Add(entry.Key, entry.Value);
+                    PageStatics.CommunityToolsProperty.CommunityToolsDictionary?.TryAdd(entry.Key, entry.Value);
                 }
             }
             #endregion

--- a/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/LauncherMetadataHelper.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 using CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using CollapseLauncher.Helper.Loading;
 using CollapseLauncher.Statics;
 using Hi3Helper;
@@ -435,7 +435,7 @@ namespace CollapseLauncher.Helper.Metadata
                                 presetConfig.GameName = stamp.GameName;
                                 presetConfig.GameLauncherApi ??= presetConfig.LauncherType switch
                                 {
-                                    LauncherType.Sophon => SophonLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
+                                    LauncherType.Sophon => LegacyLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
                                     LauncherType.HoYoPlay => HoYoPlayLauncherApiLoader.CreateApiInstance(presetConfig, stamp.GameName, stamp.GameRegion),
                                     _ => throw new NotSupportedException($"Launcher type: {presetConfig.LauncherType} is not supported!")
                                 };

--- a/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
@@ -25,6 +25,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable SwitchStatementMissingSomeEnumCasesNoDefault
 // ReSharper disable StringLiteralTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.Metadata

--- a/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
@@ -90,70 +90,74 @@ namespace CollapseLauncher.Helper.Metadata
         [JsonConverter(typeof(ServeV3StringConverter))]
         public string? SdkUrl { get; set; }
 
-        public async ValueTask EnsureReassociated(HttpClient client, string? branchUrl, string bizName, CancellationToken token)
+        public Task EnsureReassociated(HttpClient client, string? branchUrl, string bizName, CancellationToken token)
         {
             if (IsReassociated)
-                return;
+                return Task.CompletedTask;
 
             if (string.IsNullOrEmpty(branchUrl))
-                return;
+                return Task.CompletedTask;
 
             // Fetch branch info
-            ActionTimeoutValueTaskCallback<HoYoPlayLauncherGameInfo?> hypLauncherBranchCallback =
-                async innerToken =>
-                    await FallbackCDNUtil.DownloadAsJSONType(
-                        branchUrl,
-                        HoYoPlayLauncherGameInfoJsonContext.Default.HoYoPlayLauncherGameInfo,
-                        innerToken);
+            ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherGameInfo?> hypLauncherBranchCallback =
+                innerToken =>
+                    FallbackCDNUtil.DownloadAsJSONType(branchUrl,
+                                                       HoYoPlayLauncherGameInfoJsonContext.Default.HoYoPlayLauncherGameInfo,
+                                                       innerToken)
+                                   .ConfigureAwait(false);
 
-            HoYoPlayLauncherGameInfo? hypLauncherBranchInfo = await hypLauncherBranchCallback.WaitForRetryAsync(
-                LauncherApiBase.ExecutionTimeout,
-                LauncherApiBase.ExecutionTimeoutStep,
-                LauncherApiBase.ExecutionTimeoutAttempt,
-                null, token);
+            return hypLauncherBranchCallback
+                .WaitForRetryAsync(LauncherApiBase.ExecutionTimeout,
+                                   LauncherApiBase.ExecutionTimeoutStep,
+                                   LauncherApiBase.ExecutionTimeoutAttempt,
+                                   null, token)
+                .ContinueWith(async result =>
+                {
+                    HoYoPlayLauncherGameInfo? hypLauncherBranchInfo = await result;
 
-            // If branch info is null or empty, return
-            HoYoPlayGameInfoBranch? branch = hypLauncherBranchInfo?
-                .GameInfoData?
-                .GameBranchesInfo?
-                .FirstOrDefault(x => x.GameInfo?.BizName?.Equals(bizName) ?? false);
-            if (branch == null)
-                return;
+                    // If branch info is null or empty, return
+                    HoYoPlayGameInfoBranch? branch = hypLauncherBranchInfo?
+                       .GameInfoData?
+                       .GameBranchesInfo?
+                       .FirstOrDefault(x => x.GameInfo?.BizName?.Equals(bizName) ?? false);
+                    if (branch == null)
+                        return;
 
-            // Re-associate url if main field is exist
-            if (branch.GameMainField != null)
-            {
-                ArgumentException.ThrowIfNullOrEmpty(branch.GameMainField.PackageId);
-                ArgumentException.ThrowIfNullOrEmpty(branch.GameMainField.Password);
+                    // Re-associate url if main field is exist
+                    if (branch.GameMainField != null)
+                    {
+                        ArgumentException.ThrowIfNullOrEmpty(branch.GameMainField.PackageId);
+                        ArgumentException.ThrowIfNullOrEmpty(branch.GameMainField.Password);
 
-                string packageIdValue = branch.GameMainField.PackageId;
-                string passwordValue = branch.GameMainField.Password;
+                        string packageIdValue = branch.GameMainField.PackageId;
+                        string passwordValue = branch.GameMainField.Password;
 
-                MainUrl = MainUrl.AssociateGameAndLauncherId(
-                    QueryPasswordHead,
-                    QueryPackageIdHead,
-                    passwordValue,
-                    packageIdValue);
-            }
+                        MainUrl = MainUrl.AssociateGameAndLauncherId(
+                         QueryPasswordHead,
+                         QueryPackageIdHead,
+                         passwordValue,
+                         packageIdValue);
+                    }
 
-            // Re-associate url if preload field is exist
-            if (branch.GamePreloadField != null)
-            {
-                ArgumentException.ThrowIfNullOrEmpty(branch.GamePreloadField.PackageId);
-                ArgumentException.ThrowIfNullOrEmpty(branch.GamePreloadField.Password);
+                    // Re-associate url if preload field is exist
+                    if (branch.GamePreloadField != null)
+                    {
+                        ArgumentException.ThrowIfNullOrEmpty(branch.GamePreloadField.PackageId);
+                        ArgumentException.ThrowIfNullOrEmpty(branch.GamePreloadField.Password);
 
-                string packageIdValue = branch.GamePreloadField.PackageId;
-                string passwordValue = branch.GamePreloadField.Password;
+                        string packageIdValue = branch.GamePreloadField.PackageId;
+                        string passwordValue = branch.GamePreloadField.Password;
 
-                PreloadUrl = PreloadUrl.AssociateGameAndLauncherId(
-                    QueryPasswordHead,
-                    QueryPackageIdHead,
-                    passwordValue,
-                    packageIdValue);
-            }
+                        PreloadUrl = PreloadUrl.AssociateGameAndLauncherId(
+                         QueryPasswordHead,
+                         QueryPackageIdHead,
+                         passwordValue,
+                         packageIdValue);
+                    }
 
-            // Mark as re-associated
-            IsReassociated = true;
+                    // Mark as re-associated
+                    IsReassociated = true;
+                }, token);
         }
     }
 

--- a/CollapseLauncher/Classes/Helper/Metadata/Stamp.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/Stamp.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.Metadata

--- a/CollapseLauncher/Classes/Helper/StreamUtility/StreamExtension.cs
+++ b/CollapseLauncher/Classes/Helper/StreamUtility/StreamExtension.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Helper.StreamUtility
@@ -18,13 +19,6 @@ namespace CollapseLauncher.Helper.StreamUtility
             Mode = FileMode.Open,
             Access = FileAccess.Read,
             Share = FileShare.Read
-        };
-
-        internal static readonly FileStreamOptions FileStreamCreateWriteOpt = new()
-        {
-            Mode = FileMode.Create,
-            Access = FileAccess.Write,
-            Share = FileShare.Write
         };
 
         internal static readonly FileStreamOptions FileStreamCreateReadWriteOpt = new()

--- a/CollapseLauncher/Classes/Helper/Update/LauncherUpdateHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Update/LauncherUpdateHelper.cs
@@ -14,6 +14,7 @@ using Squirrel.Sources;
 using Velopack;
 using Velopack.Locators;
 using Velopack.Sources;
+// ReSharper disable UnusedMember.Global
 #endif
 
 // ReSharper disable StringLiteralTypo

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -30,6 +30,11 @@ using Windows.UI;
 using WinRT.Interop;
 using Size = System.Drawing.Size;
 using WindowId = Microsoft.UI.WindowId;
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+// ReSharper disable CommentTypo
+// ReSharper disable GrammarMistakeInComment
+// ReSharper disable UnusedMember.Global
 
 #pragma warning disable CA2012
 namespace CollapseLauncher.Helper
@@ -468,7 +473,7 @@ namespace CollapseLauncher.Helper
                             case SC_MAXIMIZE:
                                 {
                                     // TODO: Apply to force disable the "double-click to maximize" feature.
-                                    //       The feature should expected to be disabled while m_presenter.IsResizable and IsMaximizable
+                                    //       The feature should expect to be disabled while m_presenter.IsResizable and IsMaximizable
                                     //       set to false. But the feature is still not respecting the changes in WindowsAppSDK 1.4.
                                     //
                                     //       Issues have been described here:
@@ -476,7 +481,7 @@ namespace CollapseLauncher.Helper
                                     //       https://github.com/microsoft/microsoft-ui-xaml/issues/8783
 
                                     // Ignore WM_SYSCOMMAND SC_MAXIMIZE message
-                                    // Thank you Microsoft :)
+                                    // Thank you, Microsoft :)
                                     return 0;
                                 }
                             case SC_MINIMIZE:

--- a/CollapseLauncher/Classes/InstallManagement/Base/HDiffMap.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/HDiffMap.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.InstallManagement.Base

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.PkgVersion.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.PkgVersion.cs
@@ -28,6 +28,7 @@ using static Hi3Helper.Logger;
 // ReSharper disable ArrangeObjectCreationWhenTypeEvident
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.InstallManager.Base

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
@@ -170,8 +170,7 @@ namespace CollapseLauncher.InstallManager.Base
                     {
                         await GameVersionManager.GamePreset
                                                  .LauncherResourceChunksURL
-                                                 .EnsureReassociated(
-                                                                     httpClient,
+                                                 .EnsureReassociated(httpClient,
                                                                      branchUrl,
                                                                      GameVersionManager.GamePreset.LauncherBizName,
                                                                      Token.Token);
@@ -558,8 +557,7 @@ namespace CollapseLauncher.InstallManager.Base
                     {
                         await GameVersionManager.GamePreset
                                                  .LauncherResourceChunksURL
-                                                 .EnsureReassociated(
-                                                                     httpClient,
+                                                 .EnsureReassociated(httpClient,
                                                                      branchUrl,
                                                                      GameVersionManager.GamePreset.LauncherBizName,
                                                                      Token.Token);

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.cs
@@ -2752,8 +2752,7 @@ namespace CollapseLauncher.InstallManager.Base
                 {
                     // If primary button is clicked, then set folder with the default path
                     case ContentDialogResult.Primary:
-                        if (GameVersionManager.GamePreset.ProfileName != null &&
-                            GameVersionManager.GamePreset.GameDirectoryName != null)
+                        if (GameVersionManager.GamePreset is { ProfileName: not null, GameDirectoryName: not null })
                         {
                             folder = Path.Combine(LauncherConfig.AppGameFolder,
                                                   GameVersionManager.GamePreset.ProfileName,

--- a/CollapseLauncher/Classes/Interfaces/Class/CacheAsset.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/CacheAsset.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 // ReSharper disable InconsistentNaming
 // ReSharper disable CommentTypo
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher.Interfaces
 {

--- a/CollapseLauncher/Classes/Interfaces/Class/Enums.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/Enums.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 namespace CollapseLauncher
 {
     internal enum RepairAssetType

--- a/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
@@ -36,21 +36,17 @@ namespace CollapseLauncher.Interfaces
             : this(parentUI, gameVersionManager, null, gamePath, gameRepoURL, versionOverride) { }
 #nullable restore
 
-        protected const int BufferLength = 4 << 10; // 4 KiB
-        protected const int BufferMediumLength = 1 << 20; // 1 MiB
-        protected const int BufferBigLength = 2 << 20; // 2 MiB
-        protected const int SizeForMultiDownload = 10 << 20;
-        protected const int DownloadThreadCountReserved = 16;
-        protected const double DownloadThreadCountReservedMultiplication = 1.5d;
+        protected const   int    BufferMediumLength                        = 1 << 20; // 1 MiB
+        protected const   int    BufferBigLength                           = 2 << 20; // 2 MiB
+        protected const   double DownloadThreadCountReservedMultiplication = 1.5d;
         protected virtual string UserAgent { get; set; } = "UnityPlayer/2017.4.18f1 (UnityWebRequest/1.0, libcurl/7.51.0-DEV)";
 
-        protected bool IsVersionOverride { get; init; }
-        protected bool IsBurstDownloadEnabled { get => IsBurstDownloadModeEnabled; }
-        protected int DownloadThreadCount { get => AppCurrentDownloadThread; }
-        protected int DownloadThreadWithReservedCount { get => (int)Math.Round(DownloadThreadCount * DownloadThreadCountReservedMultiplication); }
-        protected int ThreadCount { get => (byte)AppCurrentThread; }
-        protected int DownloadThreadCountSqrt { get => (int)Math.Max(Math.Sqrt(DownloadThreadCount), 4); }
-        protected CancellationTokenSourceWrapper Token { get; set; }
+        protected static bool                           IsBurstDownloadEnabled          { get => IsBurstDownloadModeEnabled; }
+        protected static int                            DownloadThreadCount             { get => AppCurrentDownloadThread; }
+        protected static int                            DownloadThreadWithReservedCount { get => (int)Math.Round(DownloadThreadCount * DownloadThreadCountReservedMultiplication); }
+        protected static int                            ThreadCount                     { get => (byte)AppCurrentThread; }
+        protected        bool                           IsVersionOverride               { get; init; }
+        protected        CancellationTokenSourceWrapper Token                           { get; set; }
         protected GameVersion GameVersion
         {
             get

--- a/CollapseLauncher/Classes/Interfaces/Class/JSONSerializerHelper.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/JSONSerializerHelper.cs
@@ -6,6 +6,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher

--- a/CollapseLauncher/Classes/Interfaces/Class/JSONSerializerHelperAsync.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/JSONSerializerHelperAsync.cs
@@ -12,10 +12,10 @@ namespace CollapseLauncher
 {
     internal static partial class JsonSerializerHelper
     {
-        internal static async ValueTask<T?> DeserializeAsync<T>(this Stream data, JsonTypeInfo<T?> typeInfo, T? defaultType = null, CancellationToken token = default)
+        internal static async Task<T?> DeserializeAsync<T>(this Stream data, JsonTypeInfo<T?> typeInfo, T? defaultType = null, CancellationToken token = default)
             where T : class => await InnerDeserializeStreamAsync(data, typeInfo, defaultType, token);
 
-        internal static async ValueTask<T?> DeserializeAsync<T>(this Stream data, JsonTypeInfo<T?> typeInfo, T? defaultType = null, CancellationToken token = default)
+        internal static async Task<T?> DeserializeAsync<T>(this Stream data, JsonTypeInfo<T?> typeInfo, T? defaultType = null, CancellationToken token = default)
             where T : struct => await InnerDeserializeStreamAsync(data, typeInfo, defaultType, token);
 
         internal static async Task<JsonNode?> DeserializeAsNodeAsync(this Stream data, CancellationToken token = default)
@@ -40,7 +40,7 @@ namespace CollapseLauncher
             return listItem;
         }
 
-        private static async ValueTask<T?> InnerDeserializeStreamAsync<T>(Stream data, JsonTypeInfo<T?> typeInfo, T? defaultType, CancellationToken token) =>
+        private static async Task<T?> InnerDeserializeStreamAsync<T>(Stream data, JsonTypeInfo<T?> typeInfo, T? defaultType, CancellationToken token) =>
         // Check if the data cannot be read, then throw
         !data.CanRead ? throw new NotSupportedException("Stream is not readable! Cannot deserialize the stream to JSON!") :
         // Try to deserialize. If it returns a null, then return the default value
@@ -52,13 +52,13 @@ namespace CollapseLauncher
         // Try deserialize to JSON Node
             await JsonNode.ParseAsync(data, JsonNodeOptions, JsonDocumentOptions, token);
 
-        internal static async ValueTask SerializeAsync<T>(this T? value, Stream targetStream, JsonTypeInfo<T?> typeInfo, CancellationToken token = default)
+        internal static async Task SerializeAsync<T>(this T? value, Stream targetStream, JsonTypeInfo<T?> typeInfo, CancellationToken token = default)
             where T : class => await InnerSerializeStreamAsync(value, targetStream, typeInfo, token);
 
-        internal static async ValueTask SerializeAsync<T>(this T? value, Stream targetStream, JsonTypeInfo<T?> typeInfo, CancellationToken token = default)
+        internal static async Task SerializeAsync<T>(this T? value, Stream targetStream, JsonTypeInfo<T?> typeInfo, CancellationToken token = default)
             where T : struct => await InnerSerializeStreamAsync(value, targetStream, typeInfo, token);
 
-        private static async ValueTask InnerSerializeStreamAsync<T>(this T? value, Stream targetStream, JsonTypeInfo<T?> typeInfo, CancellationToken token)
+        private static async Task InnerSerializeStreamAsync<T>(this T? value, Stream targetStream, JsonTypeInfo<T?> typeInfo, CancellationToken token)
         {
             if (!targetStream.CanWrite)
                 throw new NotSupportedException("Stream is not writeable! Cannot serialize the object into Stream!");

--- a/CollapseLauncher/Classes/Interfaces/Class/JSONSerializerHelperAsync.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/JSONSerializerHelperAsync.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -1020,10 +1020,11 @@ namespace CollapseLauncher.Interfaces
             bool              updateTotalProgress = true,
             CancellationToken token               = default)
             where T : HashAlgorithm =>
-            Hash.GetCryptoHashAsync<T>(filePath,
-                                       hmacKey,
-                                       read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
-                                       token);
+            GetCryptoHashAsync<T>(new FileInfo(filePath),
+                                  hmacKey,
+                                  updateProgress,
+                                  updateTotalProgress,
+                                  token);
 
         protected virtual ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
             FileInfo          fileInfo,
@@ -1035,6 +1036,7 @@ namespace CollapseLauncher.Interfaces
             Hash.GetCryptoHashAsync<T>(fileInfo,
                                        hmacKey,
                                        read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
+                                       fileInfo is { Exists: true, Length: > 100 << 20 },
                                        token);
 
         protected virtual ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
@@ -1047,6 +1049,7 @@ namespace CollapseLauncher.Interfaces
             Hash.GetCryptoHashAsync<T>(stream,
                                        hmacKey,
                                        read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
+                                       stream is { Length: > 100 << 20 },
                                        token);
 
         protected virtual byte[] GetCryptoHash<T>(
@@ -1091,9 +1094,10 @@ namespace CollapseLauncher.Interfaces
             bool              updateTotalProgress = true,
             CancellationToken token               = default)
             where T : NonCryptographicHashAlgorithm, new() =>
-            Hash.GetHashAsync<T>(filePath,
-                                 read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
-                                 token);
+            GetHashAsync<T>(new FileInfo(filePath),
+                            updateProgress,
+                            updateTotalProgress,
+                            token);
 
         protected virtual ConfiguredTaskAwaitable<byte[]> GetHashAsync<T>(
             FileInfo          fileInfo,
@@ -1103,6 +1107,7 @@ namespace CollapseLauncher.Interfaces
             where T : NonCryptographicHashAlgorithm, new() =>
             Hash.GetHashAsync<T>(fileInfo,
                                  read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
+                                 fileInfo is { Exists: true, Length: > 100 << 20 },
                                  token);
 
         protected virtual ConfiguredTaskAwaitable<byte[]> GetHashAsync<T>(
@@ -1113,6 +1118,7 @@ namespace CollapseLauncher.Interfaces
             where T : NonCryptographicHashAlgorithm, new() =>
             Hash.GetHashAsync<T>(stream,
                                  read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
+                                 stream is { Length: > 100 << 20 },
                                  token);
 
         protected virtual byte[] GetHash<T>(

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -34,6 +34,7 @@ using static Hi3Helper.Logger;
 using CollapseUIExtension = CollapseLauncher.Extension.UIElementExtensions;
 // ReSharper disable InconsistentlySynchronizedField
 // ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
 
 #nullable enable
 namespace CollapseLauncher.Interfaces

--- a/CollapseLauncher/Classes/Interfaces/Class/Structs.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/Structs.cs
@@ -6,6 +6,7 @@ using System.IO;
 // ReSharper disable CheckNamespace
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/Classes/Interfaces/IGameSettings.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+// ReSharper disable UnusedMemberInSuper.Global
 
 #nullable enable
 namespace CollapseLauncher.Interfaces

--- a/CollapseLauncher/Classes/Interfaces/IGameSettingsValue.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameSettingsValue.cs
@@ -1,6 +1,7 @@
 ﻿using CollapseLauncher.GameSettings.Base;
 using System.Diagnostics;
 using System.Text.Json.Serialization.Metadata;
+// ReSharper disable UnusedMemberInSuper.Global
 
 namespace CollapseLauncher.Interfaces
 {

--- a/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 // ReSharper disable CommentTypo
 // ReSharper disable GrammarMistakeInComment
 // ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedMemberInSuper.Global
 
 #nullable enable
 namespace CollapseLauncher.Interfaces

--- a/CollapseLauncher/Classes/Properties/AppActivation.cs
+++ b/CollapseLauncher/Classes/Properties/AppActivation.cs
@@ -9,6 +9,7 @@ using Windows.ApplicationModel.Activation;
 using static CollapseLauncher.InnerLauncherConfig;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
+// ReSharper disable GrammarMistakeInComment
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -8,6 +8,7 @@ using static CollapseLauncher.InnerLauncherConfig;
 using static Hi3Helper.Logger;
 // ReSharper disable StringLiteralTypo
 // ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/Classes/Properties/WindowSizeProp/WindowSizeProp.cs
+++ b/CollapseLauncher/Classes/Properties/WindowSizeProp/WindowSizeProp.cs
@@ -27,52 +27,52 @@ namespace CollapseLauncher.WindowSize
                 "Normal",
                 new WindowSizeProp
                 {
-                    WindowBounds                  = new Size(1280, 720),
-                    PostEventPanelScaleFactor     = 1.35f,
-                    SidePanel1Width               = new GridLength(340, GridUnitType.Pixel),
-                    EventPostCarouselBounds       = new Size(340,  158),
-                    PostPanelBounds               = new Size(340,  84),
-                    PostPanelBottomMargin         = new Thickness(0, 0, 0, 20),
-                    PostPanelPaimonHeight         = 110,
-                    PostPanelPaimonMargin         = new Thickness(0, -48, -56, 0),
-                    PostPanelPaimonInnerMargin    = new Thickness(0, 0,   0,   0),
-                    PostPanelPaimonTextMargin     = new Thickness(0, 0,   0,   18),
-                    PostPanelPaimonTextSize       = 11,
-                    BannerIconWidth               = 136,
-                    BannerIconWidthHYP            = 111,
-                    BannerIconMargin              = new Thickness(0, 0, 94, 84),
-                    BannerIconMarginHYP           = new Thickness(48, 252, 0, 0),
-                    BannerIconAlignHorizontal     = HorizontalAlignment.Right,
-                    BannerIconAlignHorizontalHYP  = HorizontalAlignment.Left,
-                    BannerIconAlignVertical       = VerticalAlignment.Bottom,
-                    BannerIconAlignVerticalHYP    = VerticalAlignment.Top,
-                    SettingsPanelWidth            = 676
+                    WindowBounds                 = new Size(1280, 720),
+                    PostEventPanelScaleFactor    = 1.35f,
+                    SidePanel1Width              = new GridLength(340, GridUnitType.Pixel),
+                    EventPostCarouselBounds      = new Size(340, 158),
+                    PostPanelBounds              = new Size(340, 84),
+                    PostPanelBottomMargin        = new Thickness(0, 0, 0, 20),
+                    PostPanelPaimonHeight        = 110,
+                    PostPanelPaimonMargin        = new Thickness(0, -48, -56, 0),
+                    PostPanelPaimonInnerMargin   = new Thickness(0, 0,   0,   0),
+                    PostPanelPaimonTextMargin    = new Thickness(0, 0,   0,   18),
+                    PostPanelPaimonTextSize      = 11,
+                    BannerIconHeight             = 40,
+                    BannerIconHeightHYP          = 40,
+                    BannerIconMargin             = new Thickness(0,  0,   94, 84),
+                    BannerIconMarginHYP          = new Thickness(48, 244, 0,  0),
+                    BannerIconAlignHorizontal    = HorizontalAlignment.Right,
+                    BannerIconAlignHorizontalHYP = HorizontalAlignment.Left,
+                    BannerIconAlignVertical      = VerticalAlignment.Bottom,
+                    BannerIconAlignVerticalHYP   = VerticalAlignment.Top,
+                    SettingsPanelWidth           = 676
                 }
             },
             {
                 "Small",
                 new WindowSizeProp
                 {
-                    WindowBounds                  = new Size(1024, 576),
-                    PostEventPanelScaleFactor     = 1.25f,
-                    SidePanel1Width               = new GridLength(280, GridUnitType.Pixel),
-                    EventPostCarouselBounds       = new Size(280,  130),
-                    PostPanelBounds               = new Size(280,  82),
-                    PostPanelBottomMargin         = new Thickness(0, 0, 0, 12),
-                    PostPanelPaimonHeight         = 110,
-                    PostPanelPaimonMargin         = new Thickness(0, -48, -56, 0),
-                    PostPanelPaimonInnerMargin    = new Thickness(0, 0,   0,   0),
-                    PostPanelPaimonTextMargin     = new Thickness(0, 0,   0,   18),
-                    PostPanelPaimonTextSize       = 11,
-                    BannerIconWidth               = 100,
-                    BannerIconWidthHYP            = 86,
-                    BannerIconMargin              = new Thickness(0, 0, 70, 52),
-                    BannerIconMarginHYP           = new Thickness(22, 186, 0, 0),
-                    BannerIconAlignHorizontal     = HorizontalAlignment.Right,
-                    BannerIconAlignHorizontalHYP  = HorizontalAlignment.Left,
-                    BannerIconAlignVertical       = VerticalAlignment.Bottom,
-                    BannerIconAlignVerticalHYP    = VerticalAlignment.Top,
-                    SettingsPanelWidth            = 464
+                    WindowBounds                 = new Size(1024, 576),
+                    PostEventPanelScaleFactor    = 1.25f,
+                    SidePanel1Width              = new GridLength(280, GridUnitType.Pixel),
+                    EventPostCarouselBounds      = new Size(280, 130),
+                    PostPanelBounds              = new Size(280, 82),
+                    PostPanelBottomMargin        = new Thickness(0, 0, 0, 12),
+                    PostPanelPaimonHeight        = 110,
+                    PostPanelPaimonMargin        = new Thickness(0, -48, -56, 0),
+                    PostPanelPaimonInnerMargin   = new Thickness(0, 0,   0,   0),
+                    PostPanelPaimonTextMargin    = new Thickness(0, 0,   0,   18),
+                    PostPanelPaimonTextSize      = 11,
+                    BannerIconHeight             = 32,
+                    BannerIconHeightHYP          = 32,
+                    BannerIconMargin             = new Thickness(0,  0,   70, 52),
+                    BannerIconMarginHYP          = new Thickness(22, 184, 0,  0),
+                    BannerIconAlignHorizontal    = HorizontalAlignment.Right,
+                    BannerIconAlignHorizontalHYP = HorizontalAlignment.Left,
+                    BannerIconAlignVertical      = VerticalAlignment.Bottom,
+                    BannerIconAlignVerticalHYP   = VerticalAlignment.Top,
+                    SettingsPanelWidth           = 464
                 }
             }
         };
@@ -107,8 +107,8 @@ namespace CollapseLauncher.WindowSize
         public Thickness           PostPanelPaimonMargin        { get; set; }
         public Thickness           PostPanelPaimonInnerMargin   { get; set; }
         public Thickness           PostPanelPaimonTextMargin    { get; set; }
-        public int                 BannerIconWidth              { get; set; }
-        public int                 BannerIconWidthHYP           { get; set; }
+        public int                 BannerIconHeight             { get; set; }
+        public int                 BannerIconHeightHYP          { get; set; }
         public Thickness           BannerIconMargin             { get; set; }
         public Thickness           BannerIconMarginHYP          { get; set; }
         public HorizontalAlignment BannerIconAlignHorizontal    { get; set; }

--- a/CollapseLauncher/Classes/RegionManagement/FallbackCDNUtil.cs
+++ b/CollapseLauncher/Classes/RegionManagement/FallbackCDNUtil.cs
@@ -302,8 +302,8 @@ namespace CollapseLauncher
         private static void PerformStreamCheckAndSeek(Stream outputStream)
         {
             // Throw if output stream can't write and seek
-            if (!outputStream.CanWrite) throw new ArgumentException("outputStream must be writable!", "outputStream");
-            if (!outputStream.CanSeek) throw new ArgumentException("outputStream must be seekable!", "outputStream");
+            if (!outputStream.CanWrite) throw new ArgumentException("outputStream must be writable!", nameof(outputStream));
+            if (!outputStream.CanSeek) throw new ArgumentException("outputStream must be seekable!", nameof(outputStream));
 
             // Reset the outputStream position
             outputStream.Position = 0;

--- a/CollapseLauncher/Classes/RegistryMonitor/RegistryMonitor.cs
+++ b/CollapseLauncher/Classes/RegistryMonitor/RegistryMonitor.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using static Hi3Helper.Logger;
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable StringLiteralTypo
+// ReSharper disable UnusedMember.Global
 
 namespace RegistryUtils
 {

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/GenshinRepair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/GenshinRepair.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using static Hi3Helper.Data.ConverterTool;
 using static Hi3Helper.Locale;
 // ReSharper disable IdentifierTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -544,7 +544,7 @@ namespace CollapseLauncher
         {
             // Build the list of existing files inside the game folder
             // for comparison with asset index into catalog list
-            HashSet<string> catalog = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> catalog = new(StringComparer.OrdinalIgnoreCase);
             BuildAssetIndexCatalog(catalog, assetIndex);
 
             // Compare the catalog list with asset index and add it to target asset index
@@ -617,8 +617,8 @@ namespace CollapseLauncher
                 ".dll"
                 ], StringComparison.OrdinalIgnoreCase);
 
-            List<Regex> matchIgnoredFilesRegex = new List<Regex>();
-            string ignoredFilesPath = Path.Combine(GamePath, "@IgnoredFiles");
+            List<Regex> matchIgnoredFilesRegex = [];
+            string      ignoredFilesPath       = Path.Combine(GamePath, "@IgnoredFiles");
             if (File.Exists(ignoredFilesPath))
             {
                 try

--- a/CollapseLauncher/Classes/RepairManagement/StarRail/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/StarRail/Fetch.cs
@@ -418,7 +418,7 @@ namespace CollapseLauncher
                     if (nameDef.Length > 1)
                     {
                         // Compare if the first name definition is equal to target langName.
-                        // Also return if the file is an audio language file if it is a SFX file or not.
+                        // Also return if the file is an audio language file if it is SFX file or not.
                         return langNames.Contains(nameDef[0], StringComparer.OrdinalIgnoreCase) || nameDef[0] == "SFX";
                     }
                     // If it's not in criteria of name definition, then return true as "normal asset"

--- a/CollapseLauncher/Classes/RepairManagement/Zenless/ZenlessResManifest.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Zenless/ZenlessResManifest.cs
@@ -1,6 +1,7 @@
 ﻿using Hi3Helper.EncTool.Parser.Sleepy.JsonConverters;
 using System.Text.Json.Serialization;
 // ReSharper disable CommentTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -16,7 +16,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2024 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.82.15</Version>
+        <Version>1.82.16</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>
@@ -162,12 +162,12 @@
 
         <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241112-preview1" />
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241112-preview1" />
-        <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.241112-preview1" />
-        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.241112-preview1" />
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.241112-preview1" />
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.241112-preview1" />
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2" />
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250129-preview2" />
+        <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.250129-preview2" />
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250129-preview2" />
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2" />
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250129-preview2" />
         
         <!--
         Only include FFmpegInteropX NuGet if USEFFMPEGFORVIDEOBG is defined in constants.
@@ -184,7 +184,7 @@
         <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
-        <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0-preview2" />
+        <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
         <PackageReference Include="PhotoSauce.NativeCodecs.Libwebp" Version="*-*" />
         <PackageReference Include="Roman-Numerals" Version="2.0.1" />

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -131,8 +131,7 @@ namespace CollapseLauncher
                                            IsPreview ? "Preview" : "Stable"), LogType.Scheme, true);
 
             #pragma warning disable CS0618 // Type or member is obsolete
-                LogWriteLine(
-                             $"Runtime: {RuntimeInformation.FrameworkDescription} - WindowsAppSDK {WindowsAppSdkVersion}",
+                LogWriteLine($"Runtime: {RuntimeInformation.FrameworkDescription} - WindowsAppSDK {WindowsAppSdkVersion}",
                              LogType.Scheme, true);
                 LogWriteLine($"Built from repo {ThisAssembly.Git.RepositoryUrl}\r\n\t" +
                              $"Branch {ThisAssembly.Git.Branch} - Commit {ThisAssembly.Git.Commit} at {ThisAssembly.Git.CommitDate}",
@@ -145,7 +144,6 @@ namespace CollapseLauncher
 
                 // Initiate InnoSetupHelper's log event
                 InnoSetupLogUpdate.LoggerEvent += InnoSetupLogUpdate_LoggerEvent;
-
                 HttpLogInvoker.DownloadLog += HttpClientLogWatcher!;
 
                 switch (m_appMode)
@@ -188,8 +186,8 @@ namespace CollapseLauncher
             #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 // Reason: These are methods that either has its own error handling and/or not that important,
                 // so the execution could continue without anything to worry about **technically**
-                InitDatabaseHandler();
-                CheckRuntimeFeatures();
+                _ = InitDatabaseHandler();
+                _ = CheckRuntimeFeatures();
             #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                 AppDomain.CurrentDomain.ProcessExit += OnProcessExit!;

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -35,6 +35,7 @@ using static Hi3Helper.Shared.Region.LauncherConfig;
 // ReSharper disable CommentTypo
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher
 {

--- a/CollapseLauncher/Properties/Resources.resx
+++ b/CollapseLauncher/Properties/Resources.resx
@@ -6,7 +6,7 @@
     Version 2.0
     
     The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
+    that is mostly human-readable. The generation and parsing of the 
     various data types are done through the TypeConverter classes 
     associated with the data types.
     

--- a/CollapseLauncher/XAMLs/MainApp/DisconnectedPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/DisconnectedPage.xaml.cs
@@ -40,15 +40,15 @@ namespace CollapseLauncher
 #nullable enable
             string? gameName = LauncherConfig.GetAppConfigValue("GameCategory");
 
-            List<string>? gameCollection = LauncherMetadataHelper.GetGameNameCollection()!;
-            List<string?>? regionCollection = LauncherMetadataHelper.GetGameRegionCollection(gameName ?? "");
+            List<string>? gameCollection   = LauncherMetadataHelper.GetGameNameCollection();
+            List<string>? regionCollection = LauncherMetadataHelper.GetGameRegionCollection(gameName ?? "");
 
             if (regionCollection == null)
                 gameName = LauncherMetadataHelper.LauncherGameNameRegionCollection?.Keys.FirstOrDefault();
 
             ComboBoxGameRegion.ItemsSource = InnerLauncherConfig.BuildGameRegionListUI(gameName);
 
-            var indexCategory = gameCollection.IndexOf(gameName!);
+            var indexCategory = gameCollection?.IndexOf(gameName!) ?? -1;
             if (indexCategory < 0) indexCategory = 0;
 
             var indexRegion = LauncherMetadataHelper.GetPreviousGameRegion(gameName);

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -542,7 +542,7 @@ namespace CollapseLauncher
             }
         }
 
-        internal async void ChangeBackgroundImageAsRegionAsync(bool ShowLoadingMsg = false)
+        internal async Task ChangeBackgroundImageAsRegionAsync(bool ShowLoadingMsg = false)
         {
             var gameLauncherApi = LauncherMetadataHelper.CurrentMetadataConfig?.GameLauncherApi;
             if (gameLauncherApi == null)
@@ -1335,109 +1335,112 @@ namespace CollapseLauncher
         #region Navigation
         private void InitializeNavigationItems(bool ResetSelection = true)
         {
-            NavigationViewControl.IsSettingsVisible = true;
-            NavigationViewControl.MenuItems.Clear();
-            NavigationViewControl.FooterMenuItems.Clear();
-
-            IGameVersion CurrentGameVersionCheck = GetCurrentGameProperty().GameVersion;
-
-            FontIcon IconLauncher = new FontIcon { Glyph = "" };
-            FontIcon IconRepair = new FontIcon { Glyph = "" };
-            FontIcon IconCaches = new FontIcon { Glyph = m_isWindows11 ? "" : "" };
-            FontIcon IconGameSettings = new FontIcon { Glyph = "" };
-            FontIcon IconAppSettings = new FontIcon { Glyph = "" };
-
-            if (m_appMode == AppMode.Hi3CacheUpdater)
+            DispatcherQueue.TryEnqueue(() =>
             {
+                NavigationViewControl.IsSettingsVisible = true;
+                NavigationViewControl.MenuItems.Clear();
+                NavigationViewControl.FooterMenuItems.Clear();
+
+                IGameVersion CurrentGameVersionCheck = GetCurrentGameProperty().GameVersion;
+
+                FontIcon IconLauncher = new FontIcon { Glyph = "" };
+                FontIcon IconRepair = new FontIcon { Glyph = "" };
+                FontIcon IconCaches = new FontIcon { Glyph = m_isWindows11 ? "" : "" };
+                FontIcon IconGameSettings = new FontIcon { Glyph = "" };
+                FontIcon IconAppSettings = new FontIcon { Glyph = "" };
+
+                if (m_appMode == AppMode.Hi3CacheUpdater)
+                {
+                    if (CurrentGameVersionCheck.GamePreset.IsCacheUpdateEnabled ?? false)
+                    {
+                        NavigationViewControl.MenuItems.Add(new NavigationViewItem
+                        { Icon = IconCaches, Tag = "caches" }
+                        .BindNavigationViewItemText("_CachesPage", "PageTitle"));
+                    }
+                    return;
+                }
+
+                NavigationViewControl.MenuItems.Add(new NavigationViewItem
+                { Icon = IconLauncher, Tag = "launcher" }
+                .BindNavigationViewItemText("_HomePage", "PageTitle"));
+
+                NavigationViewControl.MenuItems.Add(new NavigationViewItemHeader()
+                    .BindNavigationViewItemText("_MainPage", "NavigationUtilities"));
+
+                if (CurrentGameVersionCheck.GamePreset.IsRepairEnabled ?? false)
+                {
+                    NavigationViewControl.MenuItems.Add(new NavigationViewItem
+                    { Icon = IconRepair, Tag = "repair" }
+                    .BindNavigationViewItemText("_GameRepairPage", "PageTitle"));
+                }
+
                 if (CurrentGameVersionCheck.GamePreset.IsCacheUpdateEnabled ?? false)
                 {
                     NavigationViewControl.MenuItems.Add(new NavigationViewItem
-                                                                { Icon = IconCaches, Tag = "caches" }
+                    { Icon = IconCaches, Tag = "caches" }
                     .BindNavigationViewItemText("_CachesPage", "PageTitle"));
                 }
-                return;
-            }
 
-            NavigationViewControl.MenuItems.Add(new NavigationViewItem
-                                                        { Icon = IconLauncher, Tag = "launcher" }
-            .BindNavigationViewItemText("_HomePage", "PageTitle"));
-
-            NavigationViewControl.MenuItems.Add(new NavigationViewItemHeader()
-                .BindNavigationViewItemText("_MainPage", "NavigationUtilities"));
-
-            if (CurrentGameVersionCheck.GamePreset.IsRepairEnabled ?? false)
-            {
-                NavigationViewControl.MenuItems.Add(new NavigationViewItem
-                                                            { Icon = IconRepair, Tag = "repair" }
-                .BindNavigationViewItemText("_GameRepairPage", "PageTitle"));
-            }
-
-            if (CurrentGameVersionCheck.GamePreset.IsCacheUpdateEnabled ?? false)
-            {
-                NavigationViewControl.MenuItems.Add(new NavigationViewItem
-                                                            { Icon = IconCaches, Tag = "caches" }
-                .BindNavigationViewItemText("_CachesPage", "PageTitle"));
-            }
-
-            switch (CurrentGameVersionCheck.GameType)
-            {
-                case GameNameType.Honkai:
-                    NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
-                                                                      { Icon = IconGameSettings, Tag = "honkaigamesettings" }
-                    .BindNavigationViewItemText("_GameSettingsPage", "PageTitle"));
-                    break;
-                case GameNameType.StarRail:
-                    NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
-                                                                      { Icon = IconGameSettings, Tag = "starrailgamesettings" }
-                    .BindNavigationViewItemText("_StarRailGameSettingsPage", "PageTitle"));
-                    break;
-                case GameNameType.Genshin:
-                    NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
-                                                                      { Icon = IconGameSettings, Tag = "genshingamesettings" }
-                    .BindNavigationViewItemText("_GenshinGameSettingsPage", "PageTitle"));
-                    break;
-                case GameNameType.Zenless:
-                    NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
-                                                                      { Icon = IconGameSettings, Tag = "zenlessgamesettings" }
-                    .BindNavigationViewItemText("_GameSettingsPage", "PageTitle"));
-                    break;
-            }
-
-            if (NavigationViewControl.SettingsItem is NavigationViewItem SettingsItem)
-            {
-                SettingsItem.Icon = IconAppSettings;
-                _ = SettingsItem.BindNavigationViewItemText("_SettingsPage", "PageTitle");
-            }
-
-            foreach (var dependency in NavigationViewControl.FindDescendants().OfType<FrameworkElement>())
-            {
-                // Avoid any icons to have shadow attached if it's not from this page
-                if (dependency.BaseUri.AbsolutePath != BaseUri.AbsolutePath)
+                switch (CurrentGameVersionCheck.GameType)
                 {
-                    continue;
-                }
-
-                switch (dependency)
-                {
-                    case FontIcon icon:
-                        AttachShadowNavigationPanelItem(icon);
+                    case GameNameType.Honkai:
+                        NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
+                        { Icon = IconGameSettings, Tag = "honkaigamesettings" }
+                        .BindNavigationViewItemText("_GameSettingsPage", "PageTitle"));
                         break;
-                    case AnimatedIcon animIcon:
-                        AttachShadowNavigationPanelItem(animIcon);
+                    case GameNameType.StarRail:
+                        NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
+                        { Icon = IconGameSettings, Tag = "starrailgamesettings" }
+                        .BindNavigationViewItemText("_StarRailGameSettingsPage", "PageTitle"));
+                        break;
+                    case GameNameType.Genshin:
+                        NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
+                        { Icon = IconGameSettings, Tag = "genshingamesettings" }
+                        .BindNavigationViewItemText("_GenshinGameSettingsPage", "PageTitle"));
+                        break;
+                    case GameNameType.Zenless:
+                        NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
+                        { Icon = IconGameSettings, Tag = "zenlessgamesettings" }
+                        .BindNavigationViewItemText("_GameSettingsPage", "PageTitle"));
                         break;
                 }
-            }
-            AttachShadowNavigationPanelItem(IconAppSettings);
 
-            if (ResetSelection)
-            {
-                NavigationViewControl.SelectedItem = (NavigationViewItem)NavigationViewControl.MenuItems[0];
-            }
+                if (NavigationViewControl.SettingsItem is NavigationViewItem SettingsItem)
+                {
+                    SettingsItem.Icon = IconAppSettings;
+                    _ = SettingsItem.BindNavigationViewItemText("_SettingsPage", "PageTitle");
+                }
 
-            NavigationViewControl.ApplyNavigationViewItemLocaleTextBindings();
+                foreach (var dependency in NavigationViewControl.FindDescendants().OfType<FrameworkElement>())
+                {
+                    // Avoid any icons to have shadow attached if it's not from this page
+                    if (dependency.BaseUri.AbsolutePath != BaseUri.AbsolutePath)
+                    {
+                        continue;
+                    }
 
-            InputSystemCursor handCursor = InputSystemCursor.Create(InputSystemCursorShape.Hand);
-            MainPageGrid.SetAllControlsCursorRecursive(handCursor);
+                    switch (dependency)
+                    {
+                        case FontIcon icon:
+                            AttachShadowNavigationPanelItem(icon);
+                            break;
+                        case AnimatedIcon animIcon:
+                            AttachShadowNavigationPanelItem(animIcon);
+                            break;
+                    }
+                }
+                AttachShadowNavigationPanelItem(IconAppSettings);
+
+                if (ResetSelection)
+                {
+                    NavigationViewControl.SelectedItem = (NavigationViewItem)NavigationViewControl.MenuItems[0];
+                }
+
+                NavigationViewControl.ApplyNavigationViewItemLocaleTextBindings();
+
+                InputSystemCursor handCursor = InputSystemCursor.Create(InputSystemCursorShape.Hand);
+                MainPageGrid.SetAllControlsCursorRecursive(handCursor);
+            });
         }
 
         public static void AttachShadowNavigationPanelItem(FrameworkElement element)
@@ -1977,12 +1980,12 @@ namespace CollapseLauncher
 
         private void DeleteKeyboardShortcutHandlers() => KeyboardHandler.KeyboardAccelerators.Clear();
 
-        private static async void DisableKbShortcuts(int time = 500)
+        private static async Task DisableKbShortcuts(int time = 500, CancellationToken token = default)
         {
             try
             {
                 CannotUseKbShortcuts = true;
-                await Task.Delay(time);
+                await Task.Delay(time, token);
                 CannotUseKbShortcuts = false;
             }
             catch
@@ -2069,7 +2072,7 @@ namespace CollapseLauncher
 
             if (NavigationViewControl.SelectedItem == NavigationViewControl.MenuItems[0]) return;
 
-            DisableKbShortcuts();
+            _ = DisableKbShortcuts();
             NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems[0];
             NavigateInnerSwitch("launcher");
 
@@ -2081,7 +2084,7 @@ namespace CollapseLauncher
 
             if (NavigationViewControl.SelectedItem == NavigationViewControl.SettingsItem) return;
 
-            DisableKbShortcuts();
+            _ = DisableKbShortcuts();
             NavigationViewControl.SelectedItem = NavigationViewControl.SettingsItem;
             Navigate(typeof(SettingsPage), "settings");
         }
@@ -2203,7 +2206,7 @@ namespace CollapseLauncher
 
             if (NavigationViewControl.SelectedItem == NavigationViewControl.MenuItems[2]) return;
 
-            DisableKbShortcuts();
+            _ = DisableKbShortcuts();
             NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems[2];
             NavigateInnerSwitch("repair");
         }
@@ -2215,7 +2218,7 @@ namespace CollapseLauncher
             if (NavigationViewControl.SelectedItem == NavigationViewControl.MenuItems[3])
                 return;
 
-            DisableKbShortcuts();
+            _ = DisableKbShortcuts();
             NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems[3];
             NavigateInnerSwitch("caches");
         }
@@ -2228,7 +2231,7 @@ namespace CollapseLauncher
             if (NavigationViewControl.SelectedItem == NavigationViewControl.FooterMenuItems.Last())
                 return;
 
-            DisableKbShortcuts();
+            _ = DisableKbShortcuts();
             NavigationViewControl.SelectedItem = NavigationViewControl.FooterMenuItems.Last();
             switch (CurrentGameProperty.GamePreset)
             {

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -224,11 +224,11 @@ namespace CollapseLauncher
 #nullable enable
             NavigationViewControl?.ApplyNavigationViewItemLocaleTextBindings();
 
-            List<string>? gameNameCollection = LauncherMetadataHelper.GetGameNameCollection()!;
-            List<string>? gameRegionCollection = LauncherMetadataHelper.GetGameRegionCollection(lastName!)!;
+            List<string>? gameNameCollection = LauncherMetadataHelper.GetGameNameCollection();
+            List<string>? gameRegionCollection = LauncherMetadataHelper.GetGameRegionCollection(lastName!);
 
-            int indexOfName = gameNameCollection.IndexOf(lastName!);
-            int indexOfRegion = gameRegionCollection.IndexOf(lastRegion!);
+            int indexOfName = gameNameCollection?.IndexOf(lastName!) ?? -1;
+            int indexOfRegion = gameRegionCollection?.IndexOf(lastRegion!) ?? -1;
 #nullable restore
                 
             // Rebuild Game Titles and Regions ComboBox items
@@ -1171,14 +1171,14 @@ namespace CollapseLauncher
 
             #nullable enable
             List<string>? gameCollection   = LauncherMetadataHelper.GetGameNameCollection();
-            List<string?>? regionCollection = LauncherMetadataHelper.GetGameRegionCollection(gameName);
+            List<string>? regionCollection = LauncherMetadataHelper.GetGameRegionCollection(gameName);
             
             if (regionCollection == null)
                 gameName = LauncherMetadataHelper.LauncherGameNameRegionCollection?.Keys.FirstOrDefault();
 
             ComboBoxGameRegion.ItemsSource = BuildGameRegionListUI(gameName);
 
-            var indexCategory                    = gameCollection?.IndexOf(gameName!) ?? -1;
+            var indexCategory= gameCollection?.IndexOf(gameName!) ?? -1;
             if (indexCategory < 0) indexCategory = 0;
 
             var indexRegion = LauncherMetadataHelper.GetPreviousGameRegion(gameName);

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml
@@ -111,6 +111,7 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
+                    <!-- ReSharper disable GrammarMistakeInMarkupAttribute -->
                     <TextBlock x:Name="LoadingStatusTextTitle"
                                Grid.Column="0"
                                VerticalAlignment="Center"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/InstallationConvert.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/InstallationConvert.xaml.cs
@@ -201,7 +201,7 @@ namespace CollapseLauncher.Dialogs
                 string infoVendorPath = Path.Combine(gamePath, $"{Path.GetFileNameWithoutExtension(profile.GameExecutableName)}_Data\\app.info");
                 if (!File.Exists(infoVendorPath)) return false;
 
-                // If does, then process the file
+                // If it does, then process the file
                 string[] infoEntries = File.ReadAllLines(infoVendorPath);
                 if (infoEntries.Length < 2) return false;
 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -752,41 +752,6 @@ namespace CollapseLauncher.Dialogs
                 isHasOnlyMigrateOption ? null : Lang._Misc.MoveToDifferentDir
             );
         }
-        public static async Task<ContentDialogResult> Dialog_SteamConversionNoPermission(UIElement content) =>
-            await SpawnDialog(
-                        Lang._Dialogs.SteamConvertNeedMigrateTitle,
-                        Lang._Dialogs.SteamConvertNeedMigrateSubtitle,
-                        content,
-                        Lang._Misc.Cancel,
-                        Lang._Misc.Yes,
-                        Lang._Misc.NoOtherLocation,
-                        ContentDialogButton.Secondary,
-                        ContentDialogTheme.Error
-            );
-
-        public static async Task<ContentDialogResult> Dialog_SteamConversionDownloadDialog(UIElement content, string sizeString) =>
-            await SpawnDialog(
-                        Lang._Dialogs.SteamConvertIntegrityDoneTitle,
-                        Lang._Dialogs.SteamConvertIntegrityDoneSubtitle,
-                        content,
-                        Lang._Misc.Cancel,
-                        Lang._Misc.Yes,
-                        null,
-                        ContentDialogButton.Secondary,
-                        ContentDialogTheme.Success
-            );
-
-        public static async Task<ContentDialogResult> Dialog_SteamConversionFailedDialog(UIElement content) =>
-            await SpawnDialog(
-                        Lang._Dialogs.SteamConvertFailedTitle,
-                        Lang._Dialogs.SteamConvertFailedSubtitle,
-                        content,
-                        Lang._Misc.OkaySad,
-                        null,
-                        null,
-                        ContentDialogButton.Close,
-                        ContentDialogTheme.Success
-            );
 
         public static async Task<ContentDialogResult> Dialog_GameInstallationFileCorrupt(UIElement content, string sourceHash, string downloadedHash) =>
             await SpawnDialog(
@@ -834,18 +799,6 @@ namespace CollapseLauncher.Dialogs
                         Lang._StartupPage.ChooseFolderDialogCancel,
                         Lang._StartupPage.ChooseFolderDialogPrimary,
                         Lang._StartupPage.ChooseFolderDialogSecondary
-            );
-
-        public static async Task<ContentDialogResult> Dialog_CannotUseAppLocationForGameDir(UIElement content) =>
-            await SpawnDialog(
-                        Lang._Dialogs.CannotUseAppLocationForGameDirTitle,
-                        Lang._Dialogs.CannotUseAppLocationForGameDirSubtitle,
-                        content,
-                        Lang._Misc.Okay,
-                        null,
-                        null,
-                        ContentDialogButton.Close,
-                        ContentDialogTheme.Error
             );
 
         public static async Task<ContentDialogResult> Dialog_ExistingDownload(UIElement content, double partialLength, double contentLength) =>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/HonkaiGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/HonkaiGameSettingsPage.Ext.cs
@@ -37,16 +37,16 @@ namespace CollapseLauncher.Pages
         #region Presets
         public ICollection<string> PresetRenderingNames
         {
-            get => Settings.Preset_SettingsGraphics.PresetKeys;
+            get => Settings.PresetSettingsGraphics.PresetKeys;
         }
 
         public int PresetRenderingIndex
         {
             get
             {
-                string name = Settings.Preset_SettingsGraphics.GetPresetKey();
-                int index = Settings.Preset_SettingsGraphics.PresetKeys.IndexOf(name);
-                PersonalGraphicsSettingV2 presetValue = Settings.Preset_SettingsGraphics.GetPresetFromKey(name);
+                string name = Settings.PresetSettingsGraphics.GetPresetKey();
+                int index = Settings.PresetSettingsGraphics.PresetKeys.IndexOf(name);
+                PersonalGraphicsSettingV2 presetValue = Settings.PresetSettingsGraphics.GetPresetFromKey(name);
 
                 if (presetValue != null)
                 {
@@ -60,14 +60,14 @@ namespace CollapseLauncher.Pages
             {
                 if (value < 0) return;
 
-                string name = Settings.Preset_SettingsGraphics.PresetKeys[value];
-                PersonalGraphicsSettingV2 presetValue = Settings.Preset_SettingsGraphics.GetPresetFromKey(name);
+                string name = Settings.PresetSettingsGraphics.PresetKeys[value];
+                PersonalGraphicsSettingV2 presetValue = Settings.PresetSettingsGraphics.GetPresetFromKey(name);
 
                 if (presetValue != null)
                 {
                     Settings.SettingsGraphics = presetValue;
                 }
-                Settings.Preset_SettingsGraphics.SetPresetKey(presetValue);
+                Settings.PresetSettingsGraphics.SetPresetKey(presetValue);
 
                 ToggleRenderingSettings(name == PresetConst.DefaultPresetName);
                 UpdatePresetRenderingSettings();

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/StarRailGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/StarRailGameSettingsPage.Ext.cs
@@ -193,7 +193,7 @@ namespace CollapseLauncher.Pages
         {
             get
             {
-                int value = Model.FPSIndexDict[NormalizeFPSNumber(Settings.GraphicsSettings.FPS)];
+                int value = Model.FpsIndexDict[NormalizeFPSNumber(Settings.GraphicsSettings.FPS)];
                 if (value != 2)
                 {
                     return value;
@@ -213,12 +213,12 @@ namespace CollapseLauncher.Pages
                 }
                 else { VSyncToggle.IsEnabled = true; }
 
-                Settings.GraphicsSettings.FPS = Model.FPSIndex[value];
+                Settings.GraphicsSettings.FPS = Model.FpsIndex[value];
             }
         }
 
         // Set it to 60 (default) if the value isn't within Model.FPSIndexDict
-        private static int NormalizeFPSNumber(int input) => !Model.FPSIndexDict.ContainsKey(input) ? Model.FPSIndex[Model.FPSDefaultIndex] : input;
+        private static int NormalizeFPSNumber(int input) => !Model.FpsIndexDict.ContainsKey(input) ? Model.FpsIndex[Model.FpsDefaultIndex] : input;
 
         //VSync
         public bool EnableVSync
@@ -328,26 +328,26 @@ namespace CollapseLauncher.Pages
         #region Audio
         public int AudioMasterVolume
         {
-            get => Settings.AudioSettings_Master.MasterVol = Settings.AudioSettings_Master.MasterVol;
-            set => Settings.AudioSettings_Master.MasterVol = value;
+            get => Settings.AudioSettingsMaster.MasterVol = Settings.AudioSettingsMaster.MasterVol;
+            set => Settings.AudioSettingsMaster.MasterVol = value;
         }
 
         public int AudioBGMVolume
         {
-            get => Settings.AudioSettings_BGM.BGMVol = Settings.AudioSettings_BGM.BGMVol;
-            set => Settings.AudioSettings_BGM.BGMVol = value;
+            get => Settings.AudioSettingsBgm.BGMVol = Settings.AudioSettingsBgm.BGMVol;
+            set => Settings.AudioSettingsBgm.BGMVol = value;
         }
 
         public int AudioSFXVolume
         {
-            get => Settings.AudioSettings_SFX.SFXVol = Settings.AudioSettings_SFX.SFXVol;
-            set => Settings.AudioSettings_SFX.SFXVol = value;
+            get => Settings.AudioSettingsSfx.SFXVol = Settings.AudioSettingsSfx.SFXVol;
+            set => Settings.AudioSettingsSfx.SFXVol = value;
         }
 
         public int AudioVOVolume
         {
-            get => Settings.AudioSettings_VO.VOVol = Settings.AudioSettings_VO.VOVol;
-            set => Settings.AudioSettings_VO.VOVol = value;
+            get => Settings.AudioSettingsVo.VOVol = Settings.AudioSettingsVo.VOVol;
+            set => Settings.AudioSettingsVo.VOVol = value;
         }
 
         public int AudioLang

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/StarRailGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/StarRailGameSettingsPage.xaml
@@ -115,7 +115,7 @@
                                             </Grid>
                                             <!--
                                                 Exclusive Fullscreen option is disabled in Honkai:Star Rail due to it being ignored by the game
-                                                Delete `Visibility="Collapsed"' to revert this change
+                                                Delete `Visibility="Collapsed"` to revert this change
                                             -->
                                             <CheckBox x:Name="GameResolutionFullscreenExclusive"
                                                       HorizontalAlignment="Left"
@@ -227,7 +227,7 @@
                                           MinWidth="128"
                                           Margin="0,8,0,0"
                                           CornerRadius="14"
-                                          ItemsSource="{x:Bind static:Model.FPSIndex}"
+                                          ItemsSource="{x:Bind static:Model.FpsIndex}"
                                           SelectedIndex="{x:Bind FPS, Mode=TwoWay}" />
                             </StackPanel>
                             <StackPanel x:Name="GameBoostPanel"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.BindingHelper.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.BindingHelper.cs
@@ -1,5 +1,5 @@
 ﻿using CollapseLauncher.Extension;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using CommunityToolkit.WinUI;
 using ImageEx;
 using Microsoft.UI.Xaml;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.Variable.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.Variable.cs
@@ -1,5 +1,5 @@
 ﻿using CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using CollapseLauncher.Helper.Metadata;
 using Hi3Helper;
 using Microsoft.UI.Xaml;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.Variable.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.Variable.cs
@@ -139,11 +139,11 @@ namespace CollapseLauncher.Pages
             }
         }
 
-        internal int CurrentBannerIconWidth
+        internal int CurrentBannerIconHeight
         {
             get => CurrentGameProperty?.GamePreset.LauncherType == LauncherType.Sophon ?
-                   WindowSize.WindowSize.CurrentWindowSize.BannerIconWidth :
-                   WindowSize.WindowSize.CurrentWindowSize.BannerIconWidthHYP;
+                   WindowSize.WindowSize.CurrentWindowSize.BannerIconHeight :
+                   WindowSize.WindowSize.CurrentWindowSize.BannerIconHeightHYP;
         }
 
         internal Thickness CurrentBannerIconMargin

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
@@ -17,7 +17,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:pages="using:CollapseLauncher.Pages"
       xmlns:s="using:CommunityToolkit.WinUI"
-      xmlns:sophonTypes="using:CollapseLauncher.Helper.LauncherApiLoader.Sophon"
+      xmlns:sophonTypes="using:CollapseLauncher.Helper.LauncherApiLoader.Legacy"
       x:Name="HomePage_Page"
       x:FieldModifier="public"
       CacheMode="BitmapCache"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
@@ -50,7 +50,7 @@
               Grid.RowSpan="{x:Bind pages:HomePage.CurrentBannerIconRowSpan}"
               Grid.Column="{x:Bind CurrentBannerIconColumn}"
               Grid.ColumnSpan="{x:Bind pages:HomePage.CurrentBannerIconColumnSpan}"
-              Width="{x:Bind CurrentBannerIconWidth}"
+              Height="{x:Bind CurrentBannerIconHeight}"
               Margin="{x:Bind CurrentBannerIconMargin}"
               HorizontalAlignment="{x:Bind CurrentBannerIconHorizontalAlign}"
               VerticalAlignment="{x:Bind CurrentBannerIconVerticalAlign}"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -2165,7 +2165,7 @@ namespace CollapseLauncher.Pages
 
                 CurrentGameProperty.GameSettings.SettingsCollapseMisc.UseCustomRegionBG = value;
                 CurrentGameProperty.GameSettings.SaveBaseSettings();
-                m_mainPage?.ChangeBackgroundImageAsRegionAsync();
+                _ = m_mainPage?.ChangeBackgroundImageAsRegionAsync();
 
                 BGPathDisplay.Text = Path.GetFileName(regionBgPath);
             } 
@@ -2469,7 +2469,7 @@ namespace CollapseLauncher.Pages
                 CurrentGameProperty.GameSettings.SettingsCollapseMisc.CustomRegionBGPath = file;
                 CurrentGameProperty.GameSettings.SaveBaseSettings();
             }
-            m_mainPage?.ChangeBackgroundImageAsRegionAsync();
+            _ = m_mainPage?.ChangeBackgroundImageAsRegionAsync();
 
             BGPathDisplay.Text = Path.GetFileName(file);
         }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -1102,8 +1102,7 @@ namespace CollapseLauncher.Pages
                         PlaytimeIdleStack.Visibility = Visibility.Collapsed;
                         PlaytimeRunningStack.Visibility = Visibility.Visible;
 
-                        int processId;
-                        if (CurrentGameProperty.TryGetGameProcessIdWithActiveWindow(out processId, out _))
+                        if (CurrentGameProperty.TryGetGameProcessIdWithActiveWindow(out var processId, out _))
                         {
                             using Process currentGameProcess = Process.GetProcessById(processId);
 
@@ -2003,7 +2002,7 @@ namespace CollapseLauncher.Pages
                     // Enable mobile mode
                     if (_Settings.SettingsCollapseMisc.LaunchMobileMode)
                     {
-                        const string regLoc  = GameSettings.StarRail.Model._ValueName;
+                        const string regLoc  = GameSettings.StarRail.Model.ValueName;
                         var          regRoot = GameSettings.Base.SettingsBase.RegistryRoot;
 
                         if (regRoot != null || !string.IsNullOrEmpty(regLoc))

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -2,7 +2,7 @@
 using CollapseLauncher.DiscordPresence;
 #endif
 using CollapseLauncher.CustomControls;
-using CollapseLauncher.Helper.LauncherApiLoader.Sophon;
+using CollapseLauncher.Helper.LauncherApiLoader.Legacy;
 using CollapseLauncher.Dialogs;
 using CollapseLauncher.Extension;
 using CollapseLauncher.GamePlaytime;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/OOBE/OOBEStartUpMenu.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/OOBE/OOBEStartUpMenu.xaml.cs
@@ -904,7 +904,7 @@ namespace CollapseLauncher.Pages.OOBE
                                                 Lang._StartupPage.Pg1LoadingSubitle2);
                 LoadingMessageHelper.SetProgressBarState(100, false);
                 LoadingMessageHelper.SetProgressBarValue(100);
-                await Task.Delay(5000);
+                await Task.Delay(2000);
 
                 LoadingMessageHelper.HideLoadingFrame();
             }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -1,6 +1,7 @@
-﻿<!--  ReSharper disable IdentifierTypo  -->
-<!--  ReSharper disable UnusedMember.Local  -->
-<!--  ReSharper disable Xaml.ConstructorWarning  -->
+﻿<!-- ReSharper disable IdentifierTypo -->
+<!-- ReSharper disable UnusedMember.Local -->
+<!-- ReSharper disable Xaml.ConstructorWarning -->
+<!-- ReSharper disable GrammarMistakeInMarkupAttribute -->
 <Page x:Class="CollapseLauncher.Pages.SettingsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -496,7 +496,7 @@ namespace CollapseLauncher.Pages
                 if (!value)
                 {
                     LauncherMetadataHelper.CurrentMetadataConfig.GameLauncherApi.GameBackgroundImgLocal = GetAppConfigValue("CurrentBackground").ToString();
-                    m_mainPage?.ChangeBackgroundImageAsRegionAsync();
+                    _ = m_mainPage?.ChangeBackgroundImageAsRegionAsync();
 
                     ToggleCustomBgButtons();
                 }
@@ -504,7 +504,7 @@ namespace CollapseLauncher.Pages
                 {
                     string currentRegionCustomBg = currentGameProperty.GameSettings.SettingsCollapseMisc.CustomRegionBGPath;
                     LauncherMetadataHelper.CurrentMetadataConfig.GameLauncherApi.GameBackgroundImgLocal = currentRegionCustomBg;
-                    m_mainPage?.ChangeBackgroundImageAsRegionAsync();
+                    _ = m_mainPage?.ChangeBackgroundImageAsRegionAsync();
 
                     ToggleCustomBgButtons();
                 }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/UpdatePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/UpdatePage.xaml.cs
@@ -208,13 +208,13 @@ namespace CollapseLauncher.Pages
         {
             DispatcherQueue?.TryEnqueue(() =>
             {
-                Status.Text = e.status;
-                if (string.IsNullOrEmpty(e.newver))
+                Status.Text = e.Status;
+                if (string.IsNullOrEmpty(e.Newver))
                 {
                     return;
                 }
 
-                GameVersion version = new GameVersion(e.newver);
+                GameVersion version = new GameVersion(e.Newver);
                 NewVersionLabel.Text = version.VersionString;
             });
         }

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/DefaultSVGRenderer.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/DefaultSVGRenderer.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+// ReSharper disable InconsistentNaming
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock;
 
@@ -18,7 +19,7 @@ internal class DefaultSVGRenderer : ISVGRenderer
         var image = new Image();
         // Create a MemoryStream object and write the SVG string to it
         using (var memoryStream = new MemoryStream())
-            using (var streamWriter = new StreamWriter(memoryStream))
+            await using (var streamWriter = new StreamWriter(memoryStream))
             {
                 await streamWriter.WriteAsync(svgString);
                 await streamWriter.FlushAsync();

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Extensions.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Extensions.cs
@@ -19,6 +19,8 @@ using System.Xml.Linq;
 using Windows.Foundation;
 using Windows.UI;
 using Windows.UI.ViewManagement;
+// ReSharper disable GrammarMistakeInComment
+// ReSharper disable UnusedMember.Global
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock;
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/ISVGRenderer.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/ISVGRenderer.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.UI.Xaml.Controls;
 using System.Threading.Tasks;
+// ReSharper disable InconsistentNaming
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock;
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/MarkdownThemes.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/MarkdownThemes.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Media;
 using FontWeight = Windows.UI.Text.FontWeight;
 using FontWeights = Microsoft.UI.Text.FontWeights;
 // ReSharper disable PartialTypeWithSinglePart
+// ReSharper disable UnusedMember.Global
 
 namespace CommunityToolkit.WinUI.Controls.MarkdownTextBlockRns;
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Renderers/ObjectRenderers/Inlines/DelimiterInlineRenderer.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Renderers/ObjectRenderers/Inlines/DelimiterInlineRenderer.cs
@@ -5,6 +5,7 @@
 using Markdig.Renderers;
 using Markdig.Syntax.Inlines;
 using System;
+// ReSharper disable GrammarMistakeInComment
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.Renderers.ObjectRenderers.Inlines;
 
@@ -12,10 +13,10 @@ internal class DelimiterInlineRenderer : MarkdownObjectRenderer<WinUIRenderer, D
 {
     protected override void Write(WinUIRenderer renderer, DelimiterInline obj)
     {
-        if (renderer == null) throw new ArgumentNullException(nameof(renderer));
-        if (obj == null) throw new ArgumentNullException(nameof(obj));
+        ArgumentNullException.ThrowIfNull(renderer, nameof(renderer));
+        ArgumentNullException.ThrowIfNull(obj, nameof(obj));
 
-        // delimiter's children are emphasized text, we don't need to explicitly render them
+        // delimiters children are emphasized text, we don't need to explicitly render them
         // Just need to render the children of the delimiter, I think..
         //renderer.WriteText(obj.ToLiteral());
         renderer.WriteChildren(obj);

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Renderers/UWPObjectRenderer.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Renderers/UWPObjectRenderer.cs
@@ -5,6 +5,8 @@
 using CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.Renderers;
 using Markdig.Renderers;
 using Markdig.Syntax;
+// ReSharper disable UnusedMember.Global
+// ReSharper disable InconsistentNaming
 
 namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers;
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Renderers/WinUIRenderer.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/Renderers/WinUIRenderer.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable InconsistentNaming
 // ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Global
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.Renderers;
 
@@ -57,8 +58,8 @@ public class WinUIRenderer : RendererBase
 
     public void WriteLeafInline(LeafBlock leafBlock)
     {
-        if (leafBlock == null || leafBlock.Inline == null) throw new ArgumentNullException(nameof(leafBlock));
-        var inline = (Inline)leafBlock.Inline;
+        if (leafBlock.Inline == null) throw new ArgumentNullException(nameof(leafBlock));
+        Inline? inline = leafBlock.Inline;
         while (inline != null)
         {
             Write(inline);

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/Html/MyDetails.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/Html/MyDetails.cs
@@ -23,15 +23,13 @@ internal class MyDetails : IAddChild
 
     public MyDetails(HtmlNode details)
     {
-        HtmlNode _htmlNode = details;
+        var header = details.ChildNodes
+                            .FirstOrDefault(
+                                            x => x.Name == "summary" ||
+                                                 x.Name == "header");
 
-        var header = _htmlNode.ChildNodes
-            .FirstOrDefault(
-                x => x.Name == "summary" ||
-                x.Name == "header");
-
-        InlineUIContainer _inlineUIContainer = new InlineUIContainer();
-        Expander          _expander          = new Expander
+        InlineUIContainer inlineUIContainer = new InlineUIContainer();
+        Expander          expander          = new Expander
         {
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
@@ -42,16 +40,16 @@ internal class MyDetails : IAddChild
                 HorizontalAlignment = HorizontalAlignment.Stretch
             }
         };
-        _expander.Content                               = _flowDocument.RichTextBlock;
+        expander.Content                               = _flowDocument.RichTextBlock;
         var headerBlock = new TextBlock
         {
             Text                = header?.InnerText,
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
-        _expander.Header = headerBlock;
-        _inlineUIContainer.Child = _expander;
+        expander.Header = headerBlock;
+        inlineUIContainer.Child = expander;
         _paragraph = new Paragraph();
-        _paragraph.Inlines.Add(_inlineUIContainer);
+        _paragraph.Inlines.Add(inlineUIContainer);
     }
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/Html/MyInline.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/Html/MyInline.cs
@@ -22,11 +22,11 @@ internal class MyInline : IAddChild
     {
         _paragraph = new Paragraph();
         _inlineUIContainer = new InlineUIContainer();
-        RichTextBlock _richTextBlock = new RichTextBlock();
-        _richTextBlock.Blocks.Add(_paragraph);
+        RichTextBlock richTextBlock = new RichTextBlock();
+        richTextBlock.Blocks.Add(_paragraph);
 
-        _richTextBlock.HorizontalAlignment = HorizontalAlignment.Stretch;
-        _inlineUIContainer.Child = _richTextBlock;
+        richTextBlock.HorizontalAlignment = HorizontalAlignment.Stretch;
+        _inlineUIContainer.Child = richTextBlock;
     }
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyAutolinkInline.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyAutolinkInline.cs
@@ -8,17 +8,12 @@ using System;
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
-internal class MyAutolinkInline : IAddChild
+internal class MyAutolinkInline(AutolinkInline autoLinkInline) : IAddChild
 {
-    public TextElement TextElement { get; }
-
-    public MyAutolinkInline(AutolinkInline autoLinkInline)
+    public TextElement TextElement { get; } = new Hyperlink
     {
-        TextElement = new Hyperlink
-        {
-            NavigateUri = new Uri(autoLinkInline.Url)
-        };
-    }
+        NavigateUri = new Uri(autoLinkInline.Url)
+    };
 
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyBlockContainer.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyBlockContainer.cs
@@ -18,11 +18,11 @@ internal class MyBlockContainer : IAddChild
 
     public MyBlockContainer()
     {
-        InlineUIContainer _inlineUIContainer = new InlineUIContainer();
+        InlineUIContainer inlineUIContainer = new InlineUIContainer();
         _flowDocument = new MyFlowDocument();
-        _inlineUIContainer.Child = _flowDocument.RichTextBlock;
+        inlineUIContainer.Child = _flowDocument.RichTextBlock;
         _paragraph = new Paragraph();
-        _paragraph.Inlines.Add(_inlineUIContainer);
+        _paragraph.Inlines.Add(inlineUIContainer);
     }
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyCodeBlock.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyCodeBlock.cs
@@ -10,6 +10,7 @@ using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using System.Collections.Generic;
 using System.Text;
+// ReSharper disable CommentTypo
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
@@ -24,15 +25,14 @@ internal class MyCodeBlock : IAddChild
 
     public MyCodeBlock(CodeBlock codeBlock, MarkdownConfig config)
     {
-        MarkdownConfig _config = config;
         _paragraph = new Paragraph();
         var container = new InlineUIContainer();
         var border    = new Border
         {
             Background   = (Brush)Application.Current.Resources["ExpanderHeaderBackground"],
-            Padding      = _config.Themes.Padding,
-            Margin       = _config.Themes.InternalMargin,
-            CornerRadius = _config.Themes.CornerRadius
+            Padding      = config.Themes.Padding,
+            Margin       = config.Themes.InternalMargin,
+            CornerRadius = config.Themes.CornerRadius
         };
         var richTextBlock = new RichTextBlock();
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyEmphasisInline.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyEmphasisInline.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
 internal class MyEmphasisInline : IAddChild
 {
-    private readonly Span _span;
+    private readonly Span _span = new();
 
     private bool _isBold;
     private bool _isItalic;
@@ -21,11 +21,6 @@ internal class MyEmphasisInline : IAddChild
     public TextElement TextElement
     {
         get => _span;
-    }
-
-    public MyEmphasisInline()
-    {
-        _span = new Span();
     }
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyHeading.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyHeading.cs
@@ -7,6 +7,7 @@ using HtmlAgilityPack;
 using Markdig.Syntax;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Documents;
+// ReSharper disable UnusedMember.Global
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
@@ -25,27 +26,26 @@ internal class MyHeading : IAddChild
     public MyHeading(HeadingBlock headingBlock, MarkdownConfig config)
     {
         _paragraph = new Paragraph();
-        MarkdownConfig _config = config;
 
         var level = headingBlock.Level;
         _paragraph.FontSize = level switch
         {
-            1 => _config.Themes.H1FontSize,
-            2 => _config.Themes.H2FontSize,
-            3 => _config.Themes.H3FontSize,
-            4 => _config.Themes.H4FontSize,
-            5 => _config.Themes.H5FontSize,
-            _ => _config.Themes.H6FontSize
+            1 => config.Themes.H1FontSize,
+            2 => config.Themes.H2FontSize,
+            3 => config.Themes.H3FontSize,
+            4 => config.Themes.H4FontSize,
+            5 => config.Themes.H5FontSize,
+            _ => config.Themes.H6FontSize
         };
-        _paragraph.Foreground = _config.Themes.HeadingForeground;
+        _paragraph.Foreground = config.Themes.HeadingForeground;
         _paragraph.FontWeight = level switch
         {
-            1 => _config.Themes.H1FontWeight,
-            2 => _config.Themes.H2FontWeight,
-            3 => _config.Themes.H3FontWeight,
-            4 => _config.Themes.H4FontWeight,
-            5 => _config.Themes.H5FontWeight,
-            _ => _config.Themes.H6FontWeight
+            1 => config.Themes.H1FontWeight,
+            2 => config.Themes.H2FontWeight,
+            3 => config.Themes.H3FontWeight,
+            4 => config.Themes.H4FontWeight,
+            5 => config.Themes.H5FontWeight,
+            _ => config.Themes.H6FontWeight
         };
         _paragraph.Margin = new Thickness(0, 8, 0, level switch
         {
@@ -60,7 +60,6 @@ internal class MyHeading : IAddChild
     {
         _htmlNode = htmlNode;
         _paragraph = new Paragraph();
-        MarkdownConfig _config = config;
 
         var align = _htmlNode?.GetAttributeValue("align", "left");
         _paragraph.TextAlignment = align switch
@@ -75,22 +74,22 @@ internal class MyHeading : IAddChild
         var level = int.Parse(htmlNode.Name.Substring(1));
         _paragraph.FontSize = level switch
         {
-            1 => _config.Themes.H1FontSize,
-            2 => _config.Themes.H2FontSize,
-            3 => _config.Themes.H3FontSize,
-            4 => _config.Themes.H4FontSize,
-            5 => _config.Themes.H5FontSize,
-            _ => _config.Themes.H6FontSize
+            1 => config.Themes.H1FontSize,
+            2 => config.Themes.H2FontSize,
+            3 => config.Themes.H3FontSize,
+            4 => config.Themes.H4FontSize,
+            5 => config.Themes.H5FontSize,
+            _ => config.Themes.H6FontSize
         };
-        _paragraph.Foreground = _config.Themes.HeadingForeground;
+        _paragraph.Foreground = config.Themes.HeadingForeground;
         _paragraph.FontWeight = level switch
         {
-            1 => _config.Themes.H1FontWeight,
-            2 => _config.Themes.H2FontWeight,
-            3 => _config.Themes.H3FontWeight,
-            4 => _config.Themes.H4FontWeight,
-            5 => _config.Themes.H5FontWeight,
-            _ => _config.Themes.H6FontWeight
+            1 => config.Themes.H1FontWeight,
+            2 => config.Themes.H2FontWeight,
+            3 => config.Themes.H3FontWeight,
+            4 => config.Themes.H4FontWeight,
+            5 => config.Themes.H5FontWeight,
+            _ => config.Themes.H6FontWeight
         };
     }
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyImage.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyImage.cs
@@ -41,7 +41,7 @@ internal class MyImage : IAddChild
     {
         _uri = uri;
         _imageProvider = config.ImageProvider;
-        _svgRenderer = config.SVGRenderer == null ? new DefaultSVGRenderer() : config.SVGRenderer;
+        _svgRenderer = config.SVGRenderer ?? new DefaultSVGRenderer();
         Init();
         var size = Extensions.GetMarkdownImageSize(linkInline);
         if (size.Width != 0)
@@ -58,7 +58,7 @@ internal class MyImage : IAddChild
     {
         Uri.TryCreate(htmlNode.GetAttributeValue("src", "#"), UriKind.RelativeOrAbsolute, out _uri);
         _imageProvider = config?.ImageProvider;
-        _svgRenderer = config?.SVGRenderer == null ? new DefaultSVGRenderer() : config.SVGRenderer;
+        _svgRenderer = config?.SVGRenderer ?? new DefaultSVGRenderer();
         Init();
         int.TryParse(
             htmlNode.GetAttributeValue("width", "0"),

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyInlineCode.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyInlineCode.cs
@@ -22,16 +22,15 @@ internal class MyInlineCode : IAddChild
 
     public MyInlineCode(CodeInline codeInline, MarkdownConfig config)
     {
-        MarkdownConfig _config = config;
         _inlineContainer = new InlineUIContainer();
         var border = new Border
         {
             VerticalAlignment = VerticalAlignment.Bottom,
-            Background        = _config.Themes.InlineCodeBackground,
+            Background        = config.Themes.InlineCodeBackground,
             // border.BorderBrush = _config.Themes.InlineCodeBorderBrush;
             // border.BorderThickness = _config.Themes.InlineCodeBorderThickness;
-            CornerRadius      = _config.Themes.InlineCodeCornerRadius,
-            Padding           = _config.Themes.InlineCodePadding
+            CornerRadius      = config.Themes.InlineCodeCornerRadius,
+            Padding           = config.Themes.InlineCodePadding
         };
         CompositeTransform3D transform = new CompositeTransform3D
         {
@@ -40,9 +39,9 @@ internal class MyInlineCode : IAddChild
         border.Transform3D = transform;
         var textBlock = new TextBlock
         {
-            FontFamily = _config.Themes.InlineCodeFontFamily,
-            FontSize   = _config.Themes.InlineCodeFontSize,
-            FontWeight = _config.Themes.InlineCodeFontWeight,
+            FontFamily = config.Themes.InlineCodeFontFamily,
+            FontSize   = config.Themes.InlineCodeFontSize,
+            FontWeight = config.Themes.InlineCodeFontWeight,
             Text       = codeInline.Content
         };
         border.Child = textBlock;

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyInlineText.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyInlineText.cs
@@ -6,21 +6,16 @@ using Microsoft.UI.Xaml.Documents;
 
 namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
-internal class MyInlineText : IAddChild
+internal class MyInlineText(string text) : IAddChild
 {
-    private readonly Run _run;
+    private readonly Run _run = new()
+    {
+        Text = text
+    };
 
     public TextElement TextElement
     {
         get => _run;
-    }
-
-    public MyInlineText(string text)
-    {
-        _run = new Run
-        {
-            Text = text
-        };
     }
 
     public void AddChild(IAddChild child) { }

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyLineBreak.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyLineBreak.cs
@@ -8,16 +8,11 @@ namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
 internal class MyLineBreak : IAddChild
 {
-    private readonly LineBreak _lineBreak;
+    private readonly LineBreak _lineBreak = new();
 
     public TextElement TextElement
     {
         get => _lineBreak;
-    }
-
-    public MyLineBreak()
-    {
-        _lineBreak = new LineBreak();
     }
 
     public void AddChild(IAddChild child) { }

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyParagraph.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyParagraph.cs
@@ -10,16 +10,11 @@ namespace CommunityToolkit.Labs.WinUI.Labs.MarkdownTextBlock.TextElements;
 
 internal class MyParagraph : IAddChild
 {
-    private readonly Paragraph _paragraph;
+    private readonly Paragraph _paragraph = new();
 
     public TextElement TextElement
     {
         get => _paragraph;
-    }
-
-    public MyParagraph()
-    {
-        _paragraph = new Paragraph();
     }
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyTableCell.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CommunityToolkit.Labs/MarkdownTextBlock/TextElements/MyTableCell.cs
@@ -15,19 +15,13 @@ internal class MyTableCell : IAddChild
     private readonly TableCell      _tableCell;
     private readonly Paragraph      _paragraph = new();
     private readonly MyFlowDocument _flowDocument;
-    private readonly int            _columnIndex;
-    private readonly int            _rowIndex;
-    private readonly Grid           _container;
 
     public TextElement TextElement
     {
         get => _paragraph;
     }
 
-    public Grid Container
-    {
-        get => _container;
-    }
+    public Grid Container { get; }
 
     public int ColumnSpan
     {
@@ -39,22 +33,16 @@ internal class MyTableCell : IAddChild
         get => _tableCell.RowSpan;
     }
 
-    public int ColumnIndex
-    {
-        get => _columnIndex;
-    }
+    public int ColumnIndex { get; }
 
-    public int RowIndex
-    {
-        get => _rowIndex;
-    }
+    public int RowIndex { get; }
 
     public MyTableCell(TableCell tableCell, TextAlignment textAlignment, bool isHeader, int columnIndex, int rowIndex)
     {
         _tableCell = tableCell;
-        _columnIndex = columnIndex;
-        _rowIndex = rowIndex;
-        _container = new Grid();
+        ColumnIndex = columnIndex;
+        RowIndex = rowIndex;
+        Container = new Grid();
 
         _flowDocument                                       = new MyFlowDocument
         {
@@ -73,7 +61,7 @@ internal class MyTableCell : IAddChild
             }
         };
 
-        _container.Padding = new Thickness(4);
+        Container.Padding = new Thickness(4);
         if (isHeader)
         {
             _flowDocument.RichTextBlock.FontWeight = FontWeights.Bold;
@@ -85,7 +73,7 @@ internal class MyTableCell : IAddChild
             TextAlignment.Right => HorizontalAlignment.Right,
             _ => HorizontalAlignment.Left
         };
-        _container.Children.Add(_flowDocument.RichTextBlock);
+        Container.Children.Add(_flowDocument.RichTextBlock);
     }
 
     public void AddChild(IAddChild child)

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/CompressedTextBlock.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/CompressedTextBlock.cs
@@ -24,15 +24,15 @@ namespace CollapseLauncher.CustomControls
             public int Spacing;
         }
 
-        class CompressedContext
+        private class CompressedContext
         {
             public          bool                 BeginOffset;
             public readonly List<CompressedText> Texts = [];
         }
 
-        private readonly CompressedContext Context          = new();
-        private readonly TextBlock         MeasureTextBlock = new();
-        private readonly TextBlock         ContentTextBlock = new();
+        private readonly CompressedContext _context          = new();
+        private readonly TextBlock         _measureTextBlock = new();
+        private readonly TextBlock         _contentTextBlock = new();
         #endregion
 
         #region Properties
@@ -91,13 +91,13 @@ namespace CollapseLauncher.CustomControls
         private static void OnForegroundChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
             var compressedTextBlock = (CompressedTextBlock)sender;
-            compressedTextBlock.ContentTextBlock.Foreground = (Brush)e.NewValue;
+            compressedTextBlock._contentTextBlock.Foreground = (Brush)e.NewValue;
         }
 
         private static void OnTextTrimmingChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
             var compressedTextBlock = (CompressedTextBlock)sender;
-            compressedTextBlock.ContentTextBlock.TextTrimming = (TextTrimming)e.NewValue;
+            compressedTextBlock._contentTextBlock.TextTrimming = (TextTrimming)e.NewValue;
         }
 
         private static void OnTextChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
@@ -115,26 +115,26 @@ namespace CollapseLauncher.CustomControls
 
         public CompressedTextBlock()
         {
-            Children.Add(ContentTextBlock);
+            Children.Add(_contentTextBlock);
         }
 
         private bool CheckCompressMark(string marks, char ch)
         {
             var contains = marks.Contains(ch);
             if (!contains) return false;
-            MeasureTextBlock.Text = "" + ch;
-            MeasureTextBlock.Measure(new Size(float.MaxValue, float.MaxValue));
-            return MeasureTextBlock.DesiredSize.Height <= MeasureTextBlock.DesiredSize.Width * 1.5;
+            _measureTextBlock.Text = "" + ch;
+            _measureTextBlock.Measure(new Size(float.MaxValue, float.MaxValue));
+            return _measureTextBlock.DesiredSize.Height <= _measureTextBlock.DesiredSize.Width * 1.5;
         }
 
         private void UpdateFontSize(double value)
         {
-            ContentTextBlock.FontSize = value;
+            _contentTextBlock.FontSize = value;
         }
 
         private void InvalidateText()
         {
-            ContentTextBlock.Inlines.Clear();
+            _contentTextBlock.Inlines.Clear();
             if (Text.Length <= 0) return;
 
             var lastChar = Text[0];
@@ -142,8 +142,8 @@ namespace CollapseLauncher.CustomControls
             var isLastCloseMark = CheckCompressMark(CloseMarks, lastChar);
             var compressedText = new CompressedText();
 
-            Context.BeginOffset = isLastOpenMark;
-            Context.Texts.Clear();
+            _context.BeginOffset = isLastOpenMark;
+            _context.Texts.Clear();
 
             for (var i = 1; i < Text.Length; i++)
             {
@@ -159,7 +159,7 @@ namespace CollapseLauncher.CustomControls
 
                 if (compressedText.Text.Length > 0 && compressedText.Spacing != spacing)
                 {
-                    Context.Texts.Add(compressedText);
+                    _context.Texts.Add(compressedText);
                     compressedText = new CompressedText();
                 }
 
@@ -173,23 +173,23 @@ namespace CollapseLauncher.CustomControls
 
             if (compressedText.Spacing != 0)
             {
-                Context.Texts.Add(compressedText);
+                _context.Texts.Add(compressedText);
                 compressedText = new CompressedText();
             }
 
             compressedText.Text += lastChar;
-            Context.Texts.Add(compressedText);
+            _context.Texts.Add(compressedText);
 
-            foreach (var text in Context.Texts)
+            foreach (var text in _context.Texts)
             {
-                ContentTextBlock.Inlines.Add(new Run
+                _contentTextBlock.Inlines.Add(new Run
                 {
                     Text = text.Text,
                     CharacterSpacing = text.Spacing
                 });
             }
 
-            ContentTextBlock.Translation = Context.BeginOffset ? new Vector3(1 - (float)ContentTextBlock.FontSize / 2, 0, 0) : new Vector3();
+            _contentTextBlock.Translation = _context.BeginOffset ? new Vector3(1 - (float)_contentTextBlock.FontSize / 2, 0, 0) : new Vector3();
         }
     }
 }

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/ContentDialogOverlay.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/ContentDialogOverlay.cs
@@ -26,12 +26,12 @@
                                   _ => UIElementExtensions.GetApplicationResource<object>("SystemFillColorAttentionBrush")
                               };
 
-            if (brushObj is not null and SolidColorBrush brush)
+            if (brushObj is SolidColorBrush brush)
             {
                 NColor titleColor = brush.Color;
                 titleColor.A = 255;
 
-                if (UIElementExtensions.GetApplicationResource<object>("DialogTitleBrush") is not null and SolidColorBrush brushTitle)
+                if (UIElementExtensions.GetApplicationResource<object>("DialogTitleBrush") is SolidColorBrush brushTitle)
                     brushTitle.Color = titleColor;
             }
 

--- a/CollapseLauncher/XAMLs/Updater/UpdaterWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/Updater/UpdaterWindow.xaml.cs
@@ -17,6 +17,7 @@ using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 // ReSharper disable StringLiteralTypo
+// ReSharper disable UnusedMember.Global
 
 namespace CollapseLauncher;
 

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -16,66 +16,66 @@
       },
       "CommunityToolkit.WinUI.Behaviors": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "vB7RvRuM2LrMQP/HCN6tlybrjSAcZtjQmiL9XUWSPqadKlxnIKs/0fMP2sthrcTy21Z/qQ7/P+/SSUFNRZ4XxA==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "nOPZoHMxX2PKvoaOMDBUIHihm35Sy3mNRMSji++P7RxNM+Tt7OuLPkqW/MAK+LE5MizxjCazwI8Zn4uLSCbjBA==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Animations": "8.2.241112-preview1",
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002",
-          "Microsoft.Xaml.Behaviors.WinUI.Managed": "2.0.9"
+          "CommunityToolkit.WinUI.Animations": "8.2.250129-preview2",
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002",
+          "Microsoft.Xaml.Behaviors.WinUI.Managed": "3.0.0"
         }
       },
       "CommunityToolkit.WinUI.Controls.Primitives": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "Z5cJyrDHEVLEhoSJpa3Vj7fNYcEfCE/Mrus8zUX2oFD5BpkNqAaJwOEIwCMDyQ6aNNBEGt5f+qs0mTgJp1pXyQ==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "rS9Q5Ej/4DgF99dLKYDXtiQW+Wtrkm4ktwlzYVmfuPd07RSLwoDxMbHTLe4Ba4uRwUjdvtfbO/IO7h6iWo5pfg==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Controls.Sizers": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "nd+k1STegyftRR3MOS+XaLpcS0vKMl46z0TZNnUrSpMb/Wfeu0uFcqFU5vsf4JgKUXx2CNDsydmFWQ7VjVCaow==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "K7NNhggJ/Woex7OuqC2Mj2Hsd508ZxyhaZDV/hi4eUynCwl1BaNX+RnwamLGJDgee5Uyz7wod9qnZvIkaWwpqw==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Converters": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "j/24+iBF7WFeciFsXcHWmMtzZFElwnI/CYa5TpVv7pR7jqk89L7RCg6BoSKl2I3zPyz6FLMc4NmrXSytG3fZ5g==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "YRWhr/lSmHRHWZ7HhwvUILwhh1SkUv2xliUEdoV9jZ5CvnA6IzSH94qaLDjLthgczFFOliN1oAjCbzUu8qvEWQ==",
         "dependencies": {
           "CommunityToolkit.Common": "8.2.1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Extensions": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "e0fuTXaeGvOttazZDpwJ/avaK8Coax7Mk9HTYywF4T1fvXZCLpmVLRuftajFK2rhQ85qOYuUKbh2FeSkeli0cg==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "7l+22QHfDcyU4SqpfIci4Sl+XcT7oFxsxI2KYitUHg4lo922cMCK70L9v6EgM8z+H4IAFF9HqPcKSDehvbZtWw==",
         "dependencies": {
           "CommunityToolkit.Common": "8.2.1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Media": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "rncwi8UKkjVfpVU1ISJdomOF3vjkgiki2RRL4o0qk2mtEyjRl9EJckIak1ExOEjjLGNTKV5CfZcypUl0d9Xv4Q==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "TZ6HBnBbH+zqhpxDSJH8b1Mg5jwAWBh3eYrkThMOahYejwI5O4zHj8KTnsf0hsSUxs6JGKhW1Y6hdY4vip3u7Q==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Animations": "8.2.241112-preview1",
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.Graphics.Win2D": "1.3.0",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Animations": "8.2.250129-preview2",
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.Graphics.Win2D": "1.3.1",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "GitInfo": {
@@ -177,11 +177,11 @@
       },
       "Microsoft.Xaml.Behaviors.WinUI.Managed": {
         "type": "Direct",
-        "requested": "[3.0.0-preview2, )",
-        "resolved": "3.0.0-preview2",
-        "contentHash": "ydrS5vI5O+n2cOHXBqJlvqHnim6KwxSapmDhnsCNr8FuPHgb9yJ/GuTqgomQa/FD1ndkwhKUrOoVOfmYOfkBdw==",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "IoeGOYbOvhnNlzYs79z2TB1EFVldlQKJHH1gjUMtrViu+MJZfnkyNeCiK1IBVo8zP86VuFPZ4Yg6Vm4mYJ8tGA==",
         "dependencies": {
-          "Microsoft.WindowsAppSDK": "1.6.241114003"
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "PhotoSauce.MagicScaler": {
@@ -282,29 +282,29 @@
       },
       "CommunityToolkit.WinUI.Animations": {
         "type": "Transitive",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "DXE3iLN7GItrXSuLEffnIN4NEooytXwkpeza0ghR9eh2F9c7K+cG+7WH4BK3TMkdIqNvE54l23Rx0K9glFdcyg==",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "vtE26jwwxVLl3/032fLDly1PE1c7kOKK6dGZ4nKeyfqsch9NsW0BWvzfsVy2YgqQe0EJpYU0aN544tc5/raNQw==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Helpers": {
         "type": "Transitive",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "sSYI2RUIfDXG0yPbdtaMmhoNCKWCu+0/Ba7hUlqnCWvH8z1NwkjG735202JrrBSXE2P+E51WGSMY8PJ+lIIUow==",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "EcqFmIFwpNgZgmOJUil58Z40YwO2DcZRUeF5tXaLxaHOFXiL/Zo2ISvw6wNlhMAsVBmMizSzYSKKL+A3yxJ5xg==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Triggers": {
         "type": "Transitive",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "m2WuTUDrCvZql51LyeTAAl5XM5/ehwjNx3Da9pJsgTVXRCJTq5Ywd3qxH/O2PTqu703EdZNf6Cq5fke5X4c4dw==",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "IzGOB0qbb2uNzBc/RytfLqGG5qQUCs2j95RcCpGg6R8CFilPNwHyJdd8etGOmw4oWVaUvXHbDeAH2Swy9595VQ==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Helpers": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Helpers": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "Google.Protobuf": {
@@ -482,8 +482,8 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Common": "[8.4.0, )",
-          "CommunityToolkit.WinUI.Extensions": "[8.2.241112-preview1, )",
-          "CommunityToolkit.WinUI.Media": "[8.2.241112-preview1, )",
+          "CommunityToolkit.WinUI.Extensions": "[8.2.250129-preview2, )",
+          "CommunityToolkit.WinUI.Media": "[8.2.250129-preview2, )",
           "Microsoft.Graphics.Win2D": "[1.3.1, )",
           "Microsoft.NET.ILLink.Tasks": "[9.0.1, )",
           "Microsoft.Web.WebView2": "[1.0.2957.106, )",
@@ -496,7 +496,7 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Common": "[8.4.0, )",
-          "CommunityToolkit.WinUI.Extensions": "[8.2.241112-preview1, )",
+          "CommunityToolkit.WinUI.Extensions": "[8.2.250129-preview2, )",
           "Microsoft.Web.WebView2": "[1.0.2957.106, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "Microsoft.WindowsAppSDK": "[1.6.250108002, )"
@@ -513,7 +513,7 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Common": "[8.4.0, )",
-          "CommunityToolkit.WinUI.Triggers": "[8.2.241112-preview1, )",
+          "CommunityToolkit.WinUI.Triggers": "[8.2.250129-preview2, )",
           "Microsoft.NET.ILLink.Tasks": "[9.0.1, )",
           "Microsoft.Web.WebView2": "[1.0.2957.106, )",
           "Microsoft.Windows.CsWinRT": "[2.2.0, )",

--- a/Hi3Helper.CommunityToolkit/ImageCropper/Hi3Helper.CommunityToolkit.WinUI.Controls.ImageCropper.csproj
+++ b/Hi3Helper.CommunityToolkit/ImageCropper/Hi3Helper.CommunityToolkit.WinUI.Controls.ImageCropper.csproj
@@ -40,8 +40,8 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
 		<PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-		<PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.241112-preview1" />
-		<PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.241112-preview1" />
+		<PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.250129-preview2" />
+		<PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Hi3Helper.CommunityToolkit/ImageCropper/packages.lock.json
+++ b/Hi3Helper.CommunityToolkit/ImageCropper/packages.lock.json
@@ -10,24 +10,24 @@
       },
       "CommunityToolkit.WinUI.Extensions": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "e0fuTXaeGvOttazZDpwJ/avaK8Coax7Mk9HTYywF4T1fvXZCLpmVLRuftajFK2rhQ85qOYuUKbh2FeSkeli0cg==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "7l+22QHfDcyU4SqpfIci4Sl+XcT7oFxsxI2KYitUHg4lo922cMCK70L9v6EgM8z+H4IAFF9HqPcKSDehvbZtWw==",
         "dependencies": {
           "CommunityToolkit.Common": "8.2.1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Media": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "rncwi8UKkjVfpVU1ISJdomOF3vjkgiki2RRL4o0qk2mtEyjRl9EJckIak1ExOEjjLGNTKV5CfZcypUl0d9Xv4Q==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "TZ6HBnBbH+zqhpxDSJH8b1Mg5jwAWBh3eYrkThMOahYejwI5O4zHj8KTnsf0hsSUxs6JGKhW1Y6hdY4vip3u7Q==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Animations": "8.2.241112-preview1",
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.Graphics.Win2D": "1.3.0",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Animations": "8.2.250129-preview2",
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.Graphics.Win2D": "1.3.1",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "Microsoft.Graphics.Win2D": {
@@ -75,11 +75,11 @@
       },
       "CommunityToolkit.WinUI.Animations": {
         "type": "Transitive",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "DXE3iLN7GItrXSuLEffnIN4NEooytXwkpeza0ghR9eh2F9c7K+cG+7WH4BK3TMkdIqNvE54l23Rx0K9glFdcyg==",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "vtE26jwwxVLl3/032fLDly1PE1c7kOKK6dGZ4nKeyfqsch9NsW0BWvzfsVy2YgqQe0EJpYU0aN544tc5/raNQw==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       }
     },

--- a/Hi3Helper.CommunityToolkit/SettingsControls/Hi3Helper.CommunityToolkit.WinUI.Controls.SettingsControls.csproj
+++ b/Hi3Helper.CommunityToolkit/SettingsControls/Hi3Helper.CommunityToolkit.WinUI.Controls.SettingsControls.csproj
@@ -34,7 +34,7 @@
 
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
-        <PackageReference Include="CommunityToolkit.WinUI.Triggers" Version="8.2.241112-preview1" />
+        <PackageReference Include="CommunityToolkit.WinUI.Triggers" Version="8.2.250129-preview2" />
         <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.1" />
         <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />

--- a/Hi3Helper.CommunityToolkit/SettingsControls/packages.lock.json
+++ b/Hi3Helper.CommunityToolkit/SettingsControls/packages.lock.json
@@ -10,12 +10,12 @@
       },
       "CommunityToolkit.WinUI.Triggers": {
         "type": "Direct",
-        "requested": "[8.2.241112-preview1, )",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "m2WuTUDrCvZql51LyeTAAl5XM5/ehwjNx3Da9pJsgTVXRCJTq5Ywd3qxH/O2PTqu703EdZNf6Cq5fke5X4c4dw==",
+        "requested": "[8.2.250129-preview2, )",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "IzGOB0qbb2uNzBc/RytfLqGG5qQUCs2j95RcCpGg6R8CFilPNwHyJdd8etGOmw4oWVaUvXHbDeAH2Swy9595VQ==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Helpers": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Helpers": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "Microsoft.NET.ILLink.Tasks": {
@@ -54,20 +54,20 @@
       },
       "CommunityToolkit.WinUI.Extensions": {
         "type": "Transitive",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "e0fuTXaeGvOttazZDpwJ/avaK8Coax7Mk9HTYywF4T1fvXZCLpmVLRuftajFK2rhQ85qOYuUKbh2FeSkeli0cg==",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "7l+22QHfDcyU4SqpfIci4Sl+XcT7oFxsxI2KYitUHg4lo922cMCK70L9v6EgM8z+H4IAFF9HqPcKSDehvbZtWw==",
         "dependencies": {
           "CommunityToolkit.Common": "8.2.1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
       "CommunityToolkit.WinUI.Helpers": {
         "type": "Transitive",
-        "resolved": "8.2.241112-preview1",
-        "contentHash": "sSYI2RUIfDXG0yPbdtaMmhoNCKWCu+0/Ba7hUlqnCWvH8z1NwkjG735202JrrBSXE2P+E51WGSMY8PJ+lIIUow==",
+        "resolved": "8.2.250129-preview2",
+        "contentHash": "EcqFmIFwpNgZgmOJUil58Z40YwO2DcZRUeF5tXaLxaHOFXiL/Zo2ISvw6wNlhMAsVBmMizSzYSKKL+A3yxJ5xg==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.241112-preview1",
-          "Microsoft.WindowsAppSDK": "1.6.240923002"
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       }
     },

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -362,6 +362,8 @@
     "SpecVeryHigh": "非常高",
     "SpecMaximum": "最高",
     "SpecUltra": "极高",
+    "SpecDynamic": "动态",
+    "SpecGlobal": "全局",
 
     "Audio_Title": "音频设置",
     "Audio_Master": "主音量",

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
 [<img src="https://user-images.githubusercontent.com/30566970/172445052-b0e62327-1d2e-4663-bc0f-af50c7f23615.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.14/CollapseLauncher-stable-Setup.exe)
 > **Note**: The version for this build is `1.82.14` (Released on: January 14th, 2025).
 
-[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.14-pre/CollapseLauncher-preview-Setup.exe)
-> **Note**: The version for this build is `1.82.14` (Released on: January 14th, 2025).
+[<img src="https://user-images.githubusercontent.com/30566970/172445153-d098de0d-1236-4124-8e13-05000b374eb6.svg" width="320"/>](https://github.com/CollapseLauncher/Collapse/releases/download/CL-v1.82.15-pre/CollapseLauncher-preview-Setup.exe)
+> **Note**: The version for this build is `1.82.15` (Released on: January 28th, 2025).
 
 To view all releases, [**click here**](https://github.com/neon-nyan/CollapseLauncher/releases).
 


### PR DESCRIPTION
# What's changed? - 1.82.16
- **[Fix]** Errors when updating game that uses HDiff, by @neon-nyan 
- **[Imp]** Update dependencies, by @neon-nyan
- **[Imp]** Reduce CPU overhead by swapping ``SoftwareBitmap`` to ``CanvasDevice`` and ``CanvasBitmap`` to draw video frames while "Acrylic Effect" mode enabled.
  - This reduces CPU overhead by removing routines to copy the video frames from software-based ``SoftwareBitmap``, and instead use Direct3D-based ``CanvasBitmap`` as the frame source.
  - However, this improvement still runs single-threaded due to the copy routine still being done on the same thread as the UI thread.
- **[Imp]** Execute metadata config download and loading in parallel.
  - Instead of running the metadata download/update/load routine sequentially, the process will now be running in parallel at the same time. Making the metadata loading runs faster.
- **[Imp]** Reduce UI hangs while switching between regions.

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
