### PR TITLE
[EMERGENCY HOTFIX] Forcefully Redirect to Sophon if Zip Method is Unavailable

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.GameState.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.GameState.cs
@@ -528,6 +528,11 @@ namespace CollapseLauncher.GameManagement.Versioning
             // If all not passed, then return null.
             return null;
         }
+
+        public virtual bool IsForceRedirectToSophon()
+        {
+            return GamePreset.GameLauncherApi?.IsForceRedirectToSophon ?? false;
+        }
         #endregion
     }
 }

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
@@ -156,8 +156,6 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                 ConvertPackageResources(sophonResourceData, hypResourceResponse?.Data?.LauncherPackages);
 
                 LauncherGameResource = sophonResourcePropRoot;
-
-                PerformDebugRoutines();
             }
         }
 

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
@@ -40,6 +40,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
         [JsonPropertyName("branch")] public string? Branch { get; init; }
         [JsonPropertyName("password")] public string? Password { get; init; }
         [JsonPropertyName("tag")] public string? Tag { get; init; }
+        [JsonPropertyName("diff_tags")] public List<string>? DiffTags { get; init; }
     }
 
     public sealed class HoYoPlayGameInfoField

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
@@ -6,24 +6,26 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 // ReSharper disable UnusedMemberInSuper.Global
+// ReSharper disable IdentifierTypo
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader
 {
     public interface ILauncherApi : IDisposable
     {
-        bool IsLoadingCompleted { get; }
-        string? GameBackgroundImg { get; }
-        string? GameBackgroundImgLocal { get; set; }
-        string? GameName { get; }
-        string? GameRegion { get; }
-        string? GameNameTranslation { get; }
-        string? GameRegionTranslation { get; }
-        HoYoPlayGameInfoField? LauncherGameInfoField { get; }
-        RegionResourceProp? LauncherGameResource { get; }
-        LauncherGameNews? LauncherGameNews { get; }
-        HttpClient? ApiGeneralHttpClient { get; }
-        HttpClient? ApiResourceHttpClient { get; }
+        bool                   IsLoadingCompleted      { get; }
+        bool                   IsForceRedirectToSophon { get; }
+        string?                GameBackgroundImg       { get; }
+        string?                GameBackgroundImgLocal  { get; set; }
+        string?                GameName                { get; }
+        string?                GameRegion              { get; }
+        string?                GameNameTranslation     { get; }
+        string?                GameRegionTranslation   { get; }
+        HoYoPlayGameInfoField? LauncherGameInfoField   { get; }
+        RegionResourceProp?    LauncherGameResource    { get; }
+        LauncherGameNews?      LauncherGameNews        { get; }
+        HttpClient?            ApiGeneralHttpClient    { get; }
+        HttpClient?            ApiResourceHttpClient   { get; }
         Task<bool> LoadAsync(OnLoadTaskAction? beforeLoadRoutine = null, OnLoadTaskAction? afterLoadRoutine = null,
                              ActionOnTimeOutRetry? onTimeoutRoutine = null, ErrorLoadRoutineDelegate? errorLoadRoutine = null,
                              CancellationToken token = default);

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -11,14 +11,17 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hi3Helper.SentryHelper;
+using Hi3Helper.Sophon.Structs;
 using System.Net.Http;
 using System.Net;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
+using System.Linq;
 // ReSharper disable PartialTypeWithSinglePart
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
 // ReSharper disable VirtualMemberCallInConstructor
+// ReSharper disable CommentTypo
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader
@@ -45,11 +48,12 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
         public string? GameRegionTranslation =>
             InnerLauncherConfig.GetGameTitleRegionTranslationString(GameRegion, Locale.Lang._GameClientRegions);
 
-        public virtual RegionResourceProp?    LauncherGameResource  { get; protected set; }
-        public virtual LauncherGameNews?      LauncherGameNews      { get; protected set; }
-        public virtual HoYoPlayGameInfoField? LauncherGameInfoField { get; protected set; }
-        public virtual HttpClient             ApiGeneralHttpClient  { get; protected set; }
-        public virtual HttpClient             ApiResourceHttpClient { get; protected set; }
+        public virtual RegionResourceProp?       LauncherGameResource       { get; protected set; }
+        public virtual HoYoPlayLauncherGameInfo? LauncherGameResourceSophon { get; protected set; }
+        public virtual LauncherGameNews?         LauncherGameNews           { get; protected set; }
+        public virtual HoYoPlayGameInfoField?    LauncherGameInfoField      { get; protected set; }
+        public virtual HttpClient                ApiGeneralHttpClient       { get; protected set; }
+        public virtual HttpClient                ApiResourceHttpClient      { get; protected set; }
 
         public void Dispose()
         {
@@ -140,12 +144,64 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
             }
         }
 
-        protected virtual Task LoadAsyncInner(ActionOnTimeOutRetry? onTimeoutRoutine,
+        protected virtual async Task LoadAsyncInner(ActionOnTimeOutRetry? onTimeoutRoutine,
                                               CancellationToken     token)
         {
-            return Task.WhenAll(LoadLauncherGameResource(onTimeoutRoutine, token),
-                                LoadLauncherNews(onTimeoutRoutine, token),
-                                LoadLauncherGameInfo(onTimeoutRoutine, token));
+            // 2025-05-05: As per now, the Sophon resource information requires to be fetched first.
+            //             This is mandatory due to latest Genshin Impact changes which removes zip
+            //             packages and also version infos.
+            await LoadLauncherGameResourceSophon(onTimeoutRoutine, token);
+            await Task.WhenAll(LoadLauncherGameResource(onTimeoutRoutine, token),
+                               LoadLauncherNews(onTimeoutRoutine, token),
+                               LoadLauncherGameInfo(onTimeoutRoutine, token));
+
+            InitializeFakeVersionInfo();
+            PerformDebugRoutines();
+        }
+
+        protected virtual void InitializeFakeVersionInfo()
+        {
+            if (LauncherGameResourceSophon == null)
+            {
+                return;
+            }
+
+            HoYoPlayGameInfoBranch? gameBranch = LauncherGameResourceSophon.GameInfoData?.GameBranchesInfo?
+                .FirstOrDefault(x => x.GameInfo?.BizName?.Equals(PresetConfig?.LauncherBizName) ?? false);
+        }
+
+        protected virtual async Task LoadLauncherGameResourceSophon(ActionOnTimeOutRetry? onTimeoutRoutine,
+                                                              CancellationToken token)
+        {
+            EnsurePresetConfigNotNull();
+
+            SophonChunkUrls? sophonUrls      = PresetConfig?.LauncherResourceChunksURL;
+            string?          sophonBranchUrl = sophonUrls?.BranchUrl;
+
+            if (string.IsNullOrEmpty(PresetConfig!.LauncherBizName) || string.IsNullOrEmpty(sophonBranchUrl))
+            {
+                Logger.LogWriteLine("This game/region doesn't have Sophon->BranchUrl or PresetConfig->LauncherBizName property defined! This might cause the launcher inaccurately check the version if Zip download is unavailable", LogType.Warning, true);
+            }
+
+            await (sophonUrls?.EnsureReassociated(ApiGeneralHttpClient,
+                                                  sophonBranchUrl,
+                                                  PresetConfig.LauncherBizName!,
+                                                  false,
+                                                  token) ?? Task.CompletedTask);
+
+            ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherGameInfo?> launcherSophonBranchCallback = 
+                innerToken =>
+                    ApiGeneralHttpClient.GetFromJsonAsync(PresetConfig.LauncherResourceChunksURL?.BranchUrl,
+                                                          HoYoPlayLauncherGameInfoJsonContext.Default.HoYoPlayLauncherGameInfo,
+                                                          innerToken)
+                    .ConfigureAwait(false);
+
+            LauncherGameResourceSophon = await launcherSophonBranchCallback
+               .WaitForRetryAsync(ExecutionTimeout,
+                                  ExecutionTimeoutStep,
+                                  ExecutionTimeoutAttempt,
+                                  onTimeoutRoutine,
+                                  token);
         }
 
         protected virtual Task LoadLauncherGameResource(ActionOnTimeOutRetry? onTimeoutRoutine,
@@ -213,8 +269,6 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
                                         LogType.Debug, true);
 #endif
                 }
-
-                PerformDebugRoutines();
             }
         }
 

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -218,20 +218,24 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
         {
             EnsurePresetConfigNotNull();
 
-            SophonChunkUrls? sophonUrls      = PresetConfig?.LauncherResourceChunksURL;
-            string?          sophonBranchUrl = sophonUrls?.BranchUrl;
+            SophonChunkUrls? sophonUrls = PresetConfig?.LauncherResourceChunksURL;
+            if (sophonUrls == null)
+            {
+                return;
+            }
 
+            string? sophonBranchUrl = sophonUrls.BranchUrl;
             if (string.IsNullOrEmpty(PresetConfig!.LauncherBizName) || string.IsNullOrEmpty(sophonBranchUrl))
             {
                 Logger.LogWriteLine("This game/region doesn't have Sophon->BranchUrl or PresetConfig->LauncherBizName property defined! This might cause the launcher inaccurately check the version if Zip download is unavailable", LogType.Warning, true);
             }
 
-            await (sophonUrls?.EnsureReassociated(ApiGeneralHttpClient,
-                                                  sophonBranchUrl,
-                                                  PresetConfig.LauncherBizName!,
-                                                  false,
-                                                  token) ?? Task.CompletedTask);
-            sophonUrls?.ResetAssociation(); // Reset association so it won't conflict with preload/update/install activity
+            await sophonUrls.EnsureReassociated(ApiGeneralHttpClient,
+                                                sophonBranchUrl,
+                                                PresetConfig.LauncherBizName!,
+                                                false,
+                                                token);
+            sophonUrls.ResetAssociation(); // Reset association so it won't conflict with preload/update/install activity
 
             ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherGameInfo?> launcherSophonBranchCallback = 
                 innerToken =>

--- a/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
@@ -98,6 +98,8 @@ namespace CollapseLauncher.Helper.Metadata
         [JsonConverter(typeof(ServeV3StringConverter))]
         public string? SdkUrl { get; set; }
 
+        public bool ResetAssociation() => IsReassociated = false;
+
         public Task EnsureReassociated(HttpClient client, string? branchUrl, string bizName, bool isPreloadForPatch, CancellationToken token)
         {
             if (IsReassociated)

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
@@ -83,10 +83,11 @@ namespace CollapseLauncher.InstallManager.Base
 
         #region Public Virtual Properties
         public virtual bool IsUseSophon =>
-            GameVersionManager.GamePreset.LauncherResourceChunksURL != null
+            GameVersionManager.IsForceRedirectToSophon() ||
+            (GameVersionManager.GamePreset.LauncherResourceChunksURL != null
             && !File.Exists(Path.Combine(GamePath, "@DisableSophon"))
             && !_canDeltaPatch && !_forceIgnoreDeltaPatch
-            && LauncherConfig.GetAppConfigValue("IsEnableSophon").ToBool();
+            && LauncherConfig.GetAppConfigValue("IsEnableSophon").ToBool());
         #endregion
 
         #region Sophon Verification Methods

--- a/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
@@ -27,13 +27,10 @@ namespace CollapseLauncher.InstallManager.Genshin
     internal sealed partial class GenshinInstall : InstallManagerBase
     {
         #region Override Properties
-
         protected override int _gameVoiceLanguageID => GameVersionManager.GamePreset.GetVoiceLanguageID();
-
         #endregion
 
         #region Properties
-
         protected override string _gameAudioLangListPath
         {
             get
@@ -74,6 +71,12 @@ namespace CollapseLauncher.InstallManager.Genshin
 #nullable enable
         public override async ValueTask<bool> IsPreloadCompleted(CancellationToken token)
         {
+            // If it's forcely redirected to sophon, check the preload using sophon
+            if (GameVersionManager.IsForceRedirectToSophon())
+            {
+                return await base.IsPreloadCompleted(token);
+            }
+
             // Get the primary file first check
             List<RegionResourceVersion>? resource = GameVersionManager.GetGamePreloadZip();
 

--- a/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
@@ -131,6 +131,11 @@ namespace CollapseLauncher.Interfaces
         bool IsGameHasDeltaPatch();
 
         /// <summary>
+        /// Check if the game installation is forcely redirected to Sophon.
+        /// </summary>
+        bool IsForceRedirectToSophon();
+
+        /// <summary>
         /// Returns the state of the game.
         /// </summary>
         ValueTask<GameInstallStateEnum> GetGameState();

--- a/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
@@ -131,7 +131,7 @@ namespace CollapseLauncher.Interfaces
         bool IsGameHasDeltaPatch();
 
         /// <summary>
-        /// Check if the game installation is forcely redirected to Sophon.
+        /// Check if the game installation is forcefully redirected to Sophon.
         /// </summary>
         bool IsForceRedirectToSophon();
 


### PR DESCRIPTION
# Main Goal
As per Genshin Impact 5.6.0 preload today, miHoYo just removed Zip packages on HoYoPlay API. This caused our launcher unable to detect or determine update state due to the main dependencies to Zip packages only.

This PR fixes the issue by checking if Zip is unavailable, then tell the GameVersionManager to fallback by forcefully redirect the install/update/preload methods to Sophon mode. This PR also avoid the same issue if HoYo might remove the Zip packages to other games in the future.

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : -