### PR TITLE
[Hotfix] Stable 1.82.27 Release

### DIFF
--- a/CollapseLauncher/Classes/Extension/DictionaryExtension.cs
+++ b/CollapseLauncher/Classes/Extension/DictionaryExtension.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CollapseLauncher.Classes.Extension
+namespace CollapseLauncher.Extension
 {
 #nullable enable
     public static class DictionaryExtension

--- a/CollapseLauncher/Classes/Extension/DispatcherQueueExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/DispatcherQueueExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.UI.Dispatching;
+using System;
+
+namespace CollapseLauncher.Extension
+{
+    public static class DispatcherQueueExtensions
+    {
+        public static bool HasThreadAccessSafe(this DispatcherQueue queue)
+        {
+            if (queue == null) return false;
+
+            try
+            {
+                return queue.HasThreadAccess;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false; // Return false if an exception occurs
+            }
+        }
+    }
+}

--- a/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
@@ -888,7 +888,7 @@ namespace CollapseLauncher.Extension
             // attach the shadow while the element is already loaded.
             if (element.Parent is null) element.Loaded += (_, _) =>
             {
-                if (element.DispatcherQueue.HasThreadAccess)
+                if (element.DispatcherQueue.HasThreadAccessSafe())
                     AssignShadowAttachment(element, isMasked);
                 else
                     element.DispatcherQueue.TryEnqueue(() => AssignShadowAttachment(element, isMasked));

--- a/CollapseLauncher/Classes/Extension/VelopackLocatorExtension.cs
+++ b/CollapseLauncher/Classes/Extension/VelopackLocatorExtension.cs
@@ -20,7 +20,7 @@ using Velopack.Locators;
 // ReSharper disable CommentTypo
 
 #nullable enable
-namespace CollapseLauncher.Classes.Extension
+namespace CollapseLauncher.Extension
 {
     internal static class VelopackLocatorExtension
     {

--- a/CollapseLauncher/Classes/Extension/VelopackLoggerExtension.cs
+++ b/CollapseLauncher/Classes/Extension/VelopackLoggerExtension.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using Velopack.Logging;
 
-namespace CollapseLauncher.Classes.Extension
+namespace CollapseLauncher.Extension
 {
     public class VelopackLoggerAdaptor(ILogger logger) : IVelopackLogger
     {

--- a/CollapseLauncher/Classes/Helper/Animation/AnimationHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Animation/AnimationHelper.cs
@@ -1,4 +1,5 @@
-﻿using Hi3Helper;
+using CollapseLauncher.Extension;
+using Hi3Helper;
 using Hi3Helper.CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
@@ -35,7 +36,7 @@ namespace CollapseLauncher.Helper.Animation
         {
             foreach (KeyFrameAnimation anim in animBase!)
             {
-                if (element?.DispatcherQueue?.HasThreadAccess ?? false)
+                if (element?.DispatcherQueue?.HasThreadAccessSafe() ?? false)
                 {
                     anim!.Duration = duration;
                     element.StartAnimation(anim);
@@ -53,7 +54,7 @@ namespace CollapseLauncher.Helper.Animation
         internal static async Task StartAnimation(this UIElement element, TimeSpan duration, params KeyFrameAnimation[] animBase)
         {
             CompositionAnimationGroup animGroup = null;
-            if (element.DispatcherQueue?.HasThreadAccess ?? false)
+            if (element.DispatcherQueue?.HasThreadAccessSafe() ?? false)
             {
                 animGroup = CompositionTarget.GetCompositorForCurrentThread().CreateAnimationGroup();
             }
@@ -69,7 +70,7 @@ namespace CollapseLauncher.Helper.Animation
             {
                 foreach (KeyFrameAnimation anim in animBase!)
                 {
-                    if (element.DispatcherQueue?.HasThreadAccess ?? false)
+                    if (element.DispatcherQueue?.HasThreadAccessSafe() ?? false)
                     {
                         anim.Duration = duration;
                         anim.StopBehavior = AnimationStopBehavior.LeaveCurrentValue;
@@ -83,7 +84,7 @@ namespace CollapseLauncher.Helper.Animation
                             animGroup.Add(anim);
                         });
                 }
-                if (element.DispatcherQueue?.HasThreadAccess ?? false)
+                if (element.DispatcherQueue?.HasThreadAccessSafe() ?? false)
                 {
                     element.StartAnimation(animGroup);
                 }

--- a/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
+++ b/CollapseLauncher/Classes/Helper/Background/BackgroundMediaUtility.cs
@@ -486,6 +486,7 @@ namespace CollapseLauncher.Helper.Background
 
         public static void SetAlternativeFileStream(FileStream stream)
         {
+            _alternativeFileStream?.Dispose();
             _alternativeFileStream = stream;
         }
 

--- a/CollapseLauncher/Classes/Helper/Database/DBHandler.cs
+++ b/CollapseLauncher/Classes/Helper/Database/DBHandler.cs
@@ -260,7 +260,8 @@ namespace CollapseLauncher.Helper.Database
                 {
                     LogWriteLine($"[DBHandler::QueryKey] Failed when getting value for key {key}! Retrying...\r\n{ex}",
                                  LogType.Error, true);
-                    break;
+                    
+                    await Task.Delay(500);
                 }
                 catch (Exception ex) when (!redirectThrow)
                 {
@@ -326,7 +327,8 @@ namespace CollapseLauncher.Helper.Database
                 {
                     LogWriteLine($"[DBHandler::StoreKeyValue] Failed when saving value for key {key}! Retrying...\r\n{ex}",
                                  LogType.Error, true);
-                    break;
+                    
+                    await Task.Delay(500);
                 }
                 catch (Exception ex) when (!redirectThrow)
                 {

--- a/CollapseLauncher/Classes/Helper/Database/DBHandler.cs
+++ b/CollapseLauncher/Classes/Helper/Database/DBHandler.cs
@@ -137,9 +137,17 @@ namespace CollapseLauncher.Helper.Database
                 _ = UserId;
 
                 if (string.IsNullOrEmpty(Uri))
-                    throw new NullReferenceException(Lang._SettingsPage.Database_Error_EmptyUri);
+                {
+                    IsEnabled = false;
+                    throw new NullReferenceException($"DB_001 {Lang._SettingsPage.Database_Error_EmptyUri}");
+                }
+                    
                 if (string.IsNullOrEmpty(Token))
-                    throw new NullReferenceException(Lang._SettingsPage.Database_Error_EmptyToken);
+                {
+                    IsEnabled = false;
+                    throw new NullReferenceException($"DB_002 {Lang._SettingsPage.Database_Error_EmptyToken}");
+                }
+                    
 
                 // Connect to database
                 // Libsql-client-dotnet technically support file based SQLite by pushing `file://` proto in the URL.
@@ -184,7 +192,7 @@ namespace CollapseLauncher.Helper.Database
             {
                 LogWriteLine($"[DBHandler::Init] Error when connecting to database system! Token invalid!\r\n{e}",
                              LogType.Error, true);
-                var ex = new AggregateException("Unauthorized: wrong token inserted", e);
+                var ex = new AggregateException("DB_003 Unauthorized: wrong token inserted", e);
                 throw ex;
             }
             catch (Exception e)

--- a/CollapseLauncher/Classes/Helper/Loading/LoadingMessageHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Loading/LoadingMessageHelper.cs
@@ -78,7 +78,7 @@ namespace CollapseLauncher.Helper.Loading
         {
             try
             {
-                if (CurrentMainWindow.LoadingStatusBackgroundGrid.DispatcherQueue.HasThreadAccess)
+                if (CurrentMainWindow.LoadingStatusBackgroundGrid.DispatcherQueue.HasThreadAccessSafe())
                 {
                     await ShowLoadingFrameInner();
                     return;
@@ -118,7 +118,7 @@ namespace CollapseLauncher.Helper.Loading
         {
             try
             {
-                if (CurrentMainWindow.LoadingStatusBackgroundGrid.DispatcherQueue.HasThreadAccess)
+                if (CurrentMainWindow.LoadingStatusBackgroundGrid.DispatcherQueue.HasThreadAccessSafe())
                 {
                     await HideLoadingFrameInner();
                     return;

--- a/CollapseLauncher/Classes/Helper/TaskSchedulerHelper.cs
+++ b/CollapseLauncher/Classes/Helper/TaskSchedulerHelper.cs
@@ -1,4 +1,4 @@
-﻿using CollapseLauncher.Classes.Extension;
+﻿using CollapseLauncher.Extension;
 using Hi3Helper;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.Region;

--- a/CollapseLauncher/Classes/Helper/Update/LauncherUpdateHelper.cs
+++ b/CollapseLauncher/Classes/Helper/Update/LauncherUpdateHelper.cs
@@ -1,4 +1,4 @@
-﻿using CollapseLauncher.Classes.Extension;
+﻿using CollapseLauncher.Extension;
 using Hi3Helper;
 using Hi3Helper.Data;
 using Hi3Helper.SentryHelper;

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -107,7 +107,7 @@ namespace CollapseLauncher.Helper
                 try
                 {
                     DispatcherQueue dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-                    if (dispatcherQueue.HasThreadAccess)
+                    if (dispatcherQueue.HasThreadAccessSafe())
                     {
                         return CurrentWindowId.HasValue
                             ? DisplayInformation.CreateForWindowId(CurrentWindowId.Value)

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -794,10 +794,10 @@ namespace CollapseLauncher.Helper
 
         internal static void EnableWindowNonClientArea()
         {
-            if (!CurrentWindowId.HasValue || CurrentAppWindow == null)
-            {
-                return;
-            }
+            // Do early check to prevent null reference exception
+            if (CurrentWindow == null || CurrentAppWindow == null) return;
+            
+            if (!CurrentWindowId.HasValue) return;
 
             double                       scaleFactor = CurrentWindowMonitorScaleFactor;
             InputNonClientPointerSource? incps       = CurrentInputNonClientPointerSource;
@@ -811,10 +811,9 @@ namespace CollapseLauncher.Helper
 
         internal static void DisableWindowNonClientArea()
         {
-            if (!CurrentWindowId.HasValue || CurrentAppWindow == null)
-            {
-                return;
-            }
+            if (CurrentWindow == null || CurrentAppWindow == null) return;
+            
+            if (!CurrentWindowId.HasValue) return;
 
             double                       scaleFactor = CurrentWindowMonitorScaleFactor;
             InputNonClientPointerSource? incps       = CurrentInputNonClientPointerSource;

--- a/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Base/InstallManagerBase.Sophon.cs
@@ -82,12 +82,27 @@ namespace CollapseLauncher.InstallManager.Base
         #endregion
 
         #region Public Virtual Properties
-        public virtual bool IsUseSophon =>
-            GameVersionManager.IsForceRedirectToSophon() ||
-            (GameVersionManager.GamePreset.LauncherResourceChunksURL != null
-            && !File.Exists(Path.Combine(GamePath, "@DisableSophon"))
-            && !_canDeltaPatch && !_forceIgnoreDeltaPatch
-            && LauncherConfig.GetAppConfigValue("IsEnableSophon").ToBool());
+        public virtual bool IsUseSophon
+        {
+            get
+            {
+                bool isForceRedirect = GameVersionManager.IsForceRedirectToSophon();
+                bool isEnabled = GameVersionManager.GamePreset.LauncherResourceChunksURL != null
+                                 && !File.Exists(Path.Combine(GamePath, "@DisableSophon"))
+                                 && !_canDeltaPatch
+                                 && !_forceIgnoreDeltaPatch
+                                 && LauncherConfig.GetAppConfigValue("IsEnableSophon").ToBool();
+
+                return isForceRedirect || isEnabled;
+            }
+        }
+
+        public virtual bool AskAdditionalSophonPkg
+        {
+            get => File.Exists(Path.Combine(GamePath, "@AskAdditionalSophonPackage"));
+        }
+
+        public string[] CommonSophonPackageMatchingFields = ["game", "en-us", "zh-tw", "zh-cn", "ko-kr", "ja-jp"];
         #endregion
 
         #region Sophon Verification Methods
@@ -540,14 +555,17 @@ namespace CollapseLauncher.InstallManager.Base
             long sizeAdditionalToDownload = otherManifestIdentity
                                            .Sum(x => x.ChunkInfo.CompressedSize);
 
-            bool isDownloadAdditionalData = await SpawnAdditionalPackageDownloadDialog(sizeCurrentToDownload,
-                                                                                       sizeAdditionalToDownload,
-                                                                                       false,
-                                                                                       GetFileDetails);
-
-            if (!isDownloadAdditionalData)
+            if (AskAdditionalSophonPkg)
             {
-                return;
+                bool isDownloadAdditionalData = await SpawnAdditionalPackageDownloadDialog(sizeCurrentToDownload,
+                                                                                           sizeAdditionalToDownload,
+                                                                                           false,
+                                                                                           GetFileDetails);
+
+                if (!isDownloadAdditionalData)
+                {
+                    return;
+                }
             }
 
             List<string> additionalMatchingFields = otherManifestIdentity.Select(x => x.MatchingField).ToList();
@@ -702,6 +720,7 @@ namespace CollapseLauncher.InstallManager.Base
                         requestedBaseUrlTo,
                         sophonUpdateAssetList,
                         GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField,
+                        false,
                         downloadSpeedLimiter);
 
                     // If it doesn't success to get the base diff, then fallback to actually download the whole game
@@ -748,10 +767,19 @@ namespace CollapseLauncher.InstallManager.Base
                     if (_gameAudioLangListPath != null)
                     {
                         // Add existing voice-over diff data
-                        await AddSophonAdditionalVODiffAssetsToList(httpClient,         requestedBaseUrlFrom,
-                                                                    requestedBaseUrlTo, sophonUpdateAssetList,
+                        await AddSophonAdditionalVODiffAssetsToList(httpClient,
+                                                                    requestedBaseUrlFrom,
+                                                                    requestedBaseUrlTo,
+                                                                    sophonUpdateAssetList,
                                                                     downloadSpeedLimiter);
                     }
+
+                    await TryGetAdditionalPackageForSophonDiff(httpClient,
+                                                               requestedBaseUrlFrom,
+                                                               requestedBaseUrlTo,
+                                                               GameVersionManager.GamePreset.LauncherResourceChunksURL.MainBranchMatchingField,
+                                                               sophonUpdateAssetList,
+                                                               downloadSpeedLimiter);
                 }
 
                 // Get the remote chunk size
@@ -972,27 +1000,69 @@ namespace CollapseLauncher.InstallManager.Base
             }
         }
 
-#endregion
+        #endregion
 
         #region Sophon Asset Package Methods
+        private async Task TryGetAdditionalPackageForSophonDiff(HttpClient                 httpClient,
+                                                                string                     requestedUrlFrom,
+                                                                string                     requestedUrlTo,
+                                                                string                     mainMatchingField,
+                                                                List<SophonAsset>          sophonPreloadAssetList,
+                                                                SophonDownloadSpeedLimiter downloadSpeedLimiter)
+        {
+            SophonChunkManifestInfoPair manifestPair = await SophonManifest
+               .CreateSophonChunkManifestInfoPair(httpClient, requestedUrlTo, mainMatchingField, false, Token.Token);
+
+            if (!manifestPair.IsFound)
+            {
+                return;
+            }
+
+            List<string> additionalPackageMatchingFields = manifestPair.OtherSophonBuildData.ManifestIdentityList
+               .Where(x => !CommonSophonPackageMatchingFields.Contains(x.MatchingField, StringComparer.OrdinalIgnoreCase))
+               .Select(x => x.MatchingField)
+               .ToList();
+
+            if (additionalPackageMatchingFields.Count == 0)
+            {
+                return;
+            }
+
+            foreach (string matchingField in additionalPackageMatchingFields)
+            {
+                await AddSophonDiffAssetsToList(httpClient,
+                                                requestedUrlFrom,
+                                                requestedUrlTo,
+                                                sophonPreloadAssetList,
+                                                matchingField,
+                                                true,
+                                                downloadSpeedLimiter);
+            }
+        }
+
         private async Task<bool> AddSophonDiffAssetsToList(HttpClient                 httpClient,
                                                            string                     requestedUrlFrom,
                                                            string                     requestedUrlTo,
                                                            List<SophonAsset>          sophonPreloadAssetList,
                                                            string                     matchingField,
+                                                           bool                       discardIfOldNotExist,
                                                            SophonDownloadSpeedLimiter downloadSpeedLimiter)
         {
             // Get the manifest pair for both previous (from) and next (to) version
             SophonChunkManifestInfoPair requestPairFrom = await SophonManifest
-               .CreateSophonChunkManifestInfoPair(httpClient, requestedUrlFrom, matchingField, Token.Token);
+               .CreateSophonChunkManifestInfoPair(httpClient, requestedUrlFrom, matchingField, false, Token.Token);
             SophonChunkManifestInfoPair requestPairTo = await SophonManifest
-               .CreateSophonChunkManifestInfoPair(httpClient, requestedUrlTo, matchingField, Token.Token);
+               .CreateSophonChunkManifestInfoPair(httpClient, requestedUrlTo, matchingField, false, Token.Token);
 
             // If the request pair source is not found, then return false
-            if (!requestPairFrom.IsFound)
+            if (!requestPairFrom.IsFound && !requestPairTo.IsFound)
             {
                 Logger.LogWriteLine($"Sophon manifest for source via URL: {requestedUrlFrom} is not found! Return message: {requestPairFrom.ReturnMessage} ({requestPairFrom.ReturnCode})", LogType.Warning, true);
-                return false;
+                if (!requestPairTo.IsFound)
+                {
+                    return false;
+                }
+                Logger.LogWriteLine($"The target Sophon manifest still exist. The assets from target's matching field: {matchingField} will be used instead!", LogType.Warning, true);
             }
 
             // If the request pair target is not found, then return false
@@ -1002,19 +1072,37 @@ namespace CollapseLauncher.InstallManager.Base
                 return false;
             }
 
-            // Ensure that the manifest is ordered based on _gameVoiceLanguageLocaleIdOrdered
-            RearrangeDataListLocaleOrder(requestPairFrom.OtherSophonBuildData.ManifestIdentityList,
-                                         x => x.MatchingField);
             RearrangeDataListLocaleOrder(requestPairTo.OtherSophonBuildData.ManifestIdentityList,
                                          x => x.MatchingField);
 
-            // Add asset to the list
-            await foreach (SophonAsset sophonAsset in SophonUpdate
-                                                     .EnumerateUpdateAsync(httpClient, requestPairFrom, requestPairTo,
-                                                                           false,      downloadSpeedLimiter)
-                                                     .WithCancellation(Token.Token))
+            if (requestPairFrom.IsFound)
             {
-                sophonPreloadAssetList.Add(sophonAsset);
+                // Ensure that the manifest is ordered based on _gameVoiceLanguageLocaleIdOrdered
+                RearrangeDataListLocaleOrder(requestPairFrom.OtherSophonBuildData.ManifestIdentityList,
+                                             x => x.MatchingField);
+
+                // Add asset to the list
+                await foreach (SophonAsset sophonAsset in SophonUpdate
+                                                         .EnumerateUpdateAsync(httpClient, requestPairFrom, requestPairTo,
+                                                                               false, downloadSpeedLimiter)
+                                                         .WithCancellation(Token.Token))
+                {
+                    sophonPreloadAssetList.Add(sophonAsset);
+                }
+            }
+            else
+            {
+                await foreach (SophonAsset sophonAsset in SophonManifest.EnumerateAsync(httpClient, requestPairTo, downloadSpeedLimiter, Token.Token))
+                {
+                    string filePath = Path.Combine(GamePath, sophonAsset.AssetName);
+                    if (!File.Exists(filePath) && discardIfOldNotExist)
+                    {
+                        Logger.LogWriteLine($"Asset from matching field: {matchingField} is discarded: {sophonAsset.AssetName}", LogType.Warning, true);
+                        continue;
+                    }
+
+                    sophonPreloadAssetList.Add(sophonAsset);
+                }
             }
 
             // Return as success
@@ -1030,8 +1118,13 @@ namespace CollapseLauncher.InstallManager.Base
             // Get the main VO language name from Id
             string mainLangId = GetLanguageLocaleCodeByID(_gameVoiceLanguageID);
             // Get the manifest pair for both previous (from) and next (to) version for the main VO
-            await AddSophonDiffAssetsToList(httpClient,             requestedUrlFrom, requestedUrlTo,
-                                            sophonPreloadAssetList, mainLangId,       downloadSpeedLimiter);
+            await AddSophonDiffAssetsToList(httpClient,
+                                            requestedUrlFrom,
+                                            requestedUrlTo,
+                                            sophonPreloadAssetList,
+                                            mainLangId,
+                                            false,
+                                            downloadSpeedLimiter);
 
             // Check if the audio lang list file is exist, then try add others
             FileInfo fileInfo = new FileInfo(_gameAudioLangListPath).StripAlternateDataStream().EnsureNoReadOnly();
@@ -1047,7 +1140,7 @@ namespace CollapseLauncher.InstallManager.Base
 #if !DEBUG
                         , false
 #endif
-                                                                               );
+                        );
 
                     // Check if the voice pack is actually the same as default.
                     if (string.IsNullOrEmpty(otherLangId) ||
@@ -1057,8 +1150,13 @@ namespace CollapseLauncher.InstallManager.Base
                     }
 
                     // Get the manifest pair for both previous (from) and next (to) version for other VOs
-                    await AddSophonDiffAssetsToList(httpClient,             requestedUrlFrom, requestedUrlTo,
-                                                    sophonPreloadAssetList, otherLangId,      downloadSpeedLimiter);
+                    await AddSophonDiffAssetsToList(httpClient,
+                                                    requestedUrlFrom,
+                                                    requestedUrlTo,
+                                                    sophonPreloadAssetList,
+                                                    otherLangId,
+                                                    false,
+                                                    downloadSpeedLimiter);
                 }
             }
         }

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -1418,7 +1418,7 @@ namespace CollapseLauncher.Interfaces
         {
             try
             {
-                if (ParentUI!.DispatcherQueue!.HasThreadAccess)
+                if (ParentUI!.DispatcherQueue!.HasThreadAccessSafe())
                 {
                     if (assetProperty == null)
                     {

--- a/CollapseLauncher/Classes/RegionManagement/FallbackCDNUtil.cs
+++ b/CollapseLauncher/Classes/RegionManagement/FallbackCDNUtil.cs
@@ -1,4 +1,4 @@
-﻿using CollapseLauncher.Classes.Extension;
+﻿using CollapseLauncher.Extension;
 using CollapseLauncher.Helper;
 using Hi3Helper;
 using Hi3Helper.Data;

--- a/CollapseLauncher/Classes/ShortcutCreator/SteamShortcut.cs
+++ b/CollapseLauncher/Classes/ShortcutCreator/SteamShortcut.cs
@@ -1,4 +1,4 @@
-﻿using CollapseLauncher.Classes.Extension;
+﻿using CollapseLauncher.Extension;
 using CollapseLauncher.Helper.Loading;
 using CollapseLauncher.Helper.Metadata;
 using Hi3Helper;

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -16,7 +16,7 @@
         <Authors>$(Company). neon-nyan, Cry0, bagusnl, shatyuka, gablm.</Authors>
         <Copyright>Copyright 2022-2025 $(Company)</Copyright>
         <!-- Versioning -->
-        <Version>1.82.26</Version>
+        <Version>1.82.27</Version>
         <LangVersion>preview</LangVersion>
         <!-- Target Settings -->
         <Platforms>x64</Platforms>

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -222,7 +222,16 @@ namespace CollapseLauncher
 
         private static async Task InitDatabaseHandler()
         {
-            await DbHandler.Init();
+            try
+            {
+                await DbHandler.Init();
+            }
+            catch (Exception e)
+            {
+                LogWriteLine($"There was an error while initializing the database handler!\r\n{e}",
+                             LogType.Error, true);
+                await SentryHelper.ExceptionHandlerAsync(e);
+            }
         }
 
         private static void InnoSetupLogUpdate_LoggerEvent(object sender, InnoSetupLogStruct e)
@@ -270,7 +279,7 @@ namespace CollapseLauncher
         #endif
         }
 
-        public static void StartMainApplication()
+        private static void StartMainApplication()
         {
             Application.Start(_ =>
                               {

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -1,4 +1,4 @@
-using CollapseLauncher.Classes.Extension;
+using CollapseLauncher.Extension;
 using CollapseLauncher.Helper;
 using CollapseLauncher.Helper.Database;
 using CollapseLauncher.Helper.Update;

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -251,7 +251,7 @@ namespace CollapseLauncher
             if (e.Exception.GetType() == typeof(NotImplementedException))
             {
                 PreviousTag = "unavailable";
-                if (!DispatcherQueue?.HasThreadAccess ?? false)
+                if (!DispatcherQueue?.HasThreadAccessSafe() ?? false)
                     DispatcherQueue?.TryEnqueue(() => MainFrameChanger.ChangeMainFrame(typeof(UnavailablePage)));
                 else
                     MainFrameChanger.ChangeMainFrame(typeof(UnavailablePage));

--- a/CollapseLauncher/XAMLs/MainApp/Pages/CachesPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/CachesPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿#if !DISABLEDISCORD
 using CollapseLauncher.DiscordPresence;
 #endif
+using CollapseLauncher.Extension;
 using CollapseLauncher.Helper;
 using CollapseLauncher.Statics;
 using Hi3Helper;
@@ -194,7 +195,7 @@ namespace CollapseLauncher.Pages
 
         private void _cacheTool_StatusChanged(object sender, TotalPerFileStatus e)
         {
-            if (!DispatcherQueue.HasThreadAccess)
+            if (!DispatcherQueue.HasThreadAccessSafe())
             {
                 DispatcherQueue?.TryEnqueue(Update);
                 return;
@@ -214,7 +215,7 @@ namespace CollapseLauncher.Pages
 
         private void _cacheTool_ProgressChanged(object sender, TotalPerFileProgress e)
         {
-            if (!DispatcherQueue.HasThreadAccess)
+            if (!DispatcherQueue.HasThreadAccessSafe())
             {
                 DispatcherQueue?.TryEnqueue(Update);
                 return;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -1309,10 +1309,6 @@ namespace CollapseLauncher.Dialogs
                     Message = exceptionContent
                 };
                 UserFeedbackResult? feedbackResult = await feedbackDialog.ShowAsync();
-                // TODO: (Optional) Implement generic user feedback pathway (preferably when SentryErrorId is null
-                // Using https://paste.mozilla.org/ 
-                // API Documentation: https://docs.dpaste.org/api/
-                // Though im not sure since user will still need to paste the link to us 🤷
 
                 if (feedbackResult is null)
                 {

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.GameManagement.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.GameManagement.cs
@@ -1,5 +1,6 @@
 using CollapseLauncher.CustomControls;
 using CollapseLauncher.Dialogs;
+using CollapseLauncher.Extension;
 using CollapseLauncher.Helper;
 using CollapseLauncher.Helper.Animation;
 using CollapseLauncher.Helper.Image;
@@ -452,7 +453,7 @@ public sealed partial class HomePage
 
     private void GameInstall_StatusChanged(object sender, TotalPerFileStatus e)
     {
-        if (DispatcherQueue.HasThreadAccess)
+        if (DispatcherQueue != null && DispatcherQueue.HasThreadAccessSafe())
             GameInstall_StatusChanged_Inner(e);
         else
             DispatcherQueue?.TryEnqueue(() => GameInstall_StatusChanged_Inner(e));
@@ -469,7 +470,7 @@ public sealed partial class HomePage
 
     private void GameInstall_ProgressChanged(object sender, TotalPerFileProgress e)
     {
-        if (DispatcherQueue.HasThreadAccess)
+        if (DispatcherQueue != null && DispatcherQueue.HasThreadAccessSafe())
             GameInstall_ProgressChanged_Inner(e);
         else
             DispatcherQueue?.TryEnqueue(() => GameInstall_ProgressChanged_Inner(e));
@@ -486,7 +487,7 @@ public sealed partial class HomePage
 
     private void GameInstallSophon_StatusChanged(object sender, TotalPerFileStatus e)
     {
-        if (DispatcherQueue.HasThreadAccess)
+        if (DispatcherQueue != null && DispatcherQueue.HasThreadAccessSafe())
             GameInstallSophon_StatusChanged_Inner(e);
         else
             DispatcherQueue?.TryEnqueue(() => GameInstallSophon_StatusChanged_Inner(e));
@@ -494,7 +495,7 @@ public sealed partial class HomePage
 
     private void GameInstallSophon_ProgressChanged(object sender, TotalPerFileProgress e)
     {
-        if (DispatcherQueue.HasThreadAccess)
+        if (DispatcherQueue != null && DispatcherQueue.HasThreadAccessSafe())
             GameInstallSophon_ProgressChanged_Inner(e);
         else
             DispatcherQueue?.TryEnqueue(() => GameInstallSophon_ProgressChanged_Inner(e));

--- a/CollapseLauncher/XAMLs/MainApp/Pages/RepairPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/RepairPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿#if !DISABLEDISCORD
 using CollapseLauncher.DiscordPresence;
 #endif
+using CollapseLauncher.Extension;
 using CollapseLauncher.Helper;
 using Hi3Helper;
 using Hi3Helper.Shared.ClassStruct;
@@ -193,7 +194,7 @@ namespace CollapseLauncher.Pages
 
         private void _repairTool_StatusChanged(object sender, TotalPerFileStatus e)
         {
-            if (!DispatcherQueue.HasThreadAccess)
+            if (!DispatcherQueue.HasThreadAccessSafe())
             {
                 DispatcherQueue?.TryEnqueue(Update);
                 return;
@@ -215,7 +216,7 @@ namespace CollapseLauncher.Pages
 
         private void _repairTool_ProgressChanged(object sender, TotalPerFileProgress e)
         {
-            if (!DispatcherQueue.HasThreadAccess)
+            if (!DispatcherQueue.HasThreadAccessSafe())
             {
                 DispatcherQueue?.TryEnqueue(Update);
                 return;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -2115,7 +2115,7 @@
                         HorizontalContentAlignment="Stretch"
                         Click="ShareYourFeedbackClick"
                         CornerRadius="{x:Bind ext:UIElementExtensions.AttachRoundedKindCornerRadius(ShareYourFeedbackButton)}"
-                        IsEnabled="False"
+                        IsEnabled="True"
                         Style="{ThemeResource AccentButtonStyle}">
                     <Grid Margin="0,-2,0,0"
                           HorizontalAlignment="Stretch">

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -422,48 +422,30 @@ namespace CollapseLauncher.Pages
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
 #if ENABLEUSERFEEDBACK
-            var userTemplate  = Lang._Misc.ExceptionFeedbackTemplate_User;
-            var emailTemplate = Lang._Misc.ExceptionFeedbackTemplate_Email;
-            string exceptionContent = $"""
-                                       {userTemplate} 
-                                       {emailTemplate} 
-                                       {Lang._Misc.ExceptionFeedbackTemplate_Message}
-                                       ------------------------------------
-                                       """;
-            
+            var content = UserFeedbackTemplate.FeedbackTemplate;
             
             UserFeedbackDialog userFeedbackDialog = new UserFeedbackDialog(XamlRoot, true)
             { 
-                Message   = exceptionContent
+                Message   = content
             };
             
-            UserFeedbackResult userFeedbackResult = await userFeedbackDialog
-               .ShowAsync( result => throw new NotImplementedException());
+            UserFeedbackResult userFeedbackResult = await userFeedbackDialog.ShowAsync();
 
             if (userFeedbackResult == null)
             {
                 LogWriteLine("User feedback dialog cancelled!");
                 return;
             }
+
+            var parsedFeedback = UserFeedbackTemplate.ParseTemplate(userFeedbackResult);
             
-            // Parse username and email
-            var msg = userFeedbackResult.Message.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-            if (msg.Length <= 4) return; // Do not send feedback if format is not correct
-            var user     = msg[0].Replace(userTemplate, "", StringComparison.InvariantCulture).Trim();
-            var email    = msg[1].Replace(userTemplate, "", StringComparison.InvariantCulture).Trim();
-            var feedback = msg.Length > 4 ? string.Join("\n", msg.Skip(4)).Trim() : null;
+            if (parsedFeedback == null)
+            {
+                LogWriteLine("Feedback result failed to be parsed! Feedback not sent.", LogType.Error, true);
+                return;
+            }
 
-            if (string.IsNullOrEmpty(user)) user = "none";
-
-            // Validate email
-            var addr = System.Net.Mail.MailAddress.TryCreate(email, out var address);
-            email = addr ? address!.Address : "user@collapselauncher.com";
-
-            if (string.IsNullOrEmpty(feedback)) return;
-
-            var feedbackContent = $"{feedback}\n\nRating: {userFeedbackResult.Rating}/5";
-
-            SentryHelper.SendGenericFeedback(feedbackContent, email, user);
+            SentryHelper.SendGenericFeedback(parsedFeedback.Message, parsedFeedback.Email, parsedFeedback.User);
         #endif
         }
 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -236,6 +236,10 @@ namespace CollapseLauncher.Pages
         {
             try
             {
+                var stream = BackgroundMediaUtility.GetAlternativeFileStream();
+                if (stream != null)
+                    await stream.DisposeAsync();
+
                 (sender as Button).IsEnabled = false;
                 if (Directory.Exists(AppGameImgFolder))
                     Directory.Delete(AppGameImgFolder, true);

--- a/CollapseLauncher/XAMLs/Updater/Classes/Updater.cs
+++ b/CollapseLauncher/XAMLs/Updater/Classes/Updater.cs
@@ -1,4 +1,4 @@
-﻿using CollapseLauncher.Classes.Extension;
+﻿using CollapseLauncher.Extension;
 using CollapseLauncher.Helper;
 using CollapseLauncher.Helper.Update;
 using Hi3Helper;

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -353,19 +353,6 @@
         "resolved": "1.7.20250508.1",
         "contentHash": "omgDNQElO0w0wY20I7XLGHISyn7Z4quh9Pc+Gp9XkRHJgiks7ARDhq4Vu+DK32bDoCBrFe1CLK4ovete4QiuVw=="
       },
-      "Microsoft.Windows.SDK.Win32Metadata": {
-        "type": "Transitive",
-        "resolved": "63.0.31-preview",
-        "contentHash": "ImR/LEJIcTiQuwYognFXPED1+zRjlb4WYX5mC3E8d0Q09Zey+MMqfMDxNlX1vBbcP3dy/Fp0Lbav25FsXZwyYQ=="
-      },
-      "Microsoft.Windows.WDK.Win32Metadata": {
-        "type": "Transitive",
-        "resolved": "0.13.25-experimental",
-        "contentHash": "IM50tb/+UIwBr9FMr6ZKcZjCMW+Axo6NjGqKxgjUfyCY8dRnYUfrJEXxAaXoWtYP4X8EmASmC1Jtwh4XucseZg==",
-        "dependencies": {
-          "Microsoft.Windows.SDK.Win32Metadata": "63.0.31-preview"
-        }
-      },
       "Microsoft.WindowsAppSDK.AI": {
         "type": "Transitive",
         "resolved": "1.8.135-experimental",
@@ -515,9 +502,7 @@
         "type": "Project",
         "dependencies": {
           "H.GeneratedIcons.System.Drawing": "[1.0.0, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[9.0.5, )",
-          "Microsoft.Windows.SDK.Win32Metadata": "[63.0.31-preview, )",
-          "Microsoft.Windows.WDK.Win32Metadata": "[0.13.25-experimental, )"
+          "Microsoft.Extensions.Logging.Abstractions": "[9.0.5, )"
         }
       },
       "h.notifyicon.winui": {
@@ -525,8 +510,6 @@
         "dependencies": {
           "H.NotifyIcon": "[0.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.5, )",
-          "Microsoft.Web.WebView2": "[1.0.3344-prerelease, )",
-          "Microsoft.Windows.SDK.BuildTools": "[10.0.26100.4188, )",
           "Microsoft.WindowsAppSDK": "[1.8.250515001-experimental2, )"
         }
       },

--- a/Hi3Helper.Core/Classes/SentryHelper/SentryExceptionFilter.cs
+++ b/Hi3Helper.Core/Classes/SentryHelper/SentryExceptionFilter.cs
@@ -9,46 +9,59 @@ namespace Hi3Helper.SentryHelper
 {
     public class NetworkException : IExceptionFilter
     {
-        private static readonly HashSet<int> SocketExceptionFilters = new()
-        {
-            10050, // WSAENETDOWN - The network subsystem has failed.
-            10051, // WSAENETUNREACH - The network can't be reached from this host at this time.
-            10052, // WSAENETRESET - The connection has been broken due to keep-alive activity detecting a failure while the operation was in progress.
-            10053, // WSAECONNABORTED - The connection was aborted due to a network error.
-            10054, // WSAECONNRESET - The connection was reset by the remote peer.
-            10060, // WSAETIMEDOUT - The connection has been dropped because of a network failure or because the peer system failed to respond.
-            10061, // WSAECONNREFUSED - The connection was refused by the remote host.
-            10065, // WSAEHOSTUNREACH - The host is unreachable.
-            10055, // WSAENOBUFS - No buffer space available (resource issue on the client side).
-            11001, // WSAHOST_NOT_FOUND - Host not found (DNS resolution error).
-            11002, // WSATRY_AGAIN - Non-authoritative host not found (transient DNS error).
-            11003, // WSANO_RECOVERY - Non-recoverable error during a DNS query.
-            11004  // WSANO_DATA - Valid name, no data record of requested type (DNS error).
-        };
+        private static readonly HashSet<SocketError> SocketExceptionFilters = 
+        [
+            SocketError.NetworkDown,           // 10050
+            SocketError.NetworkUnreachable,    // 10051
+            SocketError.NetworkReset,          // 10052
+            SocketError.ConnectionAborted,     // 10053
+            SocketError.ConnectionReset,       // 10054
+            SocketError.TimedOut,              // 10060
+            SocketError.ConnectionRefused,     // 10061
+            SocketError.HostUnreachable,       // 10065
+            SocketError.NoBufferSpaceAvailable,// 10055
+            SocketError.HostNotFound,          // 11001
+            SocketError.TryAgain,              // 11002
+            SocketError.NoRecovery,            // 11003
+            SocketError.NoData                 // 11004
+        ];
 
-        private static readonly HashSet<string> HttpExceptionFilters = new()
-        {
+        private static readonly HashSet<string> HttpExceptionFilters =
+        [
             "net_http_client_execution_error", // General HTTP client execution error.
             "net_http_request_aborted", // HTTP request was aborted by the client.
             "net_http_timeout_error", // HTTP request timed out.
             "net_http_connection_closed", // Connection closed unexpectedly.
-            "net_http_name_resolution_failure" // DNS resolution failure for the HTTP client.
-        };
+            "net_http_name_resolution_failure"
+        ];
 
-        private static readonly HashSet<HttpRequestError> HttpRequestErrorFilters = new()
-        {
+        private static readonly HashSet<HttpRequestError> HttpRequestErrorFilters =
+        [
             HttpRequestError.NameResolutionError, // DNS resolution failed.
-            HttpRequestError.SecureConnectionError, // TLS/SSL handshake failure.
-        };
+            HttpRequestError.SecureConnectionError // TLS/SSL handshake failure.
+        ];
+        
+        private static readonly HashSet<int> DiskFullHResults =
+        [
+            unchecked((int)0x80070070), // ERROR_DISK_FULL
+            unchecked((int)0x80070027)
+        ];
+        
+        private static readonly HashSet<string> NullReferenceFilters =
+        [
+            "DB_001", // DB Uri not set
+            "DB_002", // DB Token not set
+            "DB_003"  // Invalid token
+        ];
 
         public bool Filter(Exception ex)
         {
             var returnValue = ex switch
                               {
-                                  SocketException socketEx => SocketExceptionFilters.Contains(socketEx.ErrorCode),
-                                  HttpRequestException httpEx => HttpRequestErrorFilters.Contains(httpEx.HttpRequestError) 
-                                                                 || (httpEx.InnerException is SocketException socketEx && SocketExceptionFilters.Contains(socketEx.ErrorCode))
-                                                                 || HttpExceptionFilters.Any(f => httpEx.Message.Contains(f)),
+                                  HttpRequestException httpEx => IsHttpExceptionFiltered(httpEx),
+                                  IOException ioEx => IsIoExceptionFiltered(ioEx),
+                                  SocketException socketEx => SocketExceptionFilters.Contains(socketEx.SocketErrorCode),
+                                  NullReferenceException => NullReferenceFilters.Any(f => ex.Message.Contains(f)),
                                   _ => false
                               };
 
@@ -59,5 +72,16 @@ namespace Hi3Helper.SentryHelper
             
             return returnValue;
         }
+
+        private static bool IsHttpExceptionFiltered(HttpRequestException httpEx) =>
+            HttpRequestErrorFilters.Contains(httpEx.HttpRequestError)
+            || (httpEx.InnerException is SocketException socketEx &&
+                SocketExceptionFilters.Contains(socketEx.SocketErrorCode))
+            || HttpExceptionFilters.Any(f => httpEx.Message.Contains(f));
+
+        private static bool IsIoExceptionFiltered(IOException ioEx) =>
+            DiskFullHResults.Contains(ioEx.HResult)
+            || (ioEx.InnerException is SocketException socketEx &&
+                SocketExceptionFilters.Contains(socketEx.SocketErrorCode));
     }
 }

--- a/Hi3Helper.Core/Classes/SentryHelper/SentryExceptionFilter.cs
+++ b/Hi3Helper.Core/Classes/SentryHelper/SentryExceptionFilter.cs
@@ -1,6 +1,7 @@
 using Sentry.Extensibility;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Sockets;

--- a/Hi3Helper.Core/Classes/SentryHelper/SentryHelper.cs
+++ b/Hi3Helper.Core/Classes/SentryHelper/SentryHelper.cs
@@ -540,21 +540,38 @@ namespace Hi3Helper.SentryHelper
         #pragma warning restore CS0162 // Unreachable code detected
         }
         
-        public static void SendExceptionFeedback(Guid sentryId, string userEmail, string user, string feedback)
+        public static bool SendExceptionFeedback(Guid sentryId, string userEmail, string user, string feedback)
         {
             if (sentryId == Guid.Empty)
             {
-                Logger.LogWriteLine("[SentryHelper] SentryId is empty, feedback will not be sent!", LogType.Error,
+                Logger.LogWriteLine("[SendExceptionFeedback] SentryId is empty, feedback will not be sent!", LogType.Error,
                                     true);
+                return false;
+            }
+
+            if (!IsEnabled)
+            {
+                Logger.LogWriteLine("[SendExceptionFeedback] Sentry is disabled, feedback will not be sent!",
+                                    LogType.Error, true);
+                return false;
             }
 
             var sId       = new SentryId(sentryId);
             SentrySdk.CaptureFeedback(feedback, userEmail, user, null, null, sId);
+            return true;
         }
         
-        public static void SendGenericFeedback(string feedback, string userEmail, string user)
+        public static bool SendGenericFeedback(string feedback, string userEmail, string user)
         {
+            if (!IsEnabled)
+            {
+                Logger.LogWriteLine("[SendGenericFeedback] Sentry is disabled, feedback will not be sent!",
+                                    LogType.Error, true);
+                return false;
+            }
+            
             SentrySdk.CaptureFeedback(feedback, userEmail, user);
+            return true;
         }
 
         [GeneratedRegex(@"(?<=\bat\s)(CollapseLauncher|Hi3Helper)\.[^\s(]+", RegexOptions.Compiled)]

--- a/Hi3Helper.Core/Classes/SentryHelper/SentryHelper.cs
+++ b/Hi3Helper.Core/Classes/SentryHelper/SentryHelper.cs
@@ -548,10 +548,13 @@ namespace Hi3Helper.SentryHelper
                                     true);
             }
 
-            var sId          = new SentryId(sentryId);
-            var userFeedback = new UserFeedback(sId, user, userEmail, feedback);
-            
-            SentrySdk.CaptureUserFeedback(userFeedback);
+            var sId       = new SentryId(sentryId);
+            SentrySdk.CaptureFeedback(feedback, userEmail, user, null, null, sId);
+        }
+        
+        public static void SendGenericFeedback(string feedback, string userEmail, string user)
+        {
+            SentrySdk.CaptureFeedback(feedback, userEmail, user);
         }
 
         [GeneratedRegex(@"(?<=\bat\s)(CollapseLauncher|Hi3Helper)\.[^\s(]+", RegexOptions.Compiled)]

--- a/Hi3Helper.Core/Lang/Locale/LangMisc.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangMisc.cs
@@ -153,6 +153,11 @@ namespace Hi3Helper
                 public string ExceptionFeedbackTemplate_Email { get; set; } = LangFallback?._Misc.ExceptionFeedbackTemplate_Email;
                 public string ExceptionFeedbackTemplate_Message { get; set; } = LangFallback?._Misc.ExceptionFeedbackTemplate_Message;
                 
+                public string Feedback { get; set; } = LangFallback?._Misc.Feedback;
+                public string FeedbackSending { get; set; } = LangFallback?._Misc.FeedbackSending;
+                public string FeedbackSent { get; set; } = LangFallback?._Misc.FeedbackSent;
+                public string FeedbackSendFailure { get; set; } = LangFallback?._Misc.FeedbackSendFailure;
+                
                 public string Tag_Deprecated { get; set; } = LangFallback?._Misc.Tag_Deprecated;
                 
                 public string Generic_GameFeatureDeprecation { get; set; } = LangFallback?._Misc.Generic_GameFeatureDeprecation;

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -810,7 +810,7 @@
     "ExceptionFeedbackTemplate_User": "Username (Optional):",
     "ExceptionFeedbackTemplate_Email": "Email (Optional):",
     "ExceptionFeedbackTemplate_Message": "Tell us what happened after this line: (You don't need to include the error message, we will attach it for you!)",
-
+    
     "Feedback": "User Feedback",
     "FeedbackSending": "Sending your feedback...",
     "FeedbackSent": "Feedback sent!",

--- a/Hi3Helper.Core/Lang/es_419.json
+++ b/Hi3Helper.Core/Lang/es_419.json
@@ -1044,7 +1044,8 @@
     "UACWarningDontShowAgain": "No mostrar de nuevo",
 
     "EnsureExitTitle": "Saliendo de la aplicación ",
-    "EnsureExitSubtitle": "Hay operaciones críticas ejecutándose en segundo plano. ¿Estás seguro de que quieres salir?",
+    "EnsureExitSubtitle": "Hay operaciones críticas ejecutándose en segundo plano.",
+    "EnsureExitSubtitle2": "¿Estás seguro de que quieres salir?",
 
     "UserFeedback_DialogTitle": "Comparta su opinión",
     "UserFeedback_TextFieldTitleHeader": "Título",

--- a/Hi3Helper.Core/Lang/ja_JP.json
+++ b/Hi3Helper.Core/Lang/ja_JP.json
@@ -117,8 +117,8 @@
 
   "_HomePage": {
     "PageTitle": "ランチャー",
-    "PreloadTitle": "事前ダウンロードが利用可能です！",
-    "PreloadNotifTitle": "バージョン{0}の事前ダウンロードパッケージが利用可能です！",
+    "PreloadTitle": "事前ダウンロードを利用できます！",
+    "PreloadNotifTitle": "バージョン{0}の事前ダウンロードパッケージが利用できます！",
     "PreloadNotifDeltaDetectTitle": "バージョン{0}のパッケージをデルタパッチ形式で事前ダウンロードしました！",
     "PreloadNotifSubtitle": "バックグラウンドでダウンロードを開始するには、 \"ダウンロード\"をクリックしてください。",
     "PreloadNotifDeltaDetectSubtitle": "次バージョンのパッチをデルタパッチ形式で正常に事前ダウンロードしました。この事前ダウンロード形式は後でゲームの更新に使用されます。",
@@ -1058,13 +1058,30 @@
     "SophonIncrementUpdateUnavailSubtitle3": "ため、差分更新式アップデートができません。ゲームをアップデートするには、ゲーム全体の再ダウンロードが必要です。",
     "SophonIncrementUpdateUnavailSubtitle4": "\"{0}\"を押すと全体の再ダウンロードを実行し、\"{1}\"を押すとアップデートをキャンセルします。",
 
+    "SophonAdditionalPkgAvailableUpdateTitle": "追加パッケージをアップデートできます！",
+    "SophonAdditionalPkgAvailableDownloadTitle": "追加パッケージをダウンロードできます！",
+
+    "SophonAdditionalPkgAvailableSubtitle1": "ゲームにダウンロード可能な追加パッケージがあります。追加データのサイズは",
+    "SophonAdditionalPkgAvailableSubtitle2": "です。追加パッケージを含める場合、合計で",
+    "SophonAdditionalPkgAvailableSubtitle3": "のデータダウンロードが必要となる可能性があります。",
+    "SophonAdditionalPkgAvailableSubtitle4": "追加パッケージもダウンロードする場合は",
+    "SophonAdditionalPkgAvailableSubtitle5": "をクリックしてください。基礎リソースのみをダウンロードする場合は",
+    "SophonAdditionalPkgAvailableSubtitle6": "をクリックしてください。基礎リソースのみのサイズは",
+    "SophonAdditionalPkgAvailableSubtitle7": "です。",
+    "SophonAdditionalPkgAvailableFootnote1": "注：",
+    "SophonAdditionalPkgAvailableFootnote2": "基礎リソースのみダウンロードを選択した場合、ゲームのプレイ中に追加パッケージのダウンロードが必要となる可能性があります。",
+    "SophonAdditionalPkgSeeDetailsBtn": "追加パッケージの詳細を見る",
+    "SophonAdditionalConfirmYesBtn": "全てダウンロード",
+    "SophonAdditionalConfirmNoBtn": "基礎リソースのみダウンロード",
+
     "UACWarningTitle": "警告：UACの無効化を検出しました",
     "UACWarningContent": "ユーザーアカウント制御（UAC）の無効化は全くもって非推奨です。\nOSのセキュリティが侵害され、ゲームが正常に動作しなくなる可能性があるためです。\n\n\"もっと見る\"を押すと、UACを有効化する方法が表示されます。\n関連項目：「管理承認モードですべての管理者を実行する」",
     "UACWarningLearnMore": "もっと見る",
     "UACWarningDontShowAgain": "次回から表示しない",
 
     "EnsureExitTitle": "アプリケーションの終了",
-    "EnsureExitSubtitle": "バックグラウンドで重要な操作を実行中です。本当に終了しますか?",
+    "EnsureExitSubtitle": "バックグラウンドで重要な操作を実行中です。",
+    "EnsureExitSubtitle2": "本当にランチャーを終了しますか？",
 
     "UserFeedback_DialogTitle": "感想を送る",
     "UserFeedback_TextFieldTitleHeader": "フィードバックのタイトル",
@@ -1267,8 +1284,8 @@
   },
 
   "_AppNotification": {
-    "NotifMetadataUpdateTitle": "ランチャーメタデータが更新可能です！",
-    "NotifMetadataUpdateSubtitle": "新しいランチャーメタデータが利用可能です！このプロセスは、ランチャーがmiHoYo/HoYoverseのサーバーと適切に通信できるようにするために自動的に行われます。まもなく更新が始まります！",
+    "NotifMetadataUpdateTitle": "ランチャーメタデータを更新できます！",
+    "NotifMetadataUpdateSubtitle": "新しいランチャーメタデータを利用できます！このプロセスは、ランチャーがmiHoYo/HoYoverseのサーバーと適切に通信できるようにするために自動的に行われます。まもなく更新が始まります！",
     "NotifMetadataUpdateBtn": "メタデータ更新",
     "NotifMetadataUpdateBtnCountdown": "メタデータを {0}秒後に更新します。",
     "NotifMetadataUpdateBtnUpdating": "メタデータを更新しています。お待ちください...",
@@ -1614,7 +1631,8 @@
     "Audio_PlaybackDev": "再生デバイス",
     "Audio_PlaybackDev_Headphones": "ヘッドホン",
     "Audio_PlaybackDev_Speakers": "スピーカー",
-    "Audio_PlaybackDev_TV": "TV"
+    "Audio_PlaybackDev_TV": "TV",
+    "Audio_Ambient": "アンビエント音量"
   },
 
   "_NotificationToast": {

--- a/Hi3Helper.Core/Lang/zh_CN.json
+++ b/Hi3Helper.Core/Lang/zh_CN.json
@@ -1058,13 +1058,30 @@
     "SophonIncrementUpdateUnavailSubtitle3": "且该版本的增量更新不可用。不过，您仍然可以通过重新下载整个游戏来更新您的游戏。",
     "SophonIncrementUpdateUnavailSubtitle4": "点击“{0}”继续更新整个游戏，或点击“{1}”取消更新过程",
 
+    "SophonAdditionalPkgAvailableUpdateTitle": "附加组件包可更新！",
+    "SophonAdditionalPkgAvailableDownloadTitle": "附加组件包可下载！",
+
+    "SophonAdditionalPkgAvailableSubtitle1": "您的游戏包含可下载的附加组件包。附加组件大小：",
+    "SophonAdditionalPkgAvailableSubtitle2": "。如果您希望包含附加组件包，则可能总共需要下载：",
+    "SophonAdditionalPkgAvailableSubtitle3": "的数据。",
+    "SophonAdditionalPkgAvailableSubtitle4": "如果你想要下载附加组件包，请点击",
+    "SophonAdditionalPkgAvailableSubtitle5": "；如果只需要下载基础文件，请点击",
+    "SophonAdditionalPkgAvailableSubtitle6": "，总大小仅为：",
+    "SophonAdditionalPkgAvailableSubtitle7": "。",
+    "SophonAdditionalPkgAvailableFootnote1": "注：",
+    "SophonAdditionalPkgAvailableFootnote2": "如果您选择仅下载基础文件，可能需要稍后在游戏中下载附加组件包。",
+    "SophonAdditionalPkgSeeDetailsBtn": "查看附加组件包详情",
+    "SophonAdditionalConfirmYesBtn": "下载全部",
+    "SophonAdditionalConfirmNoBtn": "仅下载基础文件",
+
     "UACWarningTitle": "警告：检测到已禁用 UAC",
     "UACWarningContent": "禁用用户账户控制（UAC）从来不是一个好主意。\n操作系统的安全性会受到影响，游戏也可能无法正常运行。\n\n点击“了解更多”按钮查看如何启用 UAC。\n相关条目为：在管理员审批模式下运行所有管理员。",
     "UACWarningLearnMore": "了解更多",
     "UACWarningDontShowAgain": "不再显示",
 
     "EnsureExitTitle": "正在退出应用",
-    "EnsureExitSubtitle": "后台正在运行重要操作。您确定要退出吗？",
+    "EnsureExitSubtitle": "后台正在运行重要操作。",
+    "EnsureExitSubtitle2": "您确定要退出吗？",
 
     "UserFeedback_DialogTitle": "分享你的想法",
     "UserFeedback_TextFieldTitleHeader": "反馈标题",
@@ -1614,7 +1631,8 @@
     "Audio_PlaybackDev": "声音播放设备",
     "Audio_PlaybackDev_Headphones": "耳机",
     "Audio_PlaybackDev_Speakers": "音响",
-    "Audio_PlaybackDev_TV": "电视"
+    "Audio_PlaybackDev_TV": "电视",
+    "Audio_Ambient": "人文氛围音量"
   },
 
   "_NotificationToast": {

--- a/Hi3Helper.TaskScheduler/packages.lock.json
+++ b/Hi3Helper.TaskScheduler/packages.lock.json
@@ -17,6 +17,15 @@
         "resolved": "6.9.2",
         "contentHash": "YBHobPGogb0vYhGYIxn/ndWqTjNWZveDi5jdjrcshL2vjwU3gQGyDeI7vGgye+2rAM5fGRvlLgNWLW3DpviS/w=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
+        }
+      },
       "System.Net.Http": {
         "type": "Direct",
         "requested": "[4.3.4, )",
@@ -37,6 +46,11 @@
         "requested": "[2.12.1, )",
         "resolved": "2.12.1",
         "contentHash": "DzSVmVs0i5yHmuDy9ZMcTtKg48GU0aEFBbhp2XJrzA4saTRec/KbU5aGE/4P4FE499G3PDx9KPOHysoKzS/i3g=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       },
       "System.Security.Cryptography.Algorithms": {
         "type": "Transitive",


### PR DESCRIPTION
# What's changed? - 1.82.27
- **[Fix]** File sharing error on background image file, by @shatyuka 
- **[Fix]** Crashing during startup in certain system caused by race condition in EnableWindowNonClientArea method, by @bagusnl 
- **[Fix]** Incorrect per-file size if patch file has already been downloaded, by @neon-nyan 
- **[Fix]** NRE spam on DB initializer when DB URL/Token is empty, by @bagusnl 
- **[Fix]** ObjectDisposed exception rare occassion when calling DispatcherQueue.HasThreadAccess, by @bagusnl 
- **[Imp]** Sophon improvements, by @neon-nyan 
  - Reduce memory overhead
  - Reduce timed-out occurrence when downloading objects
  - Adding check to include additional packages if they were installed
  - Only trigger full download (with additional packages) on initial installation
    - No dialog involved. If you need to the dialog in order to download the base file, add a blank file with name: @AskAdditionalSophonPackage in your game directory
- **[Imp]** [BACKPORT] Implement changes in feedback Sentry API + enable generic feedback menu, by @bagusnl 

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
