### PR TITLE
[Feature] Prevent Windows Log off/Restart/Shutdown when running critical task

### DIFF
--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -5,7 +5,6 @@ using Hi3Helper;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.Region;
 using Hi3Helper.Win32.FileDialogCOM;
-using Hi3Helper.Win32.ManagedTools;
 using Hi3Helper.Win32.Native.Enums;
 using Hi3Helper.Win32.Native.LibraryImport;
 using Hi3Helper.Win32.Native.ManagedTools;
@@ -599,9 +598,6 @@ namespace CollapseLauncher.Helper
                     // Return FALSE (0) to prevent shutdown if critical operation is in progress
                     if (MainWindow.IsCriticalOpInProgress)
                     {
-                        // Display reason using ShutdownBlocker
-                        ShutdownBlocker.StartBlocking(CurrentWindowPtr, Locale.Lang._Dialogs.EnsureExitSubtitle,
-                                                      ILoggerHelper.GetILogger("ShutdownBlocker"));
                         return 0;
                     }
                     // Let Windows continue shutdown if no critical operation

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -600,7 +600,7 @@ namespace CollapseLauncher.Helper
                     if (MainWindow.IsCriticalOpInProgress)
                     {
                         // Display reason using ShutdownBlocker
-                        ShutdownBlocker.StartBlocking(CurrentWindowPtr, "Critical operation in progress",
+                        ShutdownBlocker.StartBlocking(CurrentWindowPtr, Locale.Lang._Dialogs.EnsureExitSubtitle,
                                                       ILoggerHelper.GetILogger("ShutdownBlocker"));
                         return 0;
                     }

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -239,7 +239,7 @@ namespace CollapseLauncher
             if (!IsCriticalOpInProgress) return;
 
             e.Cancel = true;
-            ShutdownBlocker.StartBlocking(WindowUtility.CurrentWindowPtr, "Critical operation in progress",
+            ShutdownBlocker.StartBlocking(WindowUtility.CurrentWindowPtr, Lang._Dialogs.EnsureExitSubtitle,
                                           ILoggerHelper.GetILogger("ShutdownBlocker"));
         }
 

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -6,11 +6,13 @@ using Hi3Helper;
 using Hi3Helper.Http.Legacy;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.ClassStruct;
+using Hi3Helper.Win32.ManagedTools;
 using Hi3Helper.Win32.Native.LibraryImport;
 using Hi3Helper.Win32.Native.ManagedTools;
 using InnoSetupHelper;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -25,6 +27,7 @@ using System.Threading.Tasks;
 using WinRT;
 using static CollapseLauncher.ArgumentParser;
 using static CollapseLauncher.InnerLauncherConfig;
+using static CollapseLauncher.MainWindow;
 using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
@@ -201,6 +204,8 @@ namespace CollapseLauncher
                 MainEntryPointExtension.XamlCheckProcessRequirements();
                 ComWrappersSupport.InitializeComWrappers();
 
+                SystemEvents.SessionEnding += SystemEvent_EndingSession;
+
                 StartMainApplication();
             }
         #if !DEBUG
@@ -227,6 +232,15 @@ namespace CollapseLauncher
         private static async Task InitDatabaseHandler()
         {
             await DbHandler.Init();
+        }
+
+        public static void SystemEvent_EndingSession(object sender, SessionEndingEventArgs e)
+        {
+            if (!IsCriticalOpInProgress) return;
+
+            e.Cancel = true;
+            ShutdownBlocker.StartBlocking(WindowUtility.CurrentWindowPtr, "Critical operation in progress",
+                                          ILoggerHelper.GetILogger("ShutdownBlocker"));
         }
 
         private static void InnoSetupLogUpdate_LoggerEvent(object sender, InnoSetupLogStruct e)

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -6,13 +6,11 @@ using Hi3Helper;
 using Hi3Helper.Http.Legacy;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.ClassStruct;
-using Hi3Helper.Win32.ManagedTools;
 using Hi3Helper.Win32.Native.LibraryImport;
 using Hi3Helper.Win32.Native.ManagedTools;
 using InnoSetupHelper;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
-using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -27,7 +25,6 @@ using System.Threading.Tasks;
 using WinRT;
 using static CollapseLauncher.ArgumentParser;
 using static CollapseLauncher.InnerLauncherConfig;
-using static CollapseLauncher.MainWindow;
 using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
@@ -204,8 +201,6 @@ namespace CollapseLauncher
                 MainEntryPointExtension.XamlCheckProcessRequirements();
                 ComWrappersSupport.InitializeComWrappers();
 
-                SystemEvents.SessionEnding += SystemEvent_EndingSession;
-
                 StartMainApplication();
             }
         #if !DEBUG
@@ -232,15 +227,6 @@ namespace CollapseLauncher
         private static async Task InitDatabaseHandler()
         {
             await DbHandler.Init();
-        }
-
-        public static void SystemEvent_EndingSession(object sender, SessionEndingEventArgs e)
-        {
-            if (!IsCriticalOpInProgress) return;
-
-            e.Cancel = true;
-            ShutdownBlocker.StartBlocking(WindowUtility.CurrentWindowPtr, Lang._Dialogs.EnsureExitSubtitle,
-                                          ILoggerHelper.GetILogger("ShutdownBlocker"));
         }
 
         private static void InnoSetupLogUpdate_LoggerEvent(object sender, InnoSetupLogStruct e)

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -51,7 +51,7 @@ namespace CollapseLauncher
                     
                     if (value)
                     {
-                        ShutdownBlocker.StartBlocking(WindowUtility.CurrentWindowPtr, "Critical operation in progress",
+                        ShutdownBlocker.StartBlocking(WindowUtility.CurrentWindowPtr, Locale.Lang._Dialogs.EnsureExitSubtitle,
                                                       ILoggerHelper.GetILogger("ShutdownBlocker"));
                     }
                     else if (lastValue)

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -294,7 +294,6 @@ namespace CollapseLauncher
 
             GamePropertyVault.SafeDisposeVaults();
             SentryHelper.StopSentrySdk();
-            SystemEvents.SessionEnding -= MainEntryPoint.SystemEvent_EndingSession;
             _TrayIcon?.Dispose();
             Close();
             Application.Current.Exit();

--- a/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainWindow.xaml.cs
@@ -19,7 +19,6 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
-using Microsoft.Win32;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -994,7 +994,7 @@ namespace CollapseLauncher.Dialogs
         public static Task<ContentDialogResult> Dialog_EnsureExit()
         {
             return SpawnDialog(Lang._Dialogs.EnsureExitTitle,
-                               Lang._Dialogs.EnsureExitSubtitle,
+                               $"{Lang._Dialogs.EnsureExitSubtitle} {Lang._Dialogs.EnsureExitSubtitle2}",
                                null,
                                Lang._Misc.NoCancel,
                                Lang._Misc.Yes,

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -105,12 +105,6 @@
         "resolved": "0.41.2",
         "contentHash": "oso8cno80OzCgAQOygtJXT1UhlVr2eSjwzXLqSLHyfKmSJ+3OcwDbrpzNwMj3/1SgncvQxP7OsNQ3bRfE3HvjQ=="
       },
-      "Microsoft.DotNet.ILCompiler": {
-        "type": "Direct",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "rfDodV68TLSUgVM6ZQusuUXD7GAIqwCKJWlPtfsd99iLlLbeGfqUQE7Xo8xLa1ju5GCdSBO0q35suzZ8ppclpA=="
-      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Direct",
         "requested": "[9.0.5, )",
@@ -630,15 +624,6 @@
         "resolved": "0.5.0",
         "contentHash": "5Tw6O9sBDAN1aV+kpOSVvqvFk6Ahk6bYz0TTx3808Dp40M45gKTtzTzI9SS1VeAkljE6BAOeKaykpPnG36oOgw=="
       },
-      "Microsoft.DotNet.ILCompiler": {
-        "type": "Direct",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "rfDodV68TLSUgVM6ZQusuUXD7GAIqwCKJWlPtfsd99iLlLbeGfqUQE7Xo8xLa1ju5GCdSBO0q35suzZ8ppclpA==",
-        "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "9.0.5"
-        }
-      },
       "Microsoft.Graphics.Win2D": {
         "type": "Direct",
         "requested": "[1.3.2, )",
@@ -688,11 +673,6 @@
           "Microsoft.WindowsAppSDK.Base": "1.8.250501001-experimental",
           "Microsoft.WindowsAppSDK.InteractiveExperiences": "1.8.250506001-experimental"
         }
-      },
-      "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
-        "type": "Transitive",
-        "resolved": "9.0.5",
-        "contentHash": "/x+iKUhSOhYrbaEr9x78wZmBk7Le8FlY9Xwx7uENRFCZ7K5sGrTffkJiig22EzYuALh8SeixjSzVFS0nm5+NgQ=="
       }
     }
   }

--- a/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangDialogs.cs
@@ -212,6 +212,7 @@ namespace Hi3Helper
                 public string UACWarningDontShowAgain { get; set; } = LangFallback?._Dialogs.UACWarningDontShowAgain;
                 public string EnsureExitTitle { get; set; } = LangFallback?._Dialogs.EnsureExitTitle;
                 public string EnsureExitSubtitle { get; set; } = LangFallback?._Dialogs.EnsureExitSubtitle;
+                public string EnsureExitSubtitle2 { get; set; } = LangFallback?._Dialogs.EnsureExitSubtitle2;
                 
                 public string UserFeedback_DialogTitle { get; set; } = LangFallback?._Dialogs.UserFeedback_DialogTitle;
                 public string UserFeedback_TextFieldTitleHeader { get; set; } = LangFallback?._Dialogs.UserFeedback_TextFieldTitleHeader;

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -1080,7 +1080,8 @@
     "UACWarningDontShowAgain": "Don't Show Again",
 
     "EnsureExitTitle": "Exiting Application",
-    "EnsureExitSubtitle": "There are critical operations running in the background. Are you sure you want to exit?",
+    "EnsureExitSubtitle": "There are critical operations running in the background.",
+    "EnsureExitSubtitle2": "Are you sure you want to exit?",
 
     "UserFeedback_DialogTitle": "Share Your Thoughts",
     "UserFeedback_TextFieldTitleHeader": "Feedback Title",


### PR DESCRIPTION
# Main Goal
Preventing Windows from ending it's ~~life~~ session when Collapse is running critical task. Should prevent accidental shutting down when Collapse is installing/updating/repairing games.

![image](https://github.com/user-attachments/assets/97f8d356-e6a3-43ed-a0d3-9c1f2ed9675e)

Thanks @neon-nyan for the screenshot.

P.S. This doesn't work when you run Collapse inside a debugger, because the debugger will kill its target process when Windows is ending the session.

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
