### PR TITLE
Prevent closing app while doing critical process

### DIFF
--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -466,7 +466,7 @@ namespace CollapseLauncher.Helper
                                     // Deal with close message from system shell.
                                     if (CurrentWindow is MainWindow mainWindow)
                                     {
-                                        mainWindow.CloseApp();
+                                        _ = mainWindow.CloseApp();
                                     }
                                     return 0;
                                 }

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -139,7 +139,7 @@ namespace CollapseLauncher
                 if (!await CheckForAdminAccess(this))
                 {
                     if (WindowUtility.CurrentWindow is MainWindow mainWindow)
-                        mainWindow.CloseApp();
+                        _ = mainWindow.CloseApp();
                     return;
                 }
 

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -260,8 +260,7 @@ namespace CollapseLauncher
         {
             if (IsCriticalOpInProgress)
             {
-                var ensure = await Dialog_EnsureExit(Content);
-                if (ensure != ContentDialogResult.Primary)
+                if (await Dialog_EnsureExit(Content) != ContentDialogResult.Primary)
                     return;
             }
             SentryHelper.StopSentrySdk();

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -251,12 +251,12 @@ namespace CollapseLauncher
             WindowUtility.WindowMinimize();
         }
 
-        private void CloseButton_Click(object sender, RoutedEventArgs e) => CloseApp();
+        private void CloseButton_Click(object sender, RoutedEventArgs e) => _ = CloseApp();
         
         /// <summary>
         /// Close app and do necessary events before closing
         /// </summary>
-        public async void CloseApp()
+        public async Task CloseApp()
         {
             if (IsCriticalOpInProgress)
             {

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using Microsoft.UI.Xaml.Media.Animation;
 using System;
 using System.Threading.Tasks;
 using Windows.UI;
+using static CollapseLauncher.Dialogs.SimpleDialogs;
 using static CollapseLauncher.InnerLauncherConfig;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
@@ -32,6 +33,8 @@ namespace CollapseLauncher
     public sealed partial class MainWindow : Window
     {
         private static bool _isForceDisableIntro;
+        
+        public static bool IsCriticalOpInProgress { get; set; }
 
         public void InitializeWindowProperties(bool startOobe = false)
         {
@@ -253,8 +256,14 @@ namespace CollapseLauncher
         /// <summary>
         /// Close app and do necessary events before closing
         /// </summary>
-        public void CloseApp()
+        public async void CloseApp()
         {
+            if (IsCriticalOpInProgress)
+            {
+                var ensure = await Dialog_EnsureExit(Content);
+                if (ensure != ContentDialogResult.Primary)
+                    return;
+            }
             SentryHelper.StopSentrySdk();
             _TrayIcon?.Dispose();
             Close();

--- a/CollapseLauncher/XAMLs/MainApp/Pages/CachesPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/CachesPage.xaml.cs
@@ -58,6 +58,7 @@ namespace CollapseLauncher.Pages
                     SetMainCheckUpdateBtnProperty(sender);
                 }
 
+                MainWindow.IsCriticalOpInProgress = true;
                 Sleep.PreventSleep(ILoggerHelper.GetILogger());
                 AddEvent();
 
@@ -98,6 +99,7 @@ namespace CollapseLauncher.Pages
             {
                 RemoveEvent();
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
             }
         }
 
@@ -108,6 +110,7 @@ namespace CollapseLauncher.Pages
                 UpdateCachesBtn.IsEnabled = false;
                 CancelBtn.IsEnabled       = true;
 
+                MainWindow.IsCriticalOpInProgress = true;
                 Sleep.PreventSleep(ILoggerHelper.GetILogger());
                 AddEvent();
 
@@ -147,6 +150,7 @@ namespace CollapseLauncher.Pages
             finally
             {
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
                 RemoveEvent();
             }
         }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -855,6 +855,16 @@ namespace CollapseLauncher.Dialogs
                         Lang._Misc.Cancel,
                         ContentDialogButton.Secondary,
                         ContentDialogTheme.Error);
+        
+        public static Task<ContentDialogResult> Dialog_EnsureExit(UIElement content) =>
+            SpawnDialog(Lang._Dialogs.EnsureExitTitle,
+                        Lang._Dialogs.EnsureExitSubtitle,
+                        content,
+                        Lang._Misc.NoCancel,
+                        Lang._Misc.Yes,
+                        null,
+                        ContentDialogButton.Close,
+                        ContentDialogTheme.Warning);
 
         public static Task<ContentDialogResult> Dialog_ClearMetadata(UIElement content) =>
             SpawnDialog(string.Format(Lang._SettingsPage.AppFiles_ClearMetadataDialog),

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -1268,6 +1268,7 @@ namespace CollapseLauncher.Pages
 
             try
             {
+                MainWindow.IsCriticalOpInProgress = true;
                 // Prevent device from sleep
                 Sleep.PreventSleep(ILoggerHelper.GetILogger());
                 // Set the notification trigger to "Running" state
@@ -1356,6 +1357,7 @@ namespace CollapseLauncher.Pages
 
                 // Turn the sleep back on
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
             }
         }
 
@@ -1392,6 +1394,7 @@ namespace CollapseLauncher.Pages
             bool isUseSophon = CurrentGameProperty.GameInstall.IsUseSophon;
             try
             {
+                MainWindow.IsCriticalOpInProgress = true;
                 // Prevent device from sleep
                 Sleep.PreventSleep(ILoggerHelper.GetILogger());
                 // Set the notification trigger to "Running" state
@@ -1562,6 +1565,7 @@ namespace CollapseLauncher.Pages
 
                 // Turn the sleep back on
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
             }
         }
 
@@ -2634,6 +2638,7 @@ namespace CollapseLauncher.Pages
 
             try
             {
+                MainWindow.IsCriticalOpInProgress = true;
                 // Prevent device from sleep
                 Sleep.PreventSleep(ILoggerHelper.GetILogger());
                 // Set the notification trigger to "Running" state
@@ -2741,6 +2746,7 @@ namespace CollapseLauncher.Pages
 
                 // Turn the sleep back on
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
             }
         }
         #endregion

--- a/CollapseLauncher/XAMLs/MainApp/Pages/RepairPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/RepairPage.xaml.cs
@@ -47,6 +47,7 @@ namespace CollapseLauncher.Pages
 
         private async void RunCheckRoutine(object sender, bool isFast, bool isMainButton)
         {
+            MainWindow.IsCriticalOpInProgress = true;
             Sleep.PreventSleep(ILoggerHelper.GetILogger());
             
             CheckFilesBtn.Flyout.Hide();
@@ -99,6 +100,7 @@ namespace CollapseLauncher.Pages
             {
                 RemoveEvent();
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
             }
         }
 
@@ -106,6 +108,7 @@ namespace CollapseLauncher.Pages
         {
             try
             {
+                MainWindow.IsCriticalOpInProgress = true;
                 Sleep.PreventSleep(ILoggerHelper.GetILogger());
                 RepairFilesBtn.IsEnabled = false;
                 CancelBtn.IsEnabled = true;
@@ -149,6 +152,7 @@ namespace CollapseLauncher.Pages
             {
                 RemoveEvent();
                 Sleep.RestoreSleep();
+                MainWindow.IsCriticalOpInProgress = false;
             }
         }
 

--- a/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
@@ -194,6 +194,8 @@ namespace Hi3Helper
                 public string UACWarningContent { get; set; } = LangFallback?._Dialogs.UACWarningContent;
                 public string UACWarningLearnMore { get; set; } = LangFallback?._Dialogs.UACWarningLearnMore;
                 public string UACWarningDontShowAgain { get; set; } = LangFallback?._Dialogs.UACWarningDontShowAgain;
+                public string EnsureExitTitle { get; set; } = LangFallback?._Dialogs.EnsureExitTitle;
+                public string EnsureExitSubtitle { get; set; } = LangFallback?._Dialogs.EnsureExitSubtitle;
             }
         }
         #endregion

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -1014,7 +1014,10 @@
     "UACWarningTitle": "Warning: UAC Disabled Detected",
     "UACWarningContent": "Disabling User Account Control (UAC) is never a good idea.\nThe security of the OS will be compromised and the game may not run properly.\n\nClick the \"Learn More\" button to see how to enable UAC.\nThe related entry is: Run all administrators in Admin Approval Mode.",
     "UACWarningLearnMore": "Learn More",
-    "UACWarningDontShowAgain": "Don't Show Again"
+    "UACWarningDontShowAgain": "Don't Show Again",
+    
+    "EnsureExitTitle": "Exiting Application",
+    "EnsureExitSubtitle": "There are critical operations running in the background. Are you sure you want to exit?"
   },
 
   "_FileMigrationProcess": {


### PR DESCRIPTION
# Main Goal
Show dialog confirming user before exiting app while critical process is happening
![image](https://github.com/user-attachments/assets/4d99705f-d4c6-4942-8ccd-17f8db3c7bc6)

Close #671 

Currently implemented in:
- Game Install
- Game Update
- Cache Update
- Game Repair

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0


## Sidenote:
- Bug found when making this PR, unrelated to the PR itself
When closing app while some UI progress is happening, there is a chance that it throws bunch of errors on XAML thread before it exit
![image](https://github.com/user-attachments/assets/fc94c1a2-0aae-4ead-a8aa-7d6a5e76ebb5)

![image](https://github.com/user-attachments/assets/e97de441-f552-4af5-abcd-de8819ff5863)

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
