### PR TITLE
Add Anisotropic Sampling option to ZZZ GSP

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Enums.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Enums.cs
@@ -151,6 +151,20 @@ public enum AudioPlaybackDevice
     TV = 3
 }
 
+/// <summary>
+///  Available options for graphics settings that have 5 options <br/>
+/// 1x, 2x, 4x, 8x, 16x
+/// Default : 8x [3]
+/// </summary>
+public enum AnisotropicSamplingOption
+{
+    x1,
+    x2,
+    x4,
+    x8,
+    x16
+}
+
 public static class ServerName
 {
     public const string Europe   = "prod_gf_eu";

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
@@ -499,7 +499,24 @@ namespace CollapseLauncher.GameSettings.Zenless
             .GetDataEnum<QualityOption2>();
             set => _envQualityData?.SetDataEnum(value);
         }
-
+        
+        // Key 16184 Anisotropic Sampling
+        private SystemSettingLocalData<AnisotropicSamplingOption>? _anisotropicSamplingData;
+        
+        /// <summary>
+        ///     Sets the in-game quality settings for Anisotropic Sampling
+        /// </summary>
+        /// <see cref="AnisotropicSamplingOption"/>
+        
+        [JsonIgnore]
+        public AnisotropicSamplingOption AnisotropicSampling
+        {
+            get => (_anisotropicSamplingData ??= SystemSettingDataMap
+            .AsSystemSettingLocalData("16184", AnisotropicSamplingOption.x8))
+            .GetDataEnum<AnisotropicSamplingOption>();
+            set => _anisotropicSamplingData?.SetDataEnum(value);
+        }
+        
         // Key 12155 Global Illumination
         private SystemSettingLocalData<QualityOption3>? _envGlobalIllumination;
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
@@ -507,7 +507,6 @@ namespace CollapseLauncher.GameSettings.Zenless
         ///     Sets the in-game quality settings for Anisotropic Sampling
         /// </summary>
         /// <see cref="AnisotropicSamplingOption"/>
-        
         [JsonIgnore]
         public AnisotropicSamplingOption AnisotropicSampling
         {

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.Ext.cs
@@ -48,6 +48,7 @@ namespace CollapseLauncher.Pages
                     ShadingQualitySelector.SelectedIndex     = (int)QualityOption3.High;
                     CharacterQualitySelector.SelectedIndex   = (int)QualityOption2.High;
                     EnvironmentQualitySelector.SelectedIndex = (int)QualityOption2.High;
+                    AnisotropicSamplingSelector.SelectedIndex = (int)AnisotropicSamplingOption.x8;
                     ReflectionQualitySelector.SelectedIndex  = (int)QualityOption4.High;
                     VolumetricFogSelector.SelectedIndex      = (int)QualityOption4.High;
                     HpcaSelector.SelectedIndex               = (int)HiPrecisionCharaAnimOption.Dynamic;
@@ -56,38 +57,40 @@ namespace CollapseLauncher.Pages
                     MotionBlurToggle.IsChecked               = true;
                     break;
                 case GraphicsPresetOption.Medium:
-                    VSyncToggle.IsChecked                    = true;
-                    RenderResolutionSelector.SelectedIndex   = (int)RenderResOption.f10;
-                    AntiAliasingSelector.SelectedIndex       = (int)AntiAliasingOption.TAA;
-                    GlobalIlluminationSelector.SelectedIndex = (int)QualityOption3.High;
-                    ShadowQualitySelector.SelectedIndex      = (int)QualityOption3.High;
-                    FxQualitySelector.SelectedIndex          = (int)QualityOption5.Medium;
-                    ShadingQualitySelector.SelectedIndex     = (int)QualityOption3.High;
-                    CharacterQualitySelector.SelectedIndex   = (int)QualityOption2.High;
-                    EnvironmentQualitySelector.SelectedIndex = (int)QualityOption2.High;
-                    ReflectionQualitySelector.SelectedIndex  = (int)QualityOption4.Medium;
-                    VolumetricFogSelector.SelectedIndex      = (int)QualityOption4.Medium;
-                    HpcaSelector.SelectedIndex               = (int)HiPrecisionCharaAnimOption.Off;
-                    BloomToggle.IsChecked                    = true;
-                    DistortionToggle.IsChecked               = true;
-                    MotionBlurToggle.IsChecked               = true;
+                    VSyncToggle.IsChecked                     = true;
+                    RenderResolutionSelector.SelectedIndex    = (int)RenderResOption.f10;
+                    AntiAliasingSelector.SelectedIndex        = (int)AntiAliasingOption.TAA;
+                    GlobalIlluminationSelector.SelectedIndex  = (int)QualityOption3.High;
+                    ShadowQualitySelector.SelectedIndex       = (int)QualityOption3.High;
+                    FxQualitySelector.SelectedIndex           = (int)QualityOption5.Medium;
+                    ShadingQualitySelector.SelectedIndex      = (int)QualityOption3.High;
+                    CharacterQualitySelector.SelectedIndex    = (int)QualityOption2.High;
+                    EnvironmentQualitySelector.SelectedIndex  = (int)QualityOption2.High;
+                    AnisotropicSamplingSelector.SelectedIndex = (int)AnisotropicSamplingOption.x8;
+                    ReflectionQualitySelector.SelectedIndex   = (int)QualityOption4.Medium;
+                    VolumetricFogSelector.SelectedIndex       = (int)QualityOption4.Medium;
+                    HpcaSelector.SelectedIndex                = (int)HiPrecisionCharaAnimOption.Off;
+                    BloomToggle.IsChecked                     = true;
+                    DistortionToggle.IsChecked                = true;
+                    MotionBlurToggle.IsChecked                = true;
                     break;
                 case GraphicsPresetOption.Low:
-                    VSyncToggle.IsChecked                    = true;
-                    RenderResolutionSelector.SelectedIndex   = (int)RenderResOption.f10;
-                    AntiAliasingSelector.SelectedIndex       = (int)AntiAliasingOption.TAA;
-                    GlobalIlluminationSelector.SelectedIndex = (int)QualityOption3.Low;
-                    ShadowQualitySelector.SelectedIndex      = (int)QualityOption3.Medium;
-                    FxQualitySelector.SelectedIndex          = (int)QualityOption5.Low;
-                    ShadingQualitySelector.SelectedIndex     = (int)QualityOption3.High;
-                    CharacterQualitySelector.SelectedIndex   = (int)QualityOption2.High;
-                    EnvironmentQualitySelector.SelectedIndex = (int)QualityOption2.High;
-                    ReflectionQualitySelector.SelectedIndex  = (int)QualityOption4.Low;
-                    VolumetricFogSelector.SelectedIndex      = (int)QualityOption4.Low;
-                    HpcaSelector.SelectedIndex               = (int)HiPrecisionCharaAnimOption.Off;
-                    BloomToggle.IsChecked                    = true;
-                    DistortionToggle.IsChecked               = true;
-                    MotionBlurToggle.IsChecked               = true;
+                    VSyncToggle.IsChecked                     = true;
+                    RenderResolutionSelector.SelectedIndex    = (int)RenderResOption.f10;
+                    AntiAliasingSelector.SelectedIndex        = (int)AntiAliasingOption.TAA;
+                    GlobalIlluminationSelector.SelectedIndex  = (int)QualityOption3.Low;
+                    ShadowQualitySelector.SelectedIndex       = (int)QualityOption3.Medium;
+                    FxQualitySelector.SelectedIndex           = (int)QualityOption5.Low;
+                    ShadingQualitySelector.SelectedIndex      = (int)QualityOption3.High;
+                    CharacterQualitySelector.SelectedIndex    = (int)QualityOption2.High;
+                    EnvironmentQualitySelector.SelectedIndex  = (int)QualityOption2.High;
+                    AnisotropicSamplingSelector.SelectedIndex = (int)AnisotropicSamplingOption.x8;
+                    ReflectionQualitySelector.SelectedIndex   = (int)QualityOption4.Low;
+                    VolumetricFogSelector.SelectedIndex       = (int)QualityOption4.Low;
+                    HpcaSelector.SelectedIndex                = (int)HiPrecisionCharaAnimOption.Off;
+                    BloomToggle.IsChecked                     = true;
+                    DistortionToggle.IsChecked                = true;
+                    MotionBlurToggle.IsChecked                = true;
                     break;
             }
 
@@ -561,6 +564,12 @@ namespace CollapseLauncher.Pages
         {
             get => (int)Settings.GeneralData.EnvironmentQuality;
             set => Settings.GeneralData.EnvironmentQuality = (QualityOption2)value;
+        }
+        
+        public int Graphics_AnisotropicSampling
+        {
+            get => (int)Settings.GeneralData.AnisotropicSampling;
+            set => Settings.GeneralData.AnisotropicSampling = (AnisotropicSamplingOption)value;
         }
 
         public int Graphics_GlobalIllumination

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
@@ -465,6 +465,25 @@
                                     <TextBlock Margin="0,0,8,8"
                                                HorizontalAlignment="Left"
                                                Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                               Text="{x:Bind helper:Locale.Lang._ZenlessGameSettingsPage.Graphics_AnisotropicSampling}"
+                                               TextWrapping="WrapWholeWords" />
+                                    <ComboBox x:Name="AnisotropicSamplingSelector"
+                                              Margin="0,0,16,8"
+                                              HorizontalAlignment="Stretch"
+                                              CornerRadius="14"
+                                              SelectedIndex="{x:Bind Graphics_AnisotropicSampling, Mode=TwoWay}"
+                                              SelectionChanged="EnforceCustomPreset_ComboBox">
+                                        <ComboBoxItem Content="1x" />
+                                        <ComboBoxItem Content="2x" />
+                                        <ComboBoxItem Content="4x" />
+                                        <ComboBoxItem Content="8x" />
+                                        <ComboBoxItem Content="16x" />
+                                    </ComboBox>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1">
+                                    <TextBlock Margin="0,0,8,8"
+                                               HorizontalAlignment="Left"
+                                               Style="{ThemeResource BodyStrongTextBlockStyle}"
                                                Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_GlobalIllumination}"
                                                TextWrapping="WrapWholeWords" />
                                     <ComboBox x:Name="GlobalIlluminationSelector"
@@ -479,7 +498,7 @@
                                         <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecHigh}" />
                                     </ComboBox>
                                 </StackPanel>
-                                <StackPanel Grid.Column="1">
+                                <StackPanel Grid.Column="2">
                                     <TextBlock Margin="0,0,8,8"
                                                HorizontalAlignment="Left"
                                                Style="{ThemeResource BodyStrongTextBlockStyle}"

--- a/Hi3Helper.Core/Lang/Locale/LangZenlessGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangZenlessGameSettingsPage.cs
@@ -31,7 +31,7 @@ namespace Hi3Helper
                     LangFallback?._ZenlessGameSettingsPage.Graphics_Distortion;
 
                 public string Graphics_AnisotropicSampling { get; set; } =
-                    LangFallback?._ZenlessGameSettingsPage.Graphics_AnisotropicSampling;
+                    LangFallback?._GenshinGameSettingsPage.Graphics_AnisotropicFiltering;
                 
                 public string Graphics_HighPrecisionCharacterAnimation { get; set; } =
                     LangFallback?._ZenlessGameSettingsPage.Graphics_HighPrecisionCharacterAnimation;

--- a/Hi3Helper.Core/Lang/Locale/LangZenlessGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangZenlessGameSettingsPage.cs
@@ -30,6 +30,9 @@ namespace Hi3Helper
                 public string Graphics_Distortion { get; set; } =
                     LangFallback?._ZenlessGameSettingsPage.Graphics_Distortion;
 
+                public string Graphics_AnisotropicSampling { get; set; } =
+                    LangFallback?._ZenlessGameSettingsPage.Graphics_AnisotropicSampling;
+                
                 public string Graphics_HighPrecisionCharacterAnimation { get; set; } =
                     LangFallback?._ZenlessGameSettingsPage.Graphics_HighPrecisionCharacterAnimation;
 

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -1574,7 +1574,6 @@
     "Graphics_EffectsQ": "Effects Quality",
     "Graphics_ShadingQ": "Shading Quality",
     "Graphics_Distortion": "Distortion",
-    "Graphics_AnisotropicSampling": "Anisotropic Sampling",
     "Graphics_HighPrecisionCharacterAnimation": "High-Precision Character Animation",
     "Audio_PlaybackDev": "Audio Playback Device",
     "Audio_PlaybackDev_Headphones": "Headphones",

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -1574,6 +1574,7 @@
     "Graphics_EffectsQ": "Effects Quality",
     "Graphics_ShadingQ": "Shading Quality",
     "Graphics_Distortion": "Distortion",
+    "Graphics_AnisotropicSampling": "Anisotropic Sampling",
     "Graphics_HighPrecisionCharacterAnimation": "High-Precision Character Animation",
     "Audio_PlaybackDev": "Audio Playback Device",
     "Audio_PlaybackDev_Headphones": "Headphones",


### PR DESCRIPTION
AKA Anisotropic Filtering, but kept the in-game name for clarity. All presets seem to not change the value, keeping it at x8.

# Main Goal
Update ZZZ GSP so that it is in parity with the in-game options.

## PR Status :
- Overall Status : Done ✅ 
- Commits : Done ✅ 
- Synced to base (Collapse:main) : Yes ✅ 
- Build status : OK ✅ 
- Crashing : No

## Changes:
-  **[New]** Added new dropdown menu for Anisotropic Sampling option (x1, x2, x4, x8, x16), with x8 as default
      -   **[Loc]** Added new i18n string for option
