### PR TITLE
[EMERGENCY HOTFIX] Backport Hotfixes to Stable (1.82.22)

### DIFF
--- a/CollapseLauncher/Classes/CachesManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/CachesManagement/Honkai/Fetch.cs
@@ -256,7 +256,7 @@ namespace CollapseLauncher
 
             // Parse asset index file from UABT
             BundleFile bundleFile = new BundleFile(stream);
-            SerializedFile serializeFile = new SerializedFile(bundleFile.fileList!.FirstOrDefault()!.stream);
+            SerializedFile serializeFile = new SerializedFile(bundleFile.fileList!.FirstOrDefault()!.Stream);
 
             // Try to get the asset index file as byte[] and load it as TextAsset
             byte[] dataRaw = serializeFile.GetDataFirstOrDefaultByName("packageversion.txt");

--- a/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.GameState.cs
+++ b/CollapseLauncher/Classes/GameManagement/Versioning/GameVersionBase.GameState.cs
@@ -528,6 +528,11 @@ namespace CollapseLauncher.GameManagement.Versioning
             // If all not passed, then return null.
             return null;
         }
+
+        public virtual bool IsForceRedirectToSophon()
+        {
+            return GamePreset.GameLauncherApi?.IsForceRedirectToSophon ?? false;
+        }
         #endregion
     }
 }

--- a/CollapseLauncher/Classes/GamePresetProperty.cs
+++ b/CollapseLauncher/Classes/GamePresetProperty.cs
@@ -66,7 +66,7 @@ namespace CollapseLauncher
                     GameVersion = new GameTypeGenshinVersion(ApiResourceProp, gameName, gameRegion);
                     GameSettings = new GenshinSettings(GameVersion);
                     GameCache = null;
-                    GameRepair = new GenshinRepair(uiElementParent, GameVersion, GameVersion.GameApiProp.data!.game!.latest!.decompressed_path);
+                    GameRepair = new GenshinRepair(uiElementParent, GameVersion, GameVersion.GameApiProp.data?.game?.latest?.decompressed_path ?? "");
                     GameInstall = new GenshinInstall(uiElementParent, GameVersion);
                     break;
                 case GameNameType.Zenless:

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherApiLoader.cs
@@ -159,8 +159,6 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
                 ConvertPackageResources(sophonResourceData, hypResourceResponse?.Data?.LauncherPackages);
 
                 LauncherGameResource = sophonResourcePropRoot;
-
-                PerformDebugRoutines();
             }
         }
 

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/HoYoPlay/HoYoPlayLauncherGameInfo.cs
@@ -40,6 +40,7 @@ namespace CollapseLauncher.Helper.LauncherApiLoader.HoYoPlay
         [JsonPropertyName("branch")] public string? Branch { get; init; }
         [JsonPropertyName("password")] public string? Password { get; init; }
         [JsonPropertyName("tag")] public string? Tag { get; init; }
+        [JsonPropertyName("diff_tags")] public List<string>? DiffTags { get; init; }
     }
 
     public sealed class HoYoPlayGameInfoField

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/ILauncherApi.cs
@@ -6,24 +6,26 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 // ReSharper disable UnusedMemberInSuper.Global
+// ReSharper disable IdentifierTypo
 
 #nullable enable
 namespace CollapseLauncher.Helper.LauncherApiLoader
 {
     public interface ILauncherApi : IDisposable
     {
-        bool IsLoadingCompleted { get; }
-        string? GameBackgroundImg { get; }
-        string? GameBackgroundImgLocal { get; set; }
-        string? GameName { get; }
-        string? GameRegion { get; }
-        string? GameNameTranslation { get; }
-        string? GameRegionTranslation { get; }
-        HoYoPlayGameInfoField? LauncherGameInfoField { get; }
-        RegionResourceProp? LauncherGameResource { get; }
-        LauncherGameNews? LauncherGameNews { get; }
-        HttpClient? ApiGeneralHttpClient { get; }
-        HttpClient? ApiResourceHttpClient { get; }
+        bool                   IsLoadingCompleted      { get; }
+        bool                   IsForceRedirectToSophon { get; }
+        string?                GameBackgroundImg       { get; }
+        string?                GameBackgroundImgLocal  { get; set; }
+        string?                GameName                { get; }
+        string?                GameRegion              { get; }
+        string?                GameNameTranslation     { get; }
+        string?                GameRegionTranslation   { get; }
+        HoYoPlayGameInfoField? LauncherGameInfoField   { get; }
+        RegionResourceProp?    LauncherGameResource    { get; }
+        LauncherGameNews?      LauncherGameNews        { get; }
+        HttpClient?            ApiGeneralHttpClient    { get; }
+        HttpClient?            ApiResourceHttpClient   { get; }
         Task<bool> LoadAsync(OnLoadTaskAction? beforeLoadRoutine = null, OnLoadTaskAction? afterLoadRoutine = null,
                              ActionOnTimeOutRetry? onTimeoutRoutine = null, ErrorLoadRoutineDelegate? errorLoadRoutine = null,
                              CancellationToken token = default);

--- a/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
+++ b/CollapseLauncher/Classes/Helper/LauncherApiLoader/LauncherApiBase.cs
@@ -218,20 +218,24 @@ namespace CollapseLauncher.Helper.LauncherApiLoader
         {
             EnsurePresetConfigNotNull();
 
-            SophonChunkUrls? sophonUrls      = PresetConfig?.LauncherResourceChunksURL;
-            string?          sophonBranchUrl = sophonUrls?.BranchUrl;
+            SophonChunkUrls? sophonUrls = PresetConfig?.LauncherResourceChunksURL;
+            if (sophonUrls == null)
+            {
+                return;
+            }
 
+            string? sophonBranchUrl = sophonUrls.BranchUrl;
             if (string.IsNullOrEmpty(PresetConfig!.LauncherBizName) || string.IsNullOrEmpty(sophonBranchUrl))
             {
                 Logger.LogWriteLine("This game/region doesn't have Sophon->BranchUrl or PresetConfig->LauncherBizName property defined! This might cause the launcher inaccurately check the version if Zip download is unavailable", LogType.Warning, true);
             }
 
-            await (sophonUrls?.EnsureReassociated(ApiGeneralHttpClient,
-                                                  sophonBranchUrl,
-                                                  PresetConfig.LauncherBizName!,
-                                                  false,
-                                                  token) ?? Task.CompletedTask);
-            sophonUrls?.ResetAssociation(); // Reset association so it won't conflict with preload/update/install activity
+            await sophonUrls.EnsureReassociated(ApiGeneralHttpClient,
+                                                sophonBranchUrl,
+                                                PresetConfig.LauncherBizName!,
+                                                false,
+                                                token);
+            sophonUrls.ResetAssociation(); // Reset association so it won't conflict with preload/update/install activity
 
             ActionTimeoutTaskAwaitableCallback<HoYoPlayLauncherGameInfo?> launcherSophonBranchCallback = 
                 innerToken =>

--- a/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
@@ -166,12 +166,7 @@ namespace CollapseLauncher.Helper.Metadata
                     // Re-associate url if patch URL property exists
                     if (!string.IsNullOrEmpty(PatchUrl))
                     {
-                        HoYoPlayGameInfoBranchField? branchField = isPreloadForPatch ? branch.GamePreloadField : branch.GameMainField;
-                        if (branchField == null)
-                        {
-                            throw new InvalidOperationException($"Cannot find branch field for respective patch URL (isPreloadForPatch: {isPreloadForPatch}).");
-                        }
-
+                        HoYoPlayGameInfoBranchField? branchField = (isPreloadForPatch ? branch.GamePreloadField : branch.GameMainField) ?? throw new InvalidOperationException($"Cannot find branch field for respective patch URL (isPreloadForPatch: {isPreloadForPatch}).");
                         ArgumentException.ThrowIfNullOrEmpty(branchField.PackageId);
                         ArgumentException.ThrowIfNullOrEmpty(branchField.Password);
 
@@ -179,14 +174,14 @@ namespace CollapseLauncher.Helper.Metadata
                         string passwordValue  = branchField.Password;
                         string branchValue    = isPreloadForPatch ? "predownload" : "main";
 
-                        PreloadUrl = PreloadUrl.AssociateGameAndLauncherId(QueryPasswordHead,
-                                                                           QueryPackageIdHead,
-                                                                           passwordValue,
-                                                                           packageIdValue);
-                        PreloadUrl = PreloadUrl.AssociateGameAndLauncherId(QueryBranchHead,
-                                                                           QueryPackageIdHead,
-                                                                           branchValue,
-                                                                           packageIdValue);
+                        PatchUrl = PatchUrl.AssociateGameAndLauncherId(QueryPasswordHead,
+                                                                       QueryPackageIdHead,
+                                                                       passwordValue,
+                                                                       packageIdValue);
+                        PatchUrl = PatchUrl.AssociateGameAndLauncherId(QueryBranchHead,
+                                                                       QueryPackageIdHead,
+                                                                       branchValue,
+                                                                       packageIdValue);
                     }
 
                     // Mark as re-associated

--- a/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
@@ -166,7 +166,7 @@ namespace CollapseLauncher.Helper.Metadata
                     // Re-associate url if patch URL property exists
                     if (!string.IsNullOrEmpty(PatchUrl))
                     {
-                        HoYoPlayGameInfoBranchField? branchField = (isPreloadForPatch ? branch.GamePreloadField : branch.GameMainField) ?? throw new InvalidOperationException($"Cannot find branch field for respective patch URL (isPreloadForPatch: {isPreloadForPatch}).");
+                        HoYoPlayGameInfoBranchField branchField = (isPreloadForPatch ? branch.GamePreloadField : branch.GameMainField) ?? throw new InvalidOperationException($"Cannot find branch field for respective patch URL (isPreloadForPatch: {isPreloadForPatch}).");
                         ArgumentException.ThrowIfNullOrEmpty(branchField.PackageId);
                         ArgumentException.ThrowIfNullOrEmpty(branchField.Password);
 

--- a/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
+++ b/CollapseLauncher/Classes/Helper/Metadata/PresetConfig.cs
@@ -98,6 +98,8 @@ namespace CollapseLauncher.Helper.Metadata
         [JsonConverter(typeof(ServeV3StringConverter))]
         public string? SdkUrl { get; set; }
 
+        public bool ResetAssociation() => IsReassociated = false;
+
         public Task EnsureReassociated(HttpClient client, string? branchUrl, string bizName, bool isPreloadForPatch, CancellationToken token)
         {
             if (IsReassociated)

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
@@ -5,6 +5,7 @@
 // ReSharper disable CommentTypo
 // ReSharper disable InconsistentNaming
 // ReSharper disable GrammarMistakeInComment
+// ReSharper disable LoopCanBeConvertedToQuery
 
 using CollapseLauncher.Dialogs;
 using CollapseLauncher.Extension;
@@ -29,7 +30,6 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using SophonLogger = Hi3Helper.Sophon.Helper.Logger;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 #nullable enable
 namespace CollapseLauncher.InstallManager.Base
@@ -173,6 +173,7 @@ namespace CollapseLauncher.InstallManager.Base
                                                  .EnsureReassociated(httpClient,
                                                                      branchUrl,
                                                                      GameVersionManager.GamePreset.LauncherBizName,
+                                                                     false,
                                                                      Token.Token);
                     }
 
@@ -219,24 +220,25 @@ namespace CollapseLauncher.InstallManager.Base
                             SophonManifest.CreateSophonChunkManifestInfoPair(
                                                                              httpClient,
                                                                              requestedUrl,
-                                                                             "game",
+                                                                             GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField,
                                                                              Token.Token);
 
                         // Ensure that the manifest is ordered based on _gameVoiceLanguageLocaleIdOrdered
-                        RearrangeSophonDataLocaleOrder(sophonMainInfoPair.OtherSophonData);
+                        RearrangeDataListLocaleOrder(sophonMainInfoPair.OtherSophonBuildData.ManifestIdentityList,
+                                                     x => x.MatchingField);
 
                         // Add the manifest to the pair list
                         sophonInfoPairList.Add(sophonMainInfoPair);
 
                         List<string> voLanguageList =
-                            GetSophonLanguageDisplayDictFromVoicePackList(sophonMainInfoPair.OtherSophonData);
+                            GetSophonLanguageDisplayDictFromVoicePackList(sophonMainInfoPair.OtherSophonBuildData);
 
                         // Get Audio Choices first.
                         // If the fallbackFromUpdate flag is set, then don't show the dialog and instead
                         // use the default language (ja-jp) as the fallback and read the existing audio_lang file
                         List<int>? addedVo;
                         int setAsDefaultVo = GetSophonLocaleCodeIndex(
-                                              sophonMainInfoPair.OtherSophonData,
+                                              sophonMainInfoPair.OtherSophonBuildData,
                                               "ja-jp"
                                              );
 
@@ -265,7 +267,7 @@ namespace CollapseLauncher.InstallManager.Base
                                     }
 
                                     int voLocaleIndex = GetSophonLocaleCodeIndex(
-                                         sophonMainInfoPair.OtherSophonData,
+                                         sophonMainInfoPair.OtherSophonBuildData,
                                          voLocaleId
                                         );
                                     addedVo.Add(voLocaleIndex);
@@ -335,35 +337,35 @@ namespace CollapseLauncher.InstallManager.Base
 
                         // Check for the disk space requirement first and ensure that the space is sufficient
                         await EnsureDiskSpaceSufficiencyAsync(
-                            ProgressAllSizeTotal,
-                            gameInstallPath,
-                            sophonAssetList,
-                            async (sophonAsset, ctx) =>
-                            {
-                                return await Task<long>.Factory.StartNew(() =>
-                                {
-                                    // Get the file path and start the write process
-                                    string   assetName      = sophonAsset.AssetName;
-                                    string   assetFullPath  = Path.Combine(gameInstallPath, assetName);
-                                    long     sophonAssetLen = sophonAsset.AssetSize;
-                                    FileInfo filePath       = new FileInfo(assetFullPath + "_tempSophon");
-                                    FileInfo origFilePath   = new FileInfo(assetFullPath);
+                                                              ProgressAllSizeTotal,
+                                                              gameInstallPath,
+                                                              sophonAssetList,
+                                                              async (sophonAsset, ctx) =>
+                                                              {
+                                                                  return await Task<long>.Factory.StartNew(() =>
+                                                                      {
+                                                                          // Get the file path and start the write process
+                                                                          string   assetName      = sophonAsset.AssetName;
+                                                                          string   assetFullPath  = Path.Combine(gameInstallPath, assetName);
+                                                                          long     sophonAssetLen = sophonAsset.AssetSize;
+                                                                          FileInfo filePath       = new FileInfo(assetFullPath + "_tempSophon");
+                                                                          FileInfo origFilePath   = new FileInfo(assetFullPath);
 
-                                    // If the original file path exist and the length is the same as the asset size
-                                    // or if the temp file path exist and the length is the same as the asset size
-                                    // (means the file has already been downloaded, then return sophonAssetLen)
-                                    if ((origFilePath.Exists && origFilePath.Length == sophonAssetLen)
-                                     || (filePath.Exists     && filePath.Length     == sophonAssetLen))
-                                    {
-                                        return sophonAssetLen;
-                                    }
+                                                                          // If the original file path exist and the length is the same as the asset size
+                                                                          // or if the temp file path exist and the length is the same as the asset size
+                                                                          // (means the file has already been downloaded, then return sophonAssetLen)
+                                                                          if ((origFilePath.Exists && origFilePath.Length == sophonAssetLen)
+                                                                              || (filePath.Exists     && filePath.Length     == sophonAssetLen))
+                                                                          {
+                                                                              return sophonAssetLen;
+                                                                          }
                             
-                                    // If both orig and temp file don't exist or has different size, then return 0 as it doesn't exist
-                                    return 0L;
-                                }, ctx,
-                                TaskCreationOptions.DenyChildAttach,
-                                TaskScheduler.Default);
-                            }, Token.Token);
+                                                                          // If both orig and temp file don't exist or has different size, then return 0 as it doesn't exist
+                                                                          return 0L;
+                                                                      }, ctx,
+                                                                      TaskCreationOptions.DenyChildAttach,
+                                                                      TaskScheduler.Default);
+                                                              }, Token.Token);
 
                         // Get the parallel options
                         var parallelOptions = new ParallelOptions
@@ -541,6 +543,22 @@ namespace CollapseLauncher.InstallManager.Base
                 // Subscribe the logger event
                 SophonLogger.LogHandler += UpdateSophonLogHandler;
 
+                // Try to alter method to use patch mode.
+                // If it returns true, then return.
+                if (await AlterStartPatchUpdateSophon(httpClient,
+                                                      isPreloadMode,
+                                                      maxThread,
+                                                      maxChunksThread,
+                                                      maxHttpHandler))
+                {
+                    // Indicate the download is completed (if it's a preload one)
+                    _isSophonPreloadCompleted = isPreloadMode;
+                    // Indicate the patch is completed
+                    _isSophonDownloadCompleted = true;
+
+                    return;
+                }
+
                 // Init asset list
                 List<SophonAsset> sophonUpdateAssetList = [];
 
@@ -560,17 +578,18 @@ namespace CollapseLauncher.InstallManager.Base
                                                  .EnsureReassociated(httpClient,
                                                                      branchUrl,
                                                                      GameVersionManager.GamePreset.LauncherBizName,
+                                                                     false,
                                                                      Token.Token);
                     }
 
                     string? requestedBaseUrlFrom = isPreloadMode
                         ? GameVersionManager.GamePreset.LauncherResourceChunksURL.PreloadUrl
                         : GameVersionManager.GamePreset.LauncherResourceChunksURL.MainUrl;
-                #if SIMULATEAPPLYPRELOAD
+#if SIMULATEAPPLYPRELOAD
                     string requestedBaseUrlTo = GameVersionManager.GamePreset.LauncherResourceChunksURL.PreloadUrl!;
-                #else
+#else
                     string requestedBaseUrlTo = requestedBaseUrlFrom!;
-                #endif
+#endif
                     // Add the tag query to the previous version's Url
                     requestedBaseUrlFrom += $"&tag={requestedVersionFrom.ToString()}";
 
@@ -584,7 +603,7 @@ namespace CollapseLauncher.InstallManager.Base
                         requestedBaseUrlFrom,
                         requestedBaseUrlTo,
                         sophonUpdateAssetList,
-                        "game",
+                        GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField,
                         downloadSpeedLimiter);
 
                     // If it doesn't success to get the base diff, then fallback to actually download the whole game
@@ -692,16 +711,15 @@ namespace CollapseLauncher.InstallManager.Base
                 }
 
                 // Test the disk space requirement first and ensure that the space is sufficient
-                await EnsureDiskSpaceSufficiencyAsync(
-                                                      ProgressPerFileSizeTotal,
+                await EnsureDiskSpaceSufficiencyAsync(ProgressPerFileSizeTotal,
                                                       chunkPath,
                                                       sophonUpdateAssetList,
                                                       async (x, ctx) =>
                                                           await x.GetDownloadedPreloadSize(
-                                                              chunkPath,
-                                                              gamePath,
-                                                              isPreloadMode,
-                                                              ctx),
+                                                           chunkPath,
+                                                           gamePath,
+                                                           isPreloadMode,
+                                                           ctx),
                                                       Token.Token);
 
                 Status.IsProgressPerFileIndetermined = false;
@@ -816,7 +834,7 @@ namespace CollapseLauncher.InstallManager.Base
                                            );
         }
 
-        private async Task EnsureDiskSpaceSufficiencyAsync<TFrom>(
+        private static async Task EnsureDiskSpaceSufficiencyAsync<TFrom>(
             long                                      sizeToCompare,
             string                                    gamePath,
             List<TFrom>                               assetList,
@@ -824,8 +842,7 @@ namespace CollapseLauncher.InstallManager.Base
             CancellationToken                         token)
         {
             // Get SIMD'ed total sizes
-            long downloadedSize = await assetList.SumParallelAsync(
-                                                                   async (x, ctx) => await sizeSelector(x, ctx),
+            long downloadedSize = await assetList.SumParallelAsync(async (x, ctx) => await sizeSelector(x, ctx),
                                                                    token);
 
             long sizeRemainedToDownload = sizeToCompare - downloadedSize;
@@ -857,7 +874,7 @@ namespace CollapseLauncher.InstallManager.Base
             }
         }
 
-        #endregion
+#endregion
 
         #region Sophon Asset Package Methods
         private async Task<bool> AddSophonDiffAssetsToList(HttpClient                 httpClient,
@@ -888,8 +905,10 @@ namespace CollapseLauncher.InstallManager.Base
             }
 
             // Ensure that the manifest is ordered based on _gameVoiceLanguageLocaleIdOrdered
-            RearrangeSophonDataLocaleOrder(requestPairFrom.OtherSophonData);
-            RearrangeSophonDataLocaleOrder(requestPairTo.OtherSophonData);
+            RearrangeDataListLocaleOrder(requestPairFrom.OtherSophonBuildData.ManifestIdentityList,
+                                         x => x.MatchingField);
+            RearrangeDataListLocaleOrder(requestPairTo.OtherSophonBuildData.ManifestIdentityList,
+                                         x => x.MatchingField);
 
             // Add asset to the list
             await foreach (SophonAsset sophonAsset in SophonUpdate
@@ -927,9 +946,9 @@ namespace CollapseLauncher.InstallManager.Base
                 {
                     // Get other lang Id, pass it and try add to the list
                     string? otherLangId = GetLanguageLocaleCodeByLanguageString(line
-                                                                            #if !DEBUG
+#if !DEBUG
                         , false
-                                                                            #endif
+#endif
                                                                                );
 
                     // Check if the voice pack is actually the same as default.
@@ -977,7 +996,7 @@ namespace CollapseLauncher.InstallManager.Base
 
         #region Sophon Audio/Voice-Packs Locale Methods
 
-        protected virtual int GetSophonLocaleCodeIndex(SophonData sophonData, string lookupName)
+        protected virtual int GetSophonLocaleCodeIndex(SophonManifestBuildData sophonData, string lookupName)
         {
             List<string> localeList = sophonData.ManifestIdentityList
                                                 .Where(x => IsValidLocaleCode(x.MatchingField))
@@ -988,7 +1007,7 @@ namespace CollapseLauncher.InstallManager.Base
             return Math.Max(0, index);
         }
 
-        protected virtual List<string> GetSophonLanguageDisplayDictFromVoicePackList(SophonData sophonData)
+        protected virtual List<string> GetSophonLanguageDisplayDictFromVoicePackList(SophonManifestBuildData sophonData)
         {
             List<string> value = [];
             for (var index = 0; index < sophonData.ManifestIdentityList.Count; index++)
@@ -1013,7 +1032,7 @@ namespace CollapseLauncher.InstallManager.Base
             return value;
         }
 
-        protected virtual void RearrangeSophonDataLocaleOrder(SophonData? sophonData)
+        protected virtual void RearrangeSophonDataLocaleOrder(SophonManifestBuildData? sophonData)
         {
             // Rearrange the sophon data list order based on matching field for the locale
             RearrangeDataListLocaleOrder(sophonData?.ManifestIdentityList, x => x.MatchingField);

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
@@ -83,10 +83,11 @@ namespace CollapseLauncher.InstallManager.Base
 
         #region Public Virtual Properties
         public virtual bool IsUseSophon =>
-            GameVersionManager.GamePreset.LauncherResourceChunksURL != null
+            GameVersionManager.IsForceRedirectToSophon() ||
+            (GameVersionManager.GamePreset.LauncherResourceChunksURL != null
             && !File.Exists(Path.Combine(GamePath, "@DisableSophon"))
             && !_canDeltaPatch && !_forceIgnoreDeltaPatch
-            && LauncherConfig.GetAppConfigValue("IsEnableSophon").ToBool();
+            && LauncherConfig.GetAppConfigValue("IsEnableSophon").ToBool());
         #endregion
 
         #region Sophon Verification Methods

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.SophonPatch.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.SophonPatch.cs
@@ -1,0 +1,393 @@
+﻿// ReSharper disable IdentifierTypo
+// ReSharper disable StringLiteralTypo
+// ReSharper disable ForCanBeConvertedToForeach
+// ReSharper disable IdentifierTypo
+// ReSharper disable CommentTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable GrammarMistakeInComment
+// ReSharper disable LoopCanBeConvertedToQuery
+
+using CollapseLauncher.Helper.Metadata;
+using CollapseLauncher.Interfaces;
+using Hi3Helper;
+using Hi3Helper.Shared.Region;
+using Hi3Helper.Sophon;
+using Hi3Helper.Sophon.Structs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace CollapseLauncher.InstallManager.Base
+{
+    internal partial class InstallManagerBase
+    {
+        protected virtual async Task<bool> AlterStartPatchUpdateSophon(HttpClient httpClient,
+                                                                       bool isPreloadMode,
+                                                                       int maxThread,
+                                                                       int maxChunksThread,
+                                                                       int maxHttpHandler)
+        {
+            // Sanity check
+            ArgumentNullException.ThrowIfNull(GameVersionManager,
+                                              nameof(GameVersionManager));
+            ArgumentNullException.ThrowIfNull(GameVersionManager.GamePreset.LauncherResourceChunksURL,
+                                              nameof(GameVersionManager.GamePreset.LauncherResourceChunksURL));
+            ArgumentNullException.ThrowIfNull(GameVersionManager.GamePreset.LauncherResourceChunksURL.BranchUrl,
+                                              nameof(GameVersionManager.GamePreset.LauncherResourceChunksURL.BranchUrl));
+            ArgumentNullException.ThrowIfNull(GameVersionManager.GamePreset.LauncherBizName,
+                                              nameof(GameVersionManager.GamePreset.LauncherBizName));
+
+            // Get GameVersionManager and GamePreset
+            IGameVersion gameVersion = GameVersionManager;
+            PresetConfig gamePreset = gameVersion.GamePreset;
+
+            // Gt current and future version
+            GameVersion? requestedVersionFrom = gameVersion.GetGameExistingVersion() ??
+                                                throw new NullReferenceException("Cannot get previous/current version of the game");
+            GameVersion? requestedVersionTo = (isPreloadMode ?
+                                                  gameVersion.GetGameVersionApiPreload() :
+                                                  gameVersion.GetGameVersionApi()) ??
+                                              throw new NullReferenceException("Cannot get next/future version of the game");
+
+            // Assign branch properties
+            SophonChunkUrls branchResources = gamePreset.LauncherResourceChunksURL;
+            string branchUrl = branchResources.BranchUrl;
+            string bizName = gamePreset.LauncherBizName;
+
+            // If patch URL is null, then return false and back to old compare method
+            if (string.IsNullOrEmpty(branchResources.PatchUrl))
+            {
+                return false;
+            }
+
+            // Reassociate URL's queries
+            await branchResources.EnsureReassociated(httpClient,
+                                                     branchUrl,
+                                                     bizName,
+                                                     isPreloadMode,
+                                                     Token.Token);
+
+            // Fetch manifest info and get patch metadata
+            SophonChunkManifestInfoPair patchManifest =
+                await SophonPatch.CreateSophonChunkManifestInfoPair(httpClient,
+                                                                    url: branchResources.PatchUrl,
+                                                                    versionUpdateFrom: requestedVersionFrom.Value.VersionString,
+                                                                    matchingField: GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField,
+                                                                    token: Token.Token);
+
+            // If the patch metadata is not found, then return false and back to old compare method
+            if (!patchManifest.IsFound)
+            {
+                Logger.LogWriteLine($"[InstallManagerBase::AlterStartPatchUpdateSophon] Cannot find alternative patch method for version: {requestedVersionFrom} -> {requestedVersionTo}",
+                                    LogType.Error,
+                                    true);
+                return false;
+            }
+
+            // Get matching fields from main game and the VO
+            List<string> matchingFields = [GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField];
+            matchingFields.AddRange(await GetAlterSophonPatchVOMatchingFields(Token.Token));
+
+            // Create a sophon download speed limiter instance
+            SophonDownloadSpeedLimiter downloadSpeedLimiter =
+                SophonDownloadSpeedLimiter.CreateInstance(LauncherConfig.DownloadSpeedLimitCached);
+
+            // Get the patch assets to download
+            (List<SophonPatchAsset>, List<SophonChunkManifestInfoPair>) patchAssets =
+                await GetAlterSophonPatchAssets(httpClient,
+                                                branchResources.PatchUrl,
+                                                GameRepoURL,
+                                                matchingFields,
+                                                requestedVersionFrom.Value.VersionString,
+                                                downloadSpeedLimiter,
+                                                Token.Token);
+
+            // Start the patch pipeline
+            await StartAlterSophonPatch(httpClient,
+                                        isPreloadMode,
+                                        patchAssets.Item1,
+                                        patchAssets.Item2,
+                                        downloadSpeedLimiter,
+                                        maxThread,
+                                        Token.Token);
+
+            return true;
+        }
+
+        protected virtual async Task<(List<SophonPatchAsset>, List<SophonChunkManifestInfoPair>)>
+            GetAlterSophonPatchAssets(HttpClient httpClient,
+                                      string manifestUrl,
+                                      string downloadOverUrl,
+                                      List<string> matchingFields,
+                                      string updateVersionfrom,
+                                      SophonDownloadSpeedLimiter downloadLimiter,
+                                      CancellationToken token)
+        {
+            SophonChunkManifestInfoPair? rootPatchManifest = null;
+            List<SophonChunkManifestInfoPair> patchManifestList = [];
+
+            // Iterate matching fields and get the patch metadata
+            foreach (string matchingField in matchingFields)
+            {
+                // Initialize root manifest if it's null
+                rootPatchManifest ??= await SophonPatch.CreateSophonChunkManifestInfoPair(httpClient,
+                                                                                          url: manifestUrl,
+                                                                                          versionUpdateFrom: updateVersionfrom,
+                                                                                          matchingField: matchingField,
+                                                                                          token: token);
+
+                // Get the manifest pair based on the matching field
+                SophonChunkManifestInfoPair patchManifest = rootPatchManifest
+                    .GetOtherPatchInfoPair(matchingField, updateVersionfrom);
+
+                // If the patch metadata is not found, continue to other manifest pair
+                if (!patchManifest.IsFound)
+                {
+                    Logger.LogWriteLine($"[InstallManagerBase::GetAlterSophonPatchAssets] Cannot find patch manifest for matching field: {matchingField}",
+                                        LogType.Error,
+                                        true);
+                    continue;
+                }
+
+                // Otherwise, add the manifest to the list
+                patchManifestList.Add(patchManifest);
+            }
+
+            // Initialize the return list and iterate the manifests
+            List<SophonPatchAsset> patchAssets = [];
+            foreach (SophonChunkManifestInfoPair manifestPair in patchManifestList)
+            {
+                // Get the asset and add it to the list
+                await foreach (SophonPatchAsset patchAsset in SophonPatch
+                    .EnumerateUpdateAsync(httpClient,
+                                          manifestPair,
+                                          updateVersionfrom,
+                                          downloadOverUrl,
+                                          downloadLimiter,
+                                          token))
+                {
+                    patchAssets.Add(patchAsset);
+                }
+            }
+
+            return (patchAssets, patchManifestList);
+        }
+
+        protected virtual async Task<List<string>> GetAlterSophonPatchVOMatchingFields(CancellationToken token)
+        {
+            FileInfo voAudioLangFileInfo = new(_gameAudioLangListPathStatic);
+            List<string> voAudioMatchingFields = [];
+
+            if (!voAudioLangFileInfo.Exists)
+            {
+                return voAudioMatchingFields;
+            }
+
+            using StreamReader voAudioLangReader = voAudioLangFileInfo.OpenText();
+            while ((await voAudioLangReader.ReadLineAsync(token)) is { } line)
+            {
+                string? matchingField = GetLanguageLocaleCodeByLanguageString(line);
+                if (string.IsNullOrEmpty(matchingField))
+                {
+                    continue;
+                }
+
+                voAudioMatchingFields.Add(matchingField);
+            }
+
+            return voAudioMatchingFields;
+        }
+
+        protected virtual async Task StartAlterSophonPatch(HttpClient httpClient,
+                                                           bool isPreloadMode,
+                                                           List<SophonPatchAsset> patchAssets,
+                                                           List<SophonChunkManifestInfoPair> patchManifestInfoPairs,
+                                                           SophonDownloadSpeedLimiter downloadLimiter,
+                                                           int threadNum,
+                                                           CancellationToken token)
+        {
+            Dictionary<string, int> downloadedPatchHashSet = new();
+            Lock dictionaryLock = new();
+
+            IEnumerable<Tuple<SophonPatchAsset, Dictionary<string, int>>> pipelineDownloadEnumerable = patchAssets
+               .EnsureOnlyGetDedupPatchAssets()
+               .Select(x => new Tuple<SophonPatchAsset, Dictionary<string, int>>(x, downloadedPatchHashSet));
+
+            IEnumerable<Tuple<SophonPatchAsset, Dictionary<string, int>>> pipelinePatchEnumerable = patchAssets
+               .Select(x => new Tuple<SophonPatchAsset, Dictionary<string, int>>(x, downloadedPatchHashSet));
+
+            ParallelOptions parallelOptions = new()
+            {
+                MaxDegreeOfParallelism = threadNum,
+                CancellationToken      = token,
+                TaskScheduler          = TaskScheduler.Default
+            };
+
+            string patchOutputDir = _gameSophonChunkDir;
+
+            // Get download sizes
+            long downloadSizeTotalAssetRemote = patchAssets.Where(x => x.PatchMethod != SophonPatchMethod.Remove).Sum(x => x.TargetFileSize);
+            long downloadSizePatchOnlyRemote = patchManifestInfoPairs.Sum(x => x.ChunksInfo.TotalSize);
+
+            // Get download counts
+            int downloadCountTotalAssetRemote = patchAssets.Count(x => x.PatchMethod != SophonPatchMethod.Remove);
+            int downloadCountPatchOnlyRemote = patchManifestInfoPairs.Sum(x => x.ChunksInfo.ChunksCount);
+
+            // Ensure disk space sufficiency
+            await EnsureDiskSpaceSufficiencyAsync(downloadSizePatchOnlyRemote,
+                                                  GamePath,
+                                                  patchAssets.EnsureOnlyGetDedupPatchAssets().ToList(),
+                                                  (asset, _) =>
+                                                  {
+                                                      if (asset.PatchMethod is not (SophonPatchMethod.Patch or SophonPatchMethod.CopyOver))
+                                                      {
+                                                          return ValueTask.FromResult(0L);
+                                                      }
+
+                                                      string patchFilePath = Path.Combine(patchOutputDir, asset.PatchHash);
+                                                      FileInfo patchFileInfo = new FileInfo(patchFilePath);
+
+                                                      if (!patchFileInfo.Exists)
+                                                      {
+                                                          return ValueTask.FromResult(asset.PatchSize);
+                                                      }
+
+                                                      long patchFileCurrentSize = patchFileInfo.Length;
+                                                      long patchFileRemainedSize = asset.PatchSize - patchFileCurrentSize;
+
+                                                      return ValueTask.FromResult(patchFileRemainedSize != 0 ? asset.PatchSize : 0L);
+                                                  },
+                                                  token);
+
+            // Assign local download progress
+            ProgressAllCountCurrent          = 1;
+            ProgressAllCountTotal            = downloadCountPatchOnlyRemote;
+            ProgressPerFileSizeCurrent       = 0;
+            ProgressPerFileSizeTotal         = downloadSizePatchOnlyRemote;
+            ProgressAllSizeCurrent           = 0;
+            ProgressAllSizeTotal             = downloadSizePatchOnlyRemote;
+            Status.IsIncludePerFileIndicator = false;
+
+            // Run parallel pipeline for download
+            await Parallel.ForEachAsync(pipelineDownloadEnumerable, parallelOptions, ImplDownload);
+
+            // If it's on preload mode, then return as we only need to perform patch download.
+            if (isPreloadMode)
+            {
+                return;
+            }
+
+            // If it's not a preload mode (patch mode), then execute the patch pipeline as well
+            ProgressAllCountCurrent          = 1;
+            ProgressAllCountTotal            = downloadCountTotalAssetRemote;
+            ProgressPerFileSizeCurrent       = 0;
+            ProgressPerFileSizeTotal         = downloadSizePatchOnlyRemote;
+            ProgressAllSizeCurrent           = 0;
+            ProgressAllSizeTotal             = downloadSizeTotalAssetRemote;
+            Status.IsIncludePerFileIndicator = true;
+
+            // Run parallel pipeline for patch
+            await Parallel.ForEachAsync(pipelinePatchEnumerable, parallelOptions, ImplPatchUpdate);
+
+            if (_canDeleteZip)
+            {
+                patchAssets.RemovePatches(patchOutputDir);
+            }
+
+            return;
+
+            async ValueTask ImplDownload(Tuple<SophonPatchAsset, Dictionary<string, int>> ctx, CancellationToken innerToken)
+            {
+                SophonPatchAsset        patchAsset     = ctx.Item1;
+                Dictionary<string, int> downloadedDict = ctx.Item2;
+
+                lock (dictionaryLock)
+                {
+                    _ = downloadedDict.TryAdd(patchAsset.PatchNameSource, 0);
+                    downloadedDict[patchAsset.PatchNameSource]++;
+                }
+
+                UpdateCurrentDownloadStatus();
+                await patchAsset.DownloadPatchAsync(httpClient,
+                                                    patchOutputDir,
+                                                    true,
+                                                    read =>
+                                                    {
+                                                        UpdateSophonFileTotalProgress(read);
+                                                        UpdateSophonFileDownloadProgress(read, read);
+                                                    },
+                                                    downloadLimiter,
+                                                    innerToken);
+
+                Logger.LogWriteLine($"Downloaded patch file for: {patchAsset.TargetFilePath}",
+                                    LogType.Debug,
+                                    true);
+                Interlocked.Increment(ref ProgressAllCountCurrent);
+            }
+
+            async ValueTask ImplPatchUpdate(Tuple<SophonPatchAsset, Dictionary<string, int>> ctx, CancellationToken innerToken)
+            {
+                SophonPatchAsset patchAsset = ctx.Item1;
+                Dictionary<string, int> downloadedDict = ctx.Item2;
+
+                lock (dictionaryLock)
+                {
+                    if (!string.IsNullOrEmpty(patchAsset.PatchNameSource) &&
+                        downloadedDict.Remove(patchAsset.PatchNameSource))
+                    {
+                        Interlocked.Add(ref ProgressPerFileSizeCurrent, patchAsset.PatchSize);
+                    }
+                }
+
+                UpdateCurrentPatchStatus();
+                await patchAsset.ApplyPatchUpdateAsync(httpClient,
+                                                       GamePath,
+                                                       patchOutputDir,
+                                                       true,
+                                                       read =>
+                                                       {
+                                                           UpdateSophonFileDownloadProgress(0, read);
+                                                       },
+                                                       UpdateSophonFileTotalProgress,
+                                                       downloadLimiter,
+                                                       innerToken);
+
+                (string status, string fileToLog) =
+                    patchAsset.PatchMethod switch
+                    {
+                        SophonPatchMethod.Remove => ("removed", patchAsset.OriginalFilePath),
+                        SophonPatchMethod.CopyOver => ("created", patchAsset.TargetFilePath),
+                        SophonPatchMethod.DownloadOver => ("downloaded", patchAsset.TargetFilePath),
+                        _ => ("patched", patchAsset.TargetFilePath)
+                    };
+                Logger.LogWriteLine($"File has been {status} [{patchAsset.PatchMethod}]: {fileToLog}",
+                                    LogType.Debug,
+                                    true);
+                Interlocked.Increment(ref ProgressAllCountCurrent);
+            }
+
+            void UpdateCurrentDownloadStatus()
+            {
+                string perFromToLocale = string.Format(Locale.Lang._Misc.PerFromTo,
+                                                       ProgressAllCountCurrent,
+                                                       ProgressAllCountTotal);
+                Status.ActivityStatus = $"{Locale.Lang._Misc.Downloading}: {perFromToLocale}";
+                UpdateStatus();
+            }
+
+            void UpdateCurrentPatchStatus()
+            {
+                string perFromToLocale = string.Format(Locale.Lang._Misc.PerFromTo,
+                                                       ProgressAllCountCurrent,
+                                                       ProgressAllCountTotal);
+                Status.ActivityStatus = $"{Locale.Lang._Misc.ApplyingPatch}: {perFromToLocale}";
+                UpdateStatus();
+            }
+        }
+    }
+}

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.cs
@@ -2207,12 +2207,6 @@ namespace CollapseLauncher.InstallManager.Base
             return returnDict;
         }
 
-        protected virtual void RearrangeLegacyPackageLocaleOrder(RegionResourceVersion? regionResource)
-        {
-            // Rearrange the region resource list order based on matching field for the locale
-            RearrangeDataListLocaleOrder(regionResource?.voice_packs, x => x.language);
-        }
-
         protected virtual void RearrangeDataListLocaleOrder<T>(List<T>? assetDataList, Func<T, string?> matchingFieldPredicate)
         {
             // If the asset list is null or empty, return
@@ -2819,7 +2813,7 @@ namespace CollapseLauncher.InstallManager.Base
                                 ?? throw new InvalidOperationException("Cannot obtain any latest zip package from API"))
                              .Where(asset => asset != null))
                 {
-                    RearrangeLegacyPackageLocaleOrder(asset);
+                    RearrangeDataListLocaleOrder(asset.voice_packs, x => x.language);
                     await TryAddResourceVersionList(asset, packageList);
                 }
             }

--- a/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
@@ -27,13 +27,10 @@ namespace CollapseLauncher.InstallManager.Genshin
     internal sealed partial class GenshinInstall : InstallManagerBase
     {
         #region Override Properties
-
         protected override int _gameVoiceLanguageID => GameVersionManager.GamePreset.GetVoiceLanguageID();
-
         #endregion
 
         #region Properties
-
         protected override string _gameAudioLangListPath
         {
             get
@@ -74,6 +71,12 @@ namespace CollapseLauncher.InstallManager.Genshin
 #nullable enable
         public override async ValueTask<bool> IsPreloadCompleted(CancellationToken token)
         {
+            // If it's forcely redirected to sophon, check the preload using sophon
+            if (GameVersionManager.IsForceRedirectToSophon())
+            {
+                return await base.IsPreloadCompleted(token);
+            }
+
             // Get the primary file first check
             List<RegionResourceVersion>? resource = GameVersionManager.GetGamePreloadZip();
 

--- a/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/GamePropertyBase.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 
 namespace CollapseLauncher.Interfaces
@@ -62,7 +63,14 @@ namespace CollapseLauncher.Interfaces
         protected IGameVersion GameVersionManager { get; set; }
         protected IGameSettings GameSettings { get; set; }
         protected string GamePath { get => string.IsNullOrEmpty(GamePathField) ? GameVersionManager.GameDirPath : GamePathField; }
-        protected string GameRepoURL { get; set; }
+
+        [field: MaybeNull, AllowNull]
+        protected string GameRepoURL
+        {
+            get => string.IsNullOrEmpty(field) ? GameVersionManager.GameApiProp.data?.game?.latest?.decompressed_path : field;
+            set;
+        }
+
         protected List<T1> AssetIndex { get; set; }
         protected bool UseFastMethod { get; set; }
 

--- a/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
@@ -131,6 +131,11 @@ namespace CollapseLauncher.Interfaces
         bool IsGameHasDeltaPatch();
 
         /// <summary>
+        /// Check if the game installation is forcely redirected to Sophon.
+        /// </summary>
+        bool IsForceRedirectToSophon();
+
+        /// <summary>
         /// Returns the state of the game.
         /// </summary>
         ValueTask<GameInstallStateEnum> GetGameState();

--- a/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
+++ b/CollapseLauncher/Classes/Interfaces/IGameVersionCheck.cs
@@ -131,7 +131,7 @@ namespace CollapseLauncher.Interfaces
         bool IsGameHasDeltaPatch();
 
         /// <summary>
-        /// Check if the game installation is forcely redirected to Sophon.
+        /// Check if the game installation is forcefully redirected to Sophon.
         /// </summary>
         bool IsForceRedirectToSophon();
 

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
@@ -420,21 +420,22 @@ namespace CollapseLauncher
                 // If the ignoreContainsParams is not null and the remoteName contains
                 // ignore list, then move to another entry
                 if (ignoreContainsParams != null &&
+                    manifestEntry != null &&
                     manifestEntry.remoteName
-                        .AsSpan()
-                        .ContainsAny(ignoreContainsParams))
+                                 .AsSpan()
+                                 .ContainsAny(ignoreContainsParams))
                 {
                     continue;
                 }
 
                 // Resolve the svc_catalog name where the localName contains "../"
-                if (manifestEntry.remoteName.EndsWith("svc_catalog"))
+                if (manifestEntry != null && manifestEntry.remoteName.EndsWith("svc_catalog"))
                 {
                     manifestEntry.localName = Path.GetFileName(manifestEntry.remoteName);
                 }
 
                 // Get relative path based on extension
-                bool   isUseRemoteName        = string.IsNullOrEmpty(manifestEntry.localName);
+                bool   isUseRemoteName        = string.IsNullOrEmpty(manifestEntry!.localName);
                 string actualRelativeFilePath = isUseRemoteName ? manifestEntry.remoteName : manifestEntry.localName;
 
                 // Get relative path based on extension

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
@@ -582,7 +582,7 @@ namespace CollapseLauncher
                 DispatchInfo dispatchInfo = await dispatchHelper.LoadDispatchInfo();
 
                 // DEBUG ONLY: Show encrypted Proto as JSON+Base64 format
-                string dFormat = $"Query Response (RAW Encrypted form):\r\n{dispatchInfo?.content}";
+                string dFormat = $"Query Response (RAW Encrypted form):\r\n{dispatchInfo?.Content}";
 #if DEBUG
                 LogWriteLine(dFormat);
 #endif
@@ -596,10 +596,8 @@ namespace CollapseLauncher
 
         private async Task<QueryProperty> TryDecryptAndParseDispatcher(DispatchInfo dispatchInfo, DispatchHelper dispatchHelper)
         {
-            YSDispatchDec dispatchDecryptor = new YSDispatchDec();
-
             // Decrypt the dispatcher data from the dispatcher info content
-            byte[] decryptedData = dispatchDecryptor.DecryptYSDispatch(dispatchInfo.content, GameVersionManager.GamePreset.DispatcherKeyBitLength ?? 0, GameVersionManager.GamePreset.DispatcherKey);
+            byte[] decryptedData = YSDispatchDec.DecryptYSDispatch(dispatchInfo.Content, GameVersionManager.GamePreset.DispatcherKeyBitLength ?? 0, GameVersionManager.GamePreset.DispatcherKey);
 
             // DEBUG ONLY: Show the decrypted Proto as Base64 format
             string dFormat = $"Proto Response (RAW Decrypted form):\r\n{Convert.ToBase64String(decryptedData)}";

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -276,7 +276,7 @@ namespace CollapseLauncher
                 ProgressAllSizeCurrent += sizeDifference;
                 // ReSharper disable PossibleInvalidOperationException
                 // Increment progress count and size
-                ProgressAllSizeFound += asset.IsPatchApplicable ? asset.AudioPatchInfo.PatchFileSize : asset.S;
+                ProgressAllSizeFound += asset.IsPatchApplicable ? asset.AudioPatchInfo!.PatchFileSize : asset.S;
                 ProgressAllCountFound++;
 
                 // Add asset to Display
@@ -288,11 +288,11 @@ namespace CollapseLauncher
                               : RepairAssetType.Audio,
                           Path.GetDirectoryName(asset.N),
                           asset.IsPatchApplicable
-                              ? asset.AudioPatchInfo.PatchFileSize
+                              ? asset.AudioPatchInfo!.PatchFileSize
                               : asset.S,
                           localCrc,
                           asset.IsPatchApplicable
-                              ? asset.AudioPatchInfo.NewAudioMD5Array
+                              ? asset.AudioPatchInfo!.NewAudioMD5Array
                               : asset.CRCArray
                          )
                     ));
@@ -470,7 +470,7 @@ namespace CollapseLauncher
             FileInfo file = new FileInfo(filePath);
 
             BlockPatchInfo patchInfo = TryGetPossibleOldBlockLinkedPatch(blockPath, asset);
-            string filePathOld = patchInfo != null ? Path.Combine(GamePath, ConverterTool.NormalizePath(BlockBasePath), asset.BlockPatchInfo?.PatchPairs[0].OldName) : null;
+            string filePathOld = patchInfo != null ? Path.Combine(GamePath, ConverterTool.NormalizePath(BlockBasePath), asset.BlockPatchInfo?.PatchPairs[0].OldName!) : null;
             FileInfo fileOld = patchInfo != null ? new FileInfo(filePathOld) : null;
 
             // If old block exist but current block doesn't, check if the hash of the old block matches and patchable
@@ -633,7 +633,7 @@ namespace CollapseLauncher
                         catalog.Add(path);
                         if (asset.BlockPatchInfo != null)
                         {
-                            string oldBlockPath = Path.Combine(GamePath, ConverterTool.NormalizePath(BlockBasePath), asset.BlockPatchInfo?.PatchPairs[0].OldName);
+                            string oldBlockPath = Path.Combine(GamePath, ConverterTool.NormalizePath(BlockBasePath), asset.BlockPatchInfo?.PatchPairs[0].OldName!);
                             catalog.Add(oldBlockPath);
                         }
                         break;

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -791,7 +791,7 @@ namespace CollapseLauncher
             if (_isGame820PostVersion && typeof(T) == typeof(MD5))
             {
                 // Create the Hasher provider by explicitly specify the length of the stream.
-                MhyMurmurHash2_64B murmurHashProvider = MhyMurmurHash2_64B.CreateForStream(stream, 0, stream.Length);
+                MhyMurmurHash264B murmurHashProvider = MhyMurmurHash264B.CreateForStream(stream, 0, stream.Length);
 
                 // Pass the provider and return the task
                 return Hash.GetHashAsync(stream,

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Check.cs
@@ -1,5 +1,8 @@
-﻿using Hi3Helper;
+﻿using CollapseLauncher.Helper;
+using CollapseLauncher.Helper.StreamUtility;
+using Hi3Helper;
 using Hi3Helper.Data;
+using Hi3Helper.EncTool.Hashes;
 using Hi3Helper.EncTool.Parser.AssetMetadata;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.ClassStruct;
@@ -8,6 +11,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -79,10 +83,65 @@ namespace CollapseLauncher
                 throw innerExceptionsFirst;
             }
 
+            // Re-check unused assets for blocks
+            CheckUnusedOldBlocks(assetIndex, brokenAssetIndex);
+
             // Re-add the asset index with a broken asset index
             assetIndex.Clear();
             assetIndex.AddRange(brokenAssetIndex);
         }
+
+        #region Additional Old Block Removal Check
+        private void CheckUnusedOldBlocks(List<FilePropertiesRemote> origAssetIndex, List<FilePropertiesRemote> targetAssetIndex)
+        {
+            HashSet<string> listedAssets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string filePath in origAssetIndex
+                .Select(x => Path.Combine(GamePath, x.N.NormalizePath()))
+                .Where(x => x.EndsWith(".wmv")))
+            {
+                _ = listedAssets.Add(filePath);
+            }
+
+            HashSet<string> listedAssetsTarget = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string filePath in targetAssetIndex
+                .Select(x => Path.Combine(GamePath, x.N.NormalizePath()))
+                .Where(x => x.EndsWith(".wmv")))
+            {
+                _ = listedAssetsTarget.Add(filePath);
+            }
+
+            string gamePath = GamePath.NormalizePath();
+            foreach (string blockPath in Directory.EnumerateFiles(gamePath, "*.wmv", SearchOption.AllDirectories))
+            {
+                if (!listedAssets.Contains(blockPath) &&
+                    !listedAssetsTarget.Contains(blockPath))
+                {
+                    FileInfo fileInfo = new FileInfo(blockPath)
+                        .EnsureNoReadOnly(out bool isExist);
+
+                    if (isExist)
+                    {
+                        string nameBase = blockPath.Substring(gamePath.Length).TrimStart(['/', '\\']);
+                        targetAssetIndex.Add(new FilePropertiesRemote
+                        {
+                            N = nameBase,
+                            S = fileInfo.Length,
+                            FT = FileType.Unused
+                        });
+                        Dispatch(() => AssetEntry.Add(new AssetProperty<RepairAssetType>(
+                                                           Path.GetFileName(nameBase),
+                                                           RepairAssetType.Unused,
+                                                           Path.GetDirectoryName(nameBase),
+                                                           fileInfo.Length,
+                                                           null,
+                                                           null
+                                                          )
+                                                     ));
+                    }
+                }
+            }
+        }
+        #endregion
 
         #region VideoCheck
         private void CheckAssetTypeVideo(FilePropertiesRemote asset, List<FilePropertiesRemote> targetAssetIndex)
@@ -144,7 +203,7 @@ namespace CollapseLauncher
 
             // If file doesn't exist or the file asset length isn't the same as the actual length
             // and doesn't have Patch Info, then add it.
-            if (!file.Exists || (file.Exists && file.Length != asset.S && !asset.AudioPatchInfo.HasValue))
+            if (!file.Exists || (file.Exists && file.Length != asset.S && asset.AudioPatchInfo == null))
             {
                 // Increment progress count and size
                 ProgressAllSizeFound += asset.S;
@@ -170,7 +229,7 @@ namespace CollapseLauncher
                     case false:
                         LogWriteLine($"File [T: {asset.FT}]: {asset.N} is not found locally", LogType.Warning, true);
                         break;
-                    case true when file.Length != asset.S && !asset.AudioPatchInfo.HasValue:
+                    case true when file.Length != asset.S && asset.AudioPatchInfo == null:
                         LogWriteLine($"File [T: {asset.FT}]: {asset.N} has unmatched size", LogType.Warning, true); // length mismatch
                         break;
                 }
@@ -184,7 +243,7 @@ namespace CollapseLauncher
             if (UseFastMethod)
             {
                 // If the patch info has a value and the length is similar, then flag it as patch applicable
-                if (asset.AudioPatchInfo.HasValue && file.Length == asset.S)
+                if (asset.AudioPatchInfo != null && file.Length == asset.S)
                 {
                     asset.IsPatchApplicable = true;
                 }
@@ -197,13 +256,15 @@ namespace CollapseLauncher
             await using FileStream fileStream = await NaivelyOpenFileStreamAsync(file, FileMode.Open, FileAccess.Read, FileShare.Read);
             // If pass the check above, then do MD5 Hash calculation
             var localCrc = await GetCryptoHashAsync<MD5>(fileStream, null, true, true, token);
+            if (_isGame820PostVersion) // Reverse the hash if the game version is >= 8.2.0
+                Array.Reverse(localCrc);
 
             // Get size difference for summarize the _progressAllSizeCurrent
             long sizeDifference = asset.S - file.Length;
 
             // If the asset has patch info and the hash is matching with the old hash,
             // then flag it as Patch Applicable
-            if (asset.AudioPatchInfo.HasValue && IsArrayMatch(localCrc, asset.AudioPatchInfo.Value.OldAudioMD5Array))
+            if (asset.AudioPatchInfo != null && IsArrayMatch(localCrc, asset.AudioPatchInfo.OldAudioMD5Array))
             {
                 asset.IsPatchApplicable = true;
             }
@@ -215,7 +276,7 @@ namespace CollapseLauncher
                 ProgressAllSizeCurrent += sizeDifference;
                 // ReSharper disable PossibleInvalidOperationException
                 // Increment progress count and size
-                ProgressAllSizeFound += asset.IsPatchApplicable ? asset.AudioPatchInfo.Value!.PatchFileSize : asset.S;
+                ProgressAllSizeFound += asset.IsPatchApplicable ? asset.AudioPatchInfo.PatchFileSize : asset.S;
                 ProgressAllCountFound++;
 
                 // Add asset to Display
@@ -227,11 +288,11 @@ namespace CollapseLauncher
                               : RepairAssetType.Audio,
                           Path.GetDirectoryName(asset.N),
                           asset.IsPatchApplicable
-                              ? asset.AudioPatchInfo.Value.PatchFileSize
+                              ? asset.AudioPatchInfo.PatchFileSize
                               : asset.S,
                           localCrc,
                           asset.IsPatchApplicable
-                              ? asset.AudioPatchInfo.Value.NewAudioMD5Array
+                              ? asset.AudioPatchInfo.NewAudioMD5Array
                               : asset.CRCArray
                          )
                     ));
@@ -305,7 +366,7 @@ namespace CollapseLauncher
             // Open and read fileInfo as FileStream 
             await using FileStream fileStream = await NaivelyOpenFileStreamAsync(file, FileMode.Open, FileAccess.Read, FileShare.Read);
             // If pass the check above, then do CRC calculation
-            byte[] localCrc = await GetCryptoHashAsync<MD5>(fileStream, null, true, true, token);
+            byte[] localCrc = await base.GetCryptoHashAsync<MD5>(fileStream, null, true, true, token);
 
             // If local and asset CRC doesn't match, then add the asset
             if (!IsArrayMatch(localCrc, asset.CRCArray))
@@ -419,6 +480,8 @@ namespace CollapseLauncher
                 await using FileStream fileOldFs = await NaivelyOpenFileStreamAsync(fileOld, FileMode.Open, FileAccess.Read, FileShare.Read);
                 // If pass the check above, then do CRC calculation
                 byte[] localOldCrc = await GetCryptoHashAsync<MD5>(fileOldFs, null, true, false, token);
+                if (_isGame820PostVersion) // Reverse the hash if the game version is >= 8.2.0
+                    Array.Reverse(localOldCrc);
 
                 // If the hash matches, then add the patch
                 if (IsArrayMatch(localOldCrc, patchInfo.PatchPairs[0].OldHash))
@@ -508,6 +571,8 @@ namespace CollapseLauncher
             // If pass the check above, then do CRC calculation
             // Additional: the total file size progress is disabled and will be incremented after this
             byte[] localCrc = await GetCryptoHashAsync<MD5>(filefs, null, true, true, token);
+            if (_isGame820PostVersion) // Reverse the hash if the game version is >= 8.2.0
+                Array.Reverse(localCrc);
 
             // If local and asset CRC doesn't match, then add the asset
             if (!IsArrayMatch(localCrc, asset.CRCArray))
@@ -711,6 +776,39 @@ namespace CollapseLauncher
                 LogWriteLine($"Unused file has been found: {n}", LogType.Warning, true);
             }
         }
+        #endregion
+
+        #region Override Methods
+#nullable enable
+        protected override ConfiguredTaskAwaitable<byte[]> GetCryptoHashAsync<T>(
+            Stream stream,
+            byte[]? hmacKey = null,
+            bool updateProgress = true,
+            bool updateTotalProgress = true,
+            CancellationToken token = default)
+        {
+            // If the game version is >= 8.2.0 and the T is MD5, switch to MhyMurmurHash2 implementation.
+            if (_isGame820PostVersion && typeof(T) == typeof(MD5))
+            {
+                // Create the Hasher provider by explicitly specify the length of the stream.
+                MhyMurmurHash2_64B murmurHashProvider = MhyMurmurHash2_64B.CreateForStream(stream, 0, stream.Length);
+
+                // Pass the provider and return the task
+                return Hash.GetHashAsync(stream,
+                                         murmurHashProvider,
+                                         read => UpdateHashReadProgress(read, updateProgress, updateTotalProgress),
+                                         stream is { Length: > 1024 << 20 },
+                                         token);
+            }
+
+            // Otherwise, fallback to the default implementation.
+            return base.GetCryptoHashAsync<T>(stream,
+                                              hmacKey,
+                                              updateProgress,
+                                              updateTotalProgress,
+                                              token);
+        }
+#nullable restore
         #endregion
     }
 }

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
@@ -76,8 +76,6 @@ namespace CollapseLauncher
         private readonly byte[]          _collapseHeader        = "Collapse"u8.ToArray();
         private readonly HashSet<string> _ignoredUnusedFileList = [];
 
-        private static readonly Version _game820PostVersion = new(8, 2, 0);
-
         private async Task Fetch(List<FilePropertiesRemote> assetIndex, CancellationToken token)
         {
             // Set total activity string as "Loading Indexes..."
@@ -200,9 +198,11 @@ namespace CollapseLauncher
                     EliminatePluginAssetIndex(assetIndex);
 
                     // Alter the asset bundle hash with the reference span
+                    /* 2025-05-01: This is disabled for now as we now fully use MhyMurmurHash2_64B for the hash
                     AlterAssetBundleHashWithReferenceSpan(assetIndex,
                                                           GameVersionManager.GetGameExistingVersion()?.ToVersion(),
                                                           asbReferenceSenadinaFileIdentifier);
+                    */
                 }
             }
             finally

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Fetch.cs
@@ -387,8 +387,8 @@ namespace CollapseLauncher
             keyIndexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var alternativeLookup = keyIndexes.GetAlternateLookup<ReadOnlySpan<char>>();
 
-            ref AssetBundleReferenceKVPData startKvpIndex = ref MemoryMarshal.GetReference(span.KeyValuePair);
-            ref AssetBundleReferenceKVPData endKvpIndex = ref Unsafe.Add(ref startKvpIndex, span.KeyValuePair.Length);
+            ref AssetBundleReferenceKvpData startKvpIndex = ref MemoryMarshal.GetReference(span.KeyValuePair);
+            ref AssetBundleReferenceKvpData endKvpIndex = ref Unsafe.Add(ref startKvpIndex, span.KeyValuePair.Length);
 
             int currentDataOffset = 0;
             ref AssetBundleReferenceData startDataOffset = ref MemoryMarshal.GetReference(span.Data);
@@ -536,7 +536,7 @@ namespace CollapseLauncher
             }
 
             // Find the cache asset. If null, then return
-            CacheAsset cacheAsset = cacheProperty.Item1.FirstOrDefault(x => x!.N!.EndsWith($"{HashID.CGMetadata}"));
+            CacheAsset cacheAsset = cacheProperty.Item1.FirstOrDefault(x => x!.N!.EndsWith($"{HashID.CgMetadata}"));
 
             // Deserialize and build video index into asset index
             await BuildVideoIndex(downloadClient, cacheAsset, cacheProperty.Item2, assetIndex, ignoredAssetIDs, cacheProperty.Item4, token);

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/HonkaiRepair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/HonkaiRepair.cs
@@ -17,8 +17,15 @@ namespace CollapseLauncher
     {
         #region Properties
         private const    string        AssetBasePath   = "BH3_Data/StreamingAssets/";
-        private readonly string[]      _skippableAssets = ["CG_Temp.usm$Generic", "BlockMeta.xmf$Generic", "Blocks.xmf$Generic"
+        private readonly string[]      _skippableAssets = [
+            "CG_Temp.usm$Generic",
+            "BlockMeta.xmf$Generic",
+            "Blocks.xmf$Generic"
         ];
+
+        private static readonly Version _game820PostVersion   = new(8, 2, 0);
+        private        readonly bool    _isGame820PostVersion = false;
+
         private        HonkaiCache   CacheUtil             { get; }
         private        string        AssetBaseURL          { get; set; }
         private        string        BlockBaseURL          { get => ConverterTool.CombineURLFromString(AssetBaseURL,      $"StreamingAsb/{string.Join('_', GameVersion.VersionArray)}/pc/HD"); }
@@ -56,6 +63,8 @@ namespace CollapseLauncher
                                  "Chinese(PRC)" => AudioLanguageType.Chinese,
                                  _ => GameVersionManager.GamePreset.GameDefaultCVLanguage
                              };
+
+            _isGame820PostVersion = GameVersionManager.GetGameVersionApi()?.ToVersion() >= _game820PostVersion;
         }
 
         ~HonkaiRepair() => Dispose();

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Repair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Repair.cs
@@ -236,9 +236,9 @@ namespace CollapseLauncher
             // Declare variables for patch file and URL and new file path
             if (asset.AssetIndex.BlockPatchInfo != null)
             {
-                string patchURL       = ConverterTool.CombineURLFromString(string.Format(BlockPatchDiffBaseURL, asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].OldVersionDir), asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].PatchHashStr + ".wmv");
-                string patchPath      = Path.Combine(GamePath, ConverterTool.NormalizePath(BlockPatchDiffPath), asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].PatchHashStr + ".wmv");
-                string inputFilePath  = Path.Combine(GamePath, ConverterTool.NormalizePath(BlockBasePath),      asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].OldHashStr + ".wmv");
+                string patchURL       = ConverterTool.CombineURLFromString(string.Format(BlockPatchDiffBaseURL, asset.AssetIndex.BlockPatchInfo.PatchPairs[0].OldVersionDir), asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchName);
+                string patchPath      = Path.Combine(GamePath, ConverterTool.NormalizePath(BlockPatchDiffPath), asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchName);
+                string inputFilePath  = Path.Combine(GamePath, ConverterTool.NormalizePath(BlockBasePath),      asset.AssetIndex.BlockPatchInfo.PatchPairs[0].OldName);
                 string outputFilePath = Path.Combine(GamePath, ConverterTool.NormalizePath(asset.AssetIndex.N));
 
                 // Set downloading patch status
@@ -249,13 +249,13 @@ namespace CollapseLauncher
                                    true);
 
                 // Run patching task
-                await RunPatchTask(downloadClient, downloadProgress,         asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].PatchSize, asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].PatchHash,
+                await RunPatchTask(downloadClient, downloadProgress,         asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchSize, asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchHash,
                                    patchURL,       patchPath,        inputFilePath, outputFilePath, token: token);
             }
 
             if (asset.AssetIndex.BlockPatchInfo != null)
             {
-                LogWriteLine($"File [T: {asset.AssetIndex.FT}] {asset.AssetIndex.BlockPatchInfo.Value.PatchPairs[0].OldHashStr} has been updated with new block {asset.AssetIndex.BlockPatchInfo.Value.NewBlockName}!",
+                LogWriteLine($"File [T: {asset.AssetIndex.FT}] {asset.AssetIndex.BlockPatchInfo.PatchPairs[0].OldName} has been updated with new block {asset.AssetIndex.BlockPatchInfo.NewName}!",
                              LogType.Default, true);
             }
 

--- a/CollapseLauncher/Classes/RepairManagement/Honkai/Repair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Honkai/Repair.cs
@@ -136,8 +136,8 @@ namespace CollapseLauncher
             // Declare variables for patch file and URL and new file path
             if (asset.AssetIndex.AudioPatchInfo != null)
             {
-                string patchURL       = ConverterTool.CombineURLFromString(string.Format(AudioPatchBaseRemotePath, $"{GameVersion.Major}_{GameVersion.Minor}", GameServer.Manifest.ManifestAudio.ManifestAudioRevision), asset.AssetIndex.AudioPatchInfo.Value.PatchFilename);
-                string patchPath      = Path.Combine(GamePath, ConverterTool.NormalizePath(AudioPatchBaseLocalPath), asset.AssetIndex.AudioPatchInfo.Value.PatchFilename);
+                string patchURL       = ConverterTool.CombineURLFromString(string.Format(AudioPatchBaseRemotePath, $"{GameVersion.Major}_{GameVersion.Minor}", GameServer.Manifest.ManifestAudio.ManifestAudioRevision), asset.AssetIndex.AudioPatchInfo.PatchFilename);
+                string patchPath      = Path.Combine(GamePath, ConverterTool.NormalizePath(AudioPatchBaseLocalPath), asset.AssetIndex.AudioPatchInfo.PatchFilename);
                 string inputFilePath  = Path.Combine(GamePath, ConverterTool.NormalizePath(asset.AssetIndex.N));
                 string outputFilePath = inputFilePath + "_tmp";
 
@@ -149,8 +149,15 @@ namespace CollapseLauncher
                                    true);
 
                 // Run patching task
-                await RunPatchTask(downloadClient, downloadProgress,         asset.AssetIndex.AudioPatchInfo.Value.PatchFileSize, asset.AssetIndex.AudioPatchInfo.Value.PatchMD5Array,
-                                   patchURL,       patchPath,        inputFilePath, outputFilePath,                                      true, token);
+                await RunPatchTask(downloadClient,
+                                   downloadProgress,
+                                   asset.AssetIndex.AudioPatchInfo.PatchFileSize,
+                                   asset.AssetIndex.AudioPatchInfo.PatchMD5Array,
+                                   patchURL,
+                                   patchPath,
+                                   inputFilePath,
+                                   outputFilePath,
+                                   true, token);
             }
 
             LogWriteLine($"File [T: {asset.AssetIndex.FT}] {asset.AssetIndex.N} has been updated!", LogType.Default, true);
@@ -249,8 +256,15 @@ namespace CollapseLauncher
                                    true);
 
                 // Run patching task
-                await RunPatchTask(downloadClient, downloadProgress,         asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchSize, asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchHash,
-                                   patchURL,       patchPath,        inputFilePath, outputFilePath, token: token);
+                await RunPatchTask(downloadClient,
+                                   downloadProgress,
+                                   asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchSize,
+                                   asset.AssetIndex.BlockPatchInfo.PatchPairs[0].PatchHash,
+                                   patchURL,
+                                   patchPath,
+                                   inputFilePath,
+                                   outputFilePath,
+                                   token: token);
             }
 
             if (asset.AssetIndex.BlockPatchInfo != null)

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -188,7 +188,6 @@
         <PackageReference Include="PhotoSauce.NativeCodecs.Libwebp" Version="*-*" />
         <PackageReference Include="Roman-Numerals" Version="2.0.1" />
         <PackageReference Include="SharpCompress" Version="0.39.0" Condition="$(DefineConstants.Contains('USENEWZIPDECOMPRESS'))" />
-        <PackageReference Include="SharpHDiffPatch.Core" Version="2.2.8" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -16,7 +16,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2025 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.82.21</Version>
+        <Version>1.82.22</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>
@@ -181,7 +181,7 @@
         <PackageReference Include="Microsoft.NETCore.Targets" Version="6.0.0-preview.4.21253.7" />
         <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3065.39" />
         <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
         <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.GameLauncher.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.GameLauncher.cs
@@ -569,15 +569,19 @@ public partial class HomePage
             ResizableWindowHookToken = new CancellationTokenSource();
 
             executableName = Path.GetFileNameWithoutExtension(executableName);
-            string              gameExecutableDirectory = CurrentGameProperty.GameVersion.GameDirPath;
-            ResizableWindowHook resizableWindowHook     = new ResizableWindowHook();
+            var gameExecutableDirectory = CurrentGameProperty.GameVersion?.GameDirPath;
+            if (string.IsNullOrEmpty(gameExecutableDirectory))
+            {
+                LogWriteLine("Game executable directory is not set! Cannot start Resizable Window payload!", LogType.Error);
+                return;
+            }
 
             // Set the pos + size reinitialization to true if the game is Honkai: Star Rail
             // This is required for Honkai: Star Rail since the game will reset its pos + size. Making
             // it impossible to use custom resolution (but since you are using Collapse, it's now
             // possible :teriStare:)
             bool isNeedToResetPos = gameType == GameNameType.StarRail;
-            await Task.Run(() => resizableWindowHook.StartHook(executableName, height, width, ResizableWindowHookToken.Token,
+            await Task.Run(() => ResizableWindowHook.StartHook(executableName, height, width, ResizableWindowHookToken.Token,
                                                                isNeedToResetPos, ILoggerHelper.GetILogger(), gameExecutableDirectory));
         }
         catch (Exception ex)

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -390,8 +390,8 @@
       },
       "ZstdSharp.Port": {
         "type": "Transitive",
-        "resolved": "0.8.4",
-        "contentHash": "eieSXq3kakCUXbgdxkKaRqWS6hF0KBJcqok9LlDCs60GOyrynLvPOcQ0pRw7shdPF7lh/VepJ9cP9n9HHc759g=="
+        "resolved": "0.8.5",
+        "contentHash": "TR4j17WeVSEb3ncgL2NqlXEqcy04I+Kk9CaebNDplUeL8XOgjkZ7fP4Wg4grBdPLIqsV86p2QaXTkZoRMVOsew=="
       },
       "colorthief": {
         "type": "Project",
@@ -445,7 +445,8 @@
         "dependencies": {
           "Google.Protobuf": "[3.30.0, )",
           "Hi3Helper.Http": "[2.0.0, )",
-          "Hi3Helper.Win32": "[1.0.0, )"
+          "Hi3Helper.Win32": "[1.0.0, )",
+          "System.IO.Hashing": "[9.0.4, )"
         }
       },
       "hi3helper.http": {

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -32,7 +32,7 @@
         "resolved": "8.2.250129-preview2",
         "contentHash": "rS9Q5Ej/4DgF99dLKYDXtiQW+Wtrkm4ktwlzYVmfuPd07RSLwoDxMbHTLe4Ba4uRwUjdvtfbO/IO7h6iWo5pfg==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
+          "CommunityToolkit.WinUI.Extensions": "8.2.250402",
           "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
@@ -478,8 +478,8 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Common": "[8.4.0, )",
-          "CommunityToolkit.WinUI.Extensions": "[8.2.250129-preview2, )",
-          "CommunityToolkit.WinUI.Media": "[8.2.250129-preview2, )",
+          "CommunityToolkit.WinUI.Extensions": "[8.2.250402, )",
+          "CommunityToolkit.WinUI.Media": "[8.2.250402, )",
           "Microsoft.Graphics.Win2D": "[1.3.2, )",
           "Microsoft.NET.ILLink.Tasks": "[9.0.1, )",
           "Microsoft.Web.WebView2": "[1.0.3065.39, )",

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -209,16 +209,6 @@
           "ZstdSharp.Port": "0.8.4"
         }
       },
-      "SharpHDiffPatch.Core": {
-        "type": "Direct",
-        "requested": "[2.2.8, )",
-        "resolved": "2.2.8",
-        "contentHash": "wKUdKb753eUc4oP098Z7ROHNU0WAmW94m46infYyPVGRJ/0zlNWcuEqdpB0S1dKNv2hgLovJcbUOybEXRz536Q==",
-        "dependencies": {
-          "Hi3Helper.ZstdNet": "1.6.2",
-          "ZstdSharp.Port": "0.8.1"
-        }
-      },
       "System.CommandLine": {
         "type": "Direct",
         "requested": "[2.0.0-beta4.22272.1, )",
@@ -357,6 +347,15 @@
         "resolved": "5.2.0",
         "contentHash": "b3aZSOU2CjlIIFRtPRbXParKQ+9PF+JOqkSD7Gxq6PiR07t1rnK+crPtdrWMXfW6PVo/s67trCJ+fuLsgTeADw=="
       },
+      "SharpHDiffPatch.Core": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "eHhgCafM9gD5UlFj/xkF8Hnm6BBm6loV8HE22BET8wE8VXKEQAqSux3nux7sm3xRbh+M+Y4OrNi6P3mOv4y7ow==",
+        "dependencies": {
+          "Hi3Helper.ZstdNet": "1.6.4",
+          "ZstdSharp.Port": "0.8.5"
+        }
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.6.0",
@@ -455,9 +454,10 @@
       "hi3helper.sophon": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[*, )",
+          "Google.Protobuf": "[3.30.0, )",
           "Hi3Helper.ZstdNet": "[*, )",
-          "System.IO.Hashing": "[9.0.3, )"
+          "SharpHDiffPatch.Core": "[*, )",
+          "System.IO.Hashing": "[*, )"
         }
       },
       "hi3helper.win32": {

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -32,7 +32,7 @@
         "resolved": "8.2.250129-preview2",
         "contentHash": "rS9Q5Ej/4DgF99dLKYDXtiQW+Wtrkm4ktwlzYVmfuPd07RSLwoDxMbHTLe4Ba4uRwUjdvtfbO/IO7h6iWo5pfg==",
         "dependencies": {
-          "CommunityToolkit.WinUI.Extensions": "8.2.250402",
+          "CommunityToolkit.WinUI.Extensions": "8.2.250129-preview2",
           "Microsoft.WindowsAppSDK": "1.6.250108002"
         }
       },
@@ -155,9 +155,9 @@
       },
       "Microsoft.Windows.SDK.BuildTools": {
         "type": "Direct",
-        "requested": "[10.0.26100.1742, )",
-        "resolved": "10.0.26100.1742",
-        "contentHash": "ypcHjr4KEi6xQhgClnbXoANHcyyX/QsC4Rky4igs6M4GiDa+weegPo8JuV/VMxqrZCV4zlqDsp2krgkN7ReAAg=="
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
       },
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
@@ -478,8 +478,8 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Common": "[8.4.0, )",
-          "CommunityToolkit.WinUI.Extensions": "[8.2.250402, )",
-          "CommunityToolkit.WinUI.Media": "[8.2.250402, )",
+          "CommunityToolkit.WinUI.Extensions": "[8.2.250129-preview2, )",
+          "CommunityToolkit.WinUI.Media": "[8.2.250129-preview2, )",
           "Microsoft.Graphics.Win2D": "[1.3.2, )",
           "Microsoft.NET.ILLink.Tasks": "[9.0.1, )",
           "Microsoft.Web.WebView2": "[1.0.3065.39, )",

--- a/Hi3Helper.Core/packages.lock.json
+++ b/Hi3Helper.Core/packages.lock.json
@@ -38,12 +38,18 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.3"
         }
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "WogPvgAFqQORFD8Iyha6RZ+/1QB3dsWRWxbwi8/HHVgiGQ8z0oMWpwe8Kk3Ti+Roe+P6a3sBg+WwBfEsyziZKg=="
+      },
       "hi3helper.enctool": {
         "type": "Project",
         "dependencies": {
           "Google.Protobuf": "[3.30.0, )",
           "Hi3Helper.Http": "[2.0.0, )",
-          "Hi3Helper.Win32": "[1.0.0, )"
+          "Hi3Helper.Win32": "[1.0.0, )",
+          "System.IO.Hashing": "[9.0.4, )"
         }
       },
       "hi3helper.http": {


### PR DESCRIPTION
# Main Goal
## [Fix] Honkai Impact 3rd 8.2 Game Repair Changes - Annotated from https://github.com/CollapseLauncher/Collapse/commit/8e9aee2cd642c08cb3533af5a34b9c0199bf5b72
This main change was to bring back Game Repair and Delta-Patch support for Stable due to breaking changes that were introduced by HoYo in Honkai Impact 3rd v8.2 update.

This hotfix was backported from ``main`` branch.

## [Imp] Introduce Sophon Patch Mode - Annotated from #714 
This changes implements a new update mode for Sophon which is currently in A/B Testing phase for the official HoYoPlay launcher.
Sophon Patch Update mode brings a much improved download pipeline and update efficiency as this method involves not only Copy-Over method, but also Patch-Over method via HDiffPatch.

This results a much smaller download footprint compared to the old Copy-Over only method. As an example of this, we compared Genshin Impact 5.4.0 -> 5.5.0 update between the Old and New method.

## [Fix] Zip to Sophon force fallback - Annotated from #733 
As per Genshin Impact 5.6.0 preload today, miHoYo just removed Zip packages on HoYoPlay API. This caused our launcher unable to detect or determine update state due to the main dependencies to Zip packages only.

This PR fixes the issue by checking if Zip is unavailable, then tell the GameVersionManager to fallback by forcefully redirect the install/update/preload methods to Sophon mode. This PR also avoid the same issue if HoYo might remove the Zip packages to other games in the future.

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : -