### PR TITLE
[Imp] Implement new Sophon Patch Mode

### DIFF
--- a/CollapseLauncher/Classes/GamePresetProperty.cs
+++ b/CollapseLauncher/Classes/GamePresetProperty.cs
@@ -66,7 +66,7 @@ namespace CollapseLauncher
                     GameVersion = new GameTypeGenshinVersion(ApiResourceProp, gameName, gameRegion);
                     GameSettings = new GenshinSettings(GameVersion);
                     GameCache = null;
-                    GameRepair = new GenshinRepair(uiElementParent, GameVersion, GameVersion.GameApiProp.data!.game!.latest!.decompressed_path);
+                    GameRepair = new GenshinRepair(uiElementParent, GameVersion, GameVersion.GameApiProp.data?.game?.latest?.decompressed_path ?? "");
                     GameInstall = new GenshinInstall(uiElementParent, GameVersion);
                     break;
                 case GameNameType.Zenless:

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
@@ -223,20 +223,21 @@ namespace CollapseLauncher.InstallManager.Base
                                                                              Token.Token);
 
                         // Ensure that the manifest is ordered based on _gameVoiceLanguageLocaleIdOrdered
-                        RearrangeSophonDataLocaleOrder(sophonMainInfoPair.OtherSophonData);
+                        RearrangeDataListLocaleOrder(sophonMainInfoPair.OtherSophonBuildData.ManifestIdentityList,
+                                                     x => x.MatchingField);
 
                         // Add the manifest to the pair list
                         sophonInfoPairList.Add(sophonMainInfoPair);
 
                         List<string> voLanguageList =
-                            GetSophonLanguageDisplayDictFromVoicePackList(sophonMainInfoPair.OtherSophonData);
+                            GetSophonLanguageDisplayDictFromVoicePackList(sophonMainInfoPair.OtherSophonBuildData);
 
                         // Get Audio Choices first.
                         // If the fallbackFromUpdate flag is set, then don't show the dialog and instead
                         // use the default language (ja-jp) as the fallback and read the existing audio_lang file
                         List<int>? addedVo;
                         int setAsDefaultVo = GetSophonLocaleCodeIndex(
-                                              sophonMainInfoPair.OtherSophonData,
+                                              sophonMainInfoPair.OtherSophonBuildData,
                                               "ja-jp"
                                              );
 
@@ -265,7 +266,7 @@ namespace CollapseLauncher.InstallManager.Base
                                     }
 
                                     int voLocaleIndex = GetSophonLocaleCodeIndex(
-                                         sophonMainInfoPair.OtherSophonData,
+                                         sophonMainInfoPair.OtherSophonBuildData,
                                          voLocaleId
                                         );
                                     addedVo.Add(voLocaleIndex);
@@ -888,8 +889,10 @@ namespace CollapseLauncher.InstallManager.Base
             }
 
             // Ensure that the manifest is ordered based on _gameVoiceLanguageLocaleIdOrdered
-            RearrangeSophonDataLocaleOrder(requestPairFrom.OtherSophonData);
-            RearrangeSophonDataLocaleOrder(requestPairTo.OtherSophonData);
+            RearrangeDataListLocaleOrder(requestPairFrom.OtherSophonBuildData.ManifestIdentityList,
+                                         x => x.MatchingField);
+            RearrangeDataListLocaleOrder(requestPairTo.OtherSophonBuildData.ManifestIdentityList,
+                                         x => x.MatchingField);
 
             // Add asset to the list
             await foreach (SophonAsset sophonAsset in SophonUpdate
@@ -977,7 +980,7 @@ namespace CollapseLauncher.InstallManager.Base
 
         #region Sophon Audio/Voice-Packs Locale Methods
 
-        protected virtual int GetSophonLocaleCodeIndex(SophonData sophonData, string lookupName)
+        protected virtual int GetSophonLocaleCodeIndex(SophonManifestBuildData sophonData, string lookupName)
         {
             List<string> localeList = sophonData.ManifestIdentityList
                                                 .Where(x => IsValidLocaleCode(x.MatchingField))
@@ -988,7 +991,7 @@ namespace CollapseLauncher.InstallManager.Base
             return Math.Max(0, index);
         }
 
-        protected virtual List<string> GetSophonLanguageDisplayDictFromVoicePackList(SophonData sophonData)
+        protected virtual List<string> GetSophonLanguageDisplayDictFromVoicePackList(SophonManifestBuildData sophonData)
         {
             List<string> value = [];
             for (var index = 0; index < sophonData.ManifestIdentityList.Count; index++)
@@ -1013,7 +1016,7 @@ namespace CollapseLauncher.InstallManager.Base
             return value;
         }
 
-        protected virtual void RearrangeSophonDataLocaleOrder(SophonData? sophonData)
+        protected virtual void RearrangeSophonDataLocaleOrder(SophonManifestBuildData? sophonData)
         {
             // Rearrange the sophon data list order based on matching field for the locale
             RearrangeDataListLocaleOrder(sophonData?.ManifestIdentityList, x => x.MatchingField);

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.SophonPatch.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.SophonPatch.cs
@@ -1,0 +1,393 @@
+﻿// ReSharper disable IdentifierTypo
+// ReSharper disable StringLiteralTypo
+// ReSharper disable ForCanBeConvertedToForeach
+// ReSharper disable IdentifierTypo
+// ReSharper disable CommentTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable GrammarMistakeInComment
+// ReSharper disable LoopCanBeConvertedToQuery
+
+using CollapseLauncher.Helper.Metadata;
+using CollapseLauncher.Interfaces;
+using Hi3Helper;
+using Hi3Helper.Shared.Region;
+using Hi3Helper.Sophon;
+using Hi3Helper.Sophon.Structs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace CollapseLauncher.InstallManager.Base
+{
+    internal partial class InstallManagerBase
+    {
+        protected virtual async Task<bool> AlterStartPatchUpdateSophon(HttpClient httpClient,
+                                                                       bool isPreloadMode,
+                                                                       int maxThread,
+                                                                       int maxChunksThread,
+                                                                       int maxHttpHandler)
+        {
+            // Sanity check
+            ArgumentNullException.ThrowIfNull(GameVersionManager,
+                                              nameof(GameVersionManager));
+            ArgumentNullException.ThrowIfNull(GameVersionManager.GamePreset.LauncherResourceChunksURL,
+                                              nameof(GameVersionManager.GamePreset.LauncherResourceChunksURL));
+            ArgumentNullException.ThrowIfNull(GameVersionManager.GamePreset.LauncherResourceChunksURL.BranchUrl,
+                                              nameof(GameVersionManager.GamePreset.LauncherResourceChunksURL.BranchUrl));
+            ArgumentNullException.ThrowIfNull(GameVersionManager.GamePreset.LauncherBizName,
+                                              nameof(GameVersionManager.GamePreset.LauncherBizName));
+
+            // Get GameVersionManager and GamePreset
+            IGameVersion gameVersion = GameVersionManager;
+            PresetConfig gamePreset = gameVersion.GamePreset;
+
+            // Gt current and future version
+            GameVersion? requestedVersionFrom = gameVersion.GetGameExistingVersion() ??
+                                                throw new NullReferenceException("Cannot get previous/current version of the game");
+            GameVersion? requestedVersionTo = (isPreloadMode ?
+                                                  gameVersion.GetGameVersionApiPreload() :
+                                                  gameVersion.GetGameVersionApi()) ??
+                                              throw new NullReferenceException("Cannot get next/future version of the game");
+
+            // Assign branch properties
+            SophonChunkUrls branchResources = gamePreset.LauncherResourceChunksURL;
+            string branchUrl = branchResources.BranchUrl;
+            string bizName = gamePreset.LauncherBizName;
+
+            // If patch URL is null, then return false and back to old compare method
+            if (string.IsNullOrEmpty(branchResources.PatchUrl))
+            {
+                return false;
+            }
+
+            // Reassociate URL's queries
+            await branchResources.EnsureReassociated(httpClient,
+                                                     branchUrl,
+                                                     bizName,
+                                                     isPreloadMode,
+                                                     Token.Token);
+
+            // Fetch manifest info and get patch metadata
+            SophonChunkManifestInfoPair patchManifest =
+                await SophonPatch.CreateSophonChunkManifestInfoPair(httpClient,
+                                                                    url: branchResources.PatchUrl,
+                                                                    versionUpdateFrom: requestedVersionFrom.Value.VersionString,
+                                                                    matchingField: GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField,
+                                                                    token: Token.Token);
+
+            // If the patch metadata is not found, then return false and back to old compare method
+            if (!patchManifest.IsFound)
+            {
+                Logger.LogWriteLine($"[InstallManagerBase::AlterStartPatchUpdateSophon] Cannot find alternative patch method for version: {requestedVersionFrom} -> {requestedVersionTo}",
+                                    LogType.Error,
+                                    true);
+                return false;
+            }
+
+            // Get matching fields from main game and the VO
+            List<string> matchingFields = [GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField];
+            matchingFields.AddRange(await GetAlterSophonPatchVOMatchingFields(Token.Token));
+
+            // Create a sophon download speed limiter instance
+            SophonDownloadSpeedLimiter downloadSpeedLimiter =
+                SophonDownloadSpeedLimiter.CreateInstance(LauncherConfig.DownloadSpeedLimitCached);
+
+            // Get the patch assets to download
+            (List<SophonPatchAsset>, List<SophonChunkManifestInfoPair>) patchAssets =
+                await GetAlterSophonPatchAssets(httpClient,
+                                                branchResources.PatchUrl,
+                                                GameRepoURL,
+                                                matchingFields,
+                                                requestedVersionFrom.Value.VersionString,
+                                                downloadSpeedLimiter,
+                                                Token.Token);
+
+            // Start the patch pipeline
+            await StartAlterSophonPatch(httpClient,
+                                        isPreloadMode,
+                                        patchAssets.Item1,
+                                        patchAssets.Item2,
+                                        downloadSpeedLimiter,
+                                        maxThread,
+                                        Token.Token);
+
+            return true;
+        }
+
+        protected virtual async Task<(List<SophonPatchAsset>, List<SophonChunkManifestInfoPair>)>
+            GetAlterSophonPatchAssets(HttpClient httpClient,
+                                      string manifestUrl,
+                                      string downloadOverUrl,
+                                      List<string> matchingFields,
+                                      string updateVersionfrom,
+                                      SophonDownloadSpeedLimiter downloadLimiter,
+                                      CancellationToken token)
+        {
+            SophonChunkManifestInfoPair? rootPatchManifest = null;
+            List<SophonChunkManifestInfoPair> patchManifestList = [];
+
+            // Iterate matching fields and get the patch metadata
+            foreach (string matchingField in matchingFields)
+            {
+                // Initialize root manifest if it's null
+                rootPatchManifest ??= await SophonPatch.CreateSophonChunkManifestInfoPair(httpClient,
+                                                                                          url: manifestUrl,
+                                                                                          versionUpdateFrom: updateVersionfrom,
+                                                                                          matchingField: matchingField,
+                                                                                          token: token);
+
+                // Get the manifest pair based on the matching field
+                SophonChunkManifestInfoPair patchManifest = rootPatchManifest
+                    .GetOtherPatchInfoPair(matchingField, updateVersionfrom);
+
+                // If the patch metadata is not found, continue to other manifest pair
+                if (!patchManifest.IsFound)
+                {
+                    Logger.LogWriteLine($"[InstallManagerBase::GetAlterSophonPatchAssets] Cannot find patch manifest for matching field: {matchingField}",
+                                        LogType.Error,
+                                        true);
+                    continue;
+                }
+
+                // Otherwise, add the manifest to the list
+                patchManifestList.Add(patchManifest);
+            }
+
+            // Initialize the return list and iterate the manifests
+            List<SophonPatchAsset> patchAssets = [];
+            foreach (SophonChunkManifestInfoPair manifestPair in patchManifestList)
+            {
+                // Get the asset and add it to the list
+                await foreach (SophonPatchAsset patchAsset in SophonPatch
+                    .EnumerateUpdateAsync(httpClient,
+                                          manifestPair,
+                                          updateVersionfrom,
+                                          downloadOverUrl,
+                                          downloadLimiter,
+                                          token))
+                {
+                    patchAssets.Add(patchAsset);
+                }
+            }
+
+            return (patchAssets, patchManifestList);
+        }
+
+        protected virtual async Task<List<string>> GetAlterSophonPatchVOMatchingFields(CancellationToken token)
+        {
+            FileInfo voAudioLangFileInfo = new(_gameAudioLangListPathStatic);
+            List<string> voAudioMatchingFields = [];
+
+            if (!voAudioLangFileInfo.Exists)
+            {
+                return voAudioMatchingFields;
+            }
+
+            using StreamReader voAudioLangReader = voAudioLangFileInfo.OpenText();
+            while ((await voAudioLangReader.ReadLineAsync(token)) is { } line)
+            {
+                string? matchingField = GetLanguageLocaleCodeByLanguageString(line);
+                if (string.IsNullOrEmpty(matchingField))
+                {
+                    continue;
+                }
+
+                voAudioMatchingFields.Add(matchingField);
+            }
+
+            return voAudioMatchingFields;
+        }
+
+        protected virtual async Task StartAlterSophonPatch(HttpClient httpClient,
+                                                           bool isPreloadMode,
+                                                           List<SophonPatchAsset> patchAssets,
+                                                           List<SophonChunkManifestInfoPair> patchManifestInfoPairs,
+                                                           SophonDownloadSpeedLimiter downloadLimiter,
+                                                           int threadNum,
+                                                           CancellationToken token)
+        {
+            Dictionary<string, int> downloadedPatchHashSet = new();
+            Lock dictionaryLock = new();
+
+            IEnumerable<Tuple<SophonPatchAsset, Dictionary<string, int>>> pipelineDownloadEnumerable = patchAssets
+               .EnsureOnlyGetDedupPatchAssets()
+               .Select(x => new Tuple<SophonPatchAsset, Dictionary<string, int>>(x, downloadedPatchHashSet));
+
+            IEnumerable<Tuple<SophonPatchAsset, Dictionary<string, int>>> pipelinePatchEnumerable = patchAssets
+               .Select(x => new Tuple<SophonPatchAsset, Dictionary<string, int>>(x, downloadedPatchHashSet));
+
+            ParallelOptions parallelOptions = new()
+            {
+                MaxDegreeOfParallelism = threadNum,
+                CancellationToken      = token,
+                TaskScheduler          = TaskScheduler.Default
+            };
+
+            string patchOutputDir = _gameSophonChunkDir;
+
+            // Get download sizes
+            long downloadSizeTotalAssetRemote = patchAssets.Where(x => x.PatchMethod != SophonPatchMethod.Remove).Sum(x => x.TargetFileSize);
+            long downloadSizePatchOnlyRemote = patchManifestInfoPairs.Sum(x => x.ChunksInfo.TotalSize);
+
+            // Get download counts
+            int downloadCountTotalAssetRemote = patchAssets.Count(x => x.PatchMethod != SophonPatchMethod.Remove);
+            int downloadCountPatchOnlyRemote = patchManifestInfoPairs.Sum(x => x.ChunksInfo.ChunksCount);
+
+            // Ensure disk space sufficiency
+            await EnsureDiskSpaceSufficiencyAsync(downloadSizePatchOnlyRemote,
+                                                  GamePath,
+                                                  patchAssets.EnsureOnlyGetDedupPatchAssets().ToList(),
+                                                  (asset, _) =>
+                                                  {
+                                                      if (asset.PatchMethod is not (SophonPatchMethod.Patch or SophonPatchMethod.CopyOver))
+                                                      {
+                                                          return ValueTask.FromResult(0L);
+                                                      }
+
+                                                      string patchFilePath = Path.Combine(patchOutputDir, asset.PatchHash);
+                                                      FileInfo patchFileInfo = new FileInfo(patchFilePath);
+
+                                                      if (!patchFileInfo.Exists)
+                                                      {
+                                                          return ValueTask.FromResult(asset.PatchSize);
+                                                      }
+
+                                                      long patchFileCurrentSize = patchFileInfo.Length;
+                                                      long patchFileRemainedSize = asset.PatchSize - patchFileCurrentSize;
+
+                                                      return ValueTask.FromResult(patchFileRemainedSize != 0 ? asset.PatchSize : 0L);
+                                                  },
+                                                  token);
+
+            // Assign local download progress
+            ProgressAllCountCurrent          = 1;
+            ProgressAllCountTotal            = downloadCountPatchOnlyRemote;
+            ProgressPerFileSizeCurrent       = 0;
+            ProgressPerFileSizeTotal         = downloadSizePatchOnlyRemote;
+            ProgressAllSizeCurrent           = 0;
+            ProgressAllSizeTotal             = downloadSizePatchOnlyRemote;
+            Status.IsIncludePerFileIndicator = false;
+
+            // Run parallel pipeline for download
+            await Parallel.ForEachAsync(pipelineDownloadEnumerable, parallelOptions, ImplDownload);
+
+            // If it's on preload mode, then return as we only need to perform patch download.
+            if (isPreloadMode)
+            {
+                return;
+            }
+
+            // If it's not a preload mode (patch mode), then execute the patch pipeline as well
+            ProgressAllCountCurrent          = 1;
+            ProgressAllCountTotal            = downloadCountTotalAssetRemote;
+            ProgressPerFileSizeCurrent       = 0;
+            ProgressPerFileSizeTotal         = downloadSizePatchOnlyRemote;
+            ProgressAllSizeCurrent           = 0;
+            ProgressAllSizeTotal             = downloadSizeTotalAssetRemote;
+            Status.IsIncludePerFileIndicator = true;
+
+            // Run parallel pipeline for patch
+            await Parallel.ForEachAsync(pipelinePatchEnumerable, parallelOptions, ImplPatchUpdate);
+
+            if (_canDeleteZip)
+            {
+                patchAssets.RemovePatches(patchOutputDir);
+            }
+
+            return;
+
+            async ValueTask ImplDownload(Tuple<SophonPatchAsset, Dictionary<string, int>> ctx, CancellationToken innerToken)
+            {
+                SophonPatchAsset        patchAsset     = ctx.Item1;
+                Dictionary<string, int> downloadedDict = ctx.Item2;
+
+                lock (dictionaryLock)
+                {
+                    _ = downloadedDict.TryAdd(patchAsset.PatchNameSource, 0);
+                    downloadedDict[patchAsset.PatchNameSource]++;
+                }
+
+                UpdateCurrentDownloadStatus();
+                await patchAsset.DownloadPatchAsync(httpClient,
+                                                    patchOutputDir,
+                                                    true,
+                                                    read =>
+                                                    {
+                                                        UpdateSophonFileTotalProgress(read);
+                                                        UpdateSophonFileDownloadProgress(read, read);
+                                                    },
+                                                    downloadLimiter,
+                                                    innerToken);
+
+                Logger.LogWriteLine($"Downloaded patch file for: {patchAsset.TargetFilePath}",
+                                    LogType.Debug,
+                                    true);
+                Interlocked.Increment(ref ProgressAllCountCurrent);
+            }
+
+            async ValueTask ImplPatchUpdate(Tuple<SophonPatchAsset, Dictionary<string, int>> ctx, CancellationToken innerToken)
+            {
+                SophonPatchAsset patchAsset = ctx.Item1;
+                Dictionary<string, int> downloadedDict = ctx.Item2;
+
+                lock (dictionaryLock)
+                {
+                    if (!string.IsNullOrEmpty(patchAsset.PatchNameSource) &&
+                        downloadedDict.Remove(patchAsset.PatchNameSource))
+                    {
+                        Interlocked.Add(ref ProgressPerFileSizeCurrent, patchAsset.PatchSize);
+                    }
+                }
+
+                UpdateCurrentPatchStatus();
+                await patchAsset.ApplyPatchUpdateAsync(httpClient,
+                                                       GamePath,
+                                                       patchOutputDir,
+                                                       true,
+                                                       read =>
+                                                       {
+                                                           UpdateSophonFileDownloadProgress(0, read);
+                                                       },
+                                                       UpdateSophonFileTotalProgress,
+                                                       downloadLimiter,
+                                                       innerToken);
+
+                (string status, string fileToLog) =
+                    patchAsset.PatchMethod switch
+                    {
+                        SophonPatchMethod.Remove => ("removed", patchAsset.OriginalFilePath),
+                        SophonPatchMethod.CopyOver => ("created", patchAsset.TargetFilePath),
+                        SophonPatchMethod.DownloadOver => ("downloaded", patchAsset.TargetFilePath),
+                        _ => ("patched", patchAsset.TargetFilePath)
+                    };
+                Logger.LogWriteLine($"File has been {status} [{patchAsset.PatchMethod}]: {fileToLog}",
+                                    LogType.Debug,
+                                    true);
+                Interlocked.Increment(ref ProgressAllCountCurrent);
+            }
+
+            void UpdateCurrentDownloadStatus()
+            {
+                string perFromToLocale = string.Format(Locale.Lang._Misc.PerFromTo,
+                                                       ProgressAllCountCurrent,
+                                                       ProgressAllCountTotal);
+                Status.ActivityStatus = $"{Locale.Lang._Misc.Downloading}: {perFromToLocale}";
+                UpdateStatus();
+            }
+
+            void UpdateCurrentPatchStatus()
+            {
+                string perFromToLocale = string.Format(Locale.Lang._Misc.PerFromTo,
+                                                       ProgressAllCountCurrent,
+                                                       ProgressAllCountTotal);
+                Status.ActivityStatus = $"{Locale.Lang._Misc.ApplyingPatch}: {perFromToLocale}";
+                UpdateStatus();
+            }
+        }
+    }
+}

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.cs
@@ -2215,12 +2215,6 @@ namespace CollapseLauncher.InstallManager.Base
             return returnDict;
         }
 
-        protected virtual void RearrangeLegacyPackageLocaleOrder(RegionResourceVersion? regionResource)
-        {
-            // Rearrange the region resource list order based on matching field for the locale
-            RearrangeDataListLocaleOrder(regionResource?.voice_packs, x => x.language);
-        }
-
         protected virtual void RearrangeDataListLocaleOrder<T>(List<T>? assetDataList, Func<T, string?> matchingFieldPredicate)
         {
             // If the asset list is null or empty, return
@@ -2825,7 +2819,7 @@ namespace CollapseLauncher.InstallManager.Base
                                 ?? throw new InvalidOperationException("Cannot obtain any latest zip package from API"))
                              .Where(asset => asset != null))
                 {
-                    RearrangeLegacyPackageLocaleOrder(asset);
+                    RearrangeDataListLocaleOrder(asset.voice_packs, x => x.language);
                     await TryAddResourceVersionList(asset, packageList);
                 }
             }

--- a/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 
 namespace CollapseLauncher.Interfaces
@@ -62,7 +63,14 @@ namespace CollapseLauncher.Interfaces
         protected IGameVersion GameVersionManager { get; set; }
         protected IGameSettings GameSettings { get; set; }
         protected string GamePath { get => string.IsNullOrEmpty(GamePathField) ? GameVersionManager.GameDirPath : GamePathField; }
-        protected string GameRepoURL { get; set; }
+
+        [field: MaybeNull, AllowNull]
+        protected string GameRepoURL
+        {
+            get => string.IsNullOrEmpty(field) ? GameVersionManager.GameApiProp.data?.game?.latest?.decompressed_path : field;
+            set;
+        }
+
         protected List<T1> AssetIndex { get; set; }
         protected bool UseFastMethod { get; set; }
 

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <!-- General Properties -->
         <OutputType>WinExe</OutputType>
@@ -197,7 +197,6 @@
         <PackageReference Include="PhotoSauce.NativeCodecs.Libwebp" Version="*-*" />
         <PackageReference Include="Roman-Numerals" Version="2.0.1" />
         <PackageReference Include="SharpCompress" Version="0.39.0" Condition="$(DefineConstants.Contains('USENEWZIPDECOMPRESS'))" />
-        <PackageReference Include="SharpHDiffPatch.Core" Version="2.3.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -303,8 +303,8 @@
       },
       "Google.Protobuf": {
         "type": "Transitive",
-        "resolved": "3.30.1",
-        "contentHash": "HeWXDQBabQn/sCGicbeLJ0HMunknfC4FdLrOQOsaMJHcpqx3HVIpyyJqTrqJlWnza870twhOb+rBcaTiC/TlNA=="
+        "resolved": "3.30.0",
+        "contentHash": "ZnEI4oZWnHvd+Yz5Gcnx5Q5RQIuzptIzd0fmxAN8f81FYHI0USZqMOrPTkrsd/QEzo9vl2b217v9FqFgHfufQw=="
       },
       "Hi3Helper.ZstdNet": {
         "type": "Transitive",
@@ -459,9 +459,10 @@
       "hi3helper.sophon": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[*, )",
+          "Google.Protobuf": "[3.30.0, )",
           "Hi3Helper.ZstdNet": "[*, )",
-          "System.IO.Hashing": "[9.0.3, )"
+          "SharpHDiffPatch.Core": "[*, )",
+          "System.IO.Hashing": "[*, )"
         }
       },
       "hi3helper.win32": {

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -209,16 +209,6 @@
           "ZstdSharp.Port": "0.8.4"
         }
       },
-      "SharpHDiffPatch.Core": {
-        "type": "Direct",
-        "requested": "[2.3.0, )",
-        "resolved": "2.3.0",
-        "contentHash": "xmI09P+o5eEQYhWIE2+cluwjhTpz8WfNCFd6LG1foDKM+J2N71RA4A7b3E8y/8xnq0pc7zKENsRTk5eUGIVCzw==",
-        "dependencies": {
-          "Hi3Helper.ZstdNet": "1.6.4",
-          "ZstdSharp.Port": "0.8.5"
-        }
-      },
       "System.CommandLine": {
         "type": "Direct",
         "requested": "[2.0.0-beta4.22272.1, )",
@@ -362,6 +352,15 @@
         "type": "Transitive",
         "resolved": "5.4.0",
         "contentHash": "fXjF+bn7uOSPjrALfY+GQGhaeXFXfAX8XrSWeUJOek/hhIss1hhi/l2AJPefjVdaNWyb1muJAdUUZnBofZjlvw=="
+      },
+      "SharpHDiffPatch.Core": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "eHhgCafM9gD5UlFj/xkF8Hnm6BBm6loV8HE22BET8wE8VXKEQAqSux3nux7sm3xRbh+M+Y4OrNi6P3mOv4y7ow==",
+        "dependencies": {
+          "Hi3Helper.ZstdNet": "1.6.4",
+          "ZstdSharp.Port": "0.8.5"
+        }
       },
       "System.Buffers": {
         "type": "Transitive",


### PR DESCRIPTION
# Main Goal
This PR implements a new update mode for Sophon which is currently in A/B Testing phase for the official HoYoPlay launcher.
Sophon Patch Update mode brings a much improved download pipeline and update efficiency as this method involves not only Copy-Over method, but also Patch-Over method via HDiffPatch.

This results a much smaller download footprint compared to the old Copy-Over only method. As an example of this, we compared Genshin Impact 5.4.0 -> 5.5.0 update between the Old and New method.

The old method requires 15.97 GB of data to download. Meanwhile, the new method only requires 5.92 GB of data to download, which is **62.9%** of size reduction over old method.

Note: In this test, we installed two VOs: en-us + ja-jp
![image](https://github.com/user-attachments/assets/67b8e1f7-d33e-4086-91aa-09125a53728c)

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : -
