### PR TITLE
Adds debug dialog spawning UI in settings

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -2471,6 +2471,58 @@
                             </Grid>
                         </Grid>
                     </Button>
+                    <NavigationViewItemSeparator Margin="16,16" Visibility="Collapsed" x:Name="DebugItemSeparator" />
+                    <StackPanel Orientation="Vertical" Spacing="8" Visibility="Collapsed" x:Name="DebugStackPanel">
+                        <AutoSuggestBox x:Name="DebugCustomDialogComboBox"
+                                  ItemsSource="{x:Bind DialogMethodNames, Mode=OneWay}"
+                                  Text="{x:Bind SelectedDialogMethodName, Mode=TwoWay}"
+                                  QuerySubmitted="DebugCustomDialogComboBox_OnQuerySubmitted"
+                                  TextChanged="DebugCustomDialogComboBox_OnTextChanged"
+                                  PlaceholderText="Search custom dialog..."/>
+                        <Button x:Name="DebugCustomDialogButton"
+                                Margin="0,0,0,8"
+                                Padding="12,8"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Click="DebugCustomDialogButton_Click"
+                                CornerRadius="{x:Bind ext:UIElementExtensions.AttachRoundedKindCornerRadius(DebugCustomDialogButton)}"
+                                IsEnabled="True"
+                                Style="{ThemeResource AccentButtonStyle}">
+                            <Grid Margin="0,-2,0,0"
+                                  HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid HorizontalAlignment="Left">
+                                    <TextBlock HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               FontWeight="Medium"
+                                               HorizontalTextAlignment="Left"
+                                               Text="{x:Bind helper:Locale.Lang._SettingsPage.Debug_CustomDialogBtn}" />
+                                </Grid>
+                                <Grid Grid.Column="1"
+                                      Margin="4,2,0,0"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      RenderTransformOrigin="0.5, 0.5">
+                                    <Grid.RenderTransform>
+                                        <RotateTransform Angle="-90" />
+                                    </Grid.RenderTransform>
+                                    <AnimatedIcon Width="16"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center">
+                                        <animatedvisuals:AnimatedChevronDownSmallVisualSource />
+                                        <AnimatedIcon.FallbackIconSource>
+                                            <FontIconSource FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                            Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
+                                                            Glyph="&#xE70D;" />
+                                        </AnimatedIcon.FallbackIconSource>
+                                    </AnimatedIcon>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                    </StackPanel>
                     <StackPanel HorizontalAlignment="Center"
                                 Orientation="Horizontal">
                         <TextBlock Margin="0,0,6,0"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -2343,7 +2343,7 @@ namespace CollapseLauncher.Pages
             SettingsSearchHighlightNextBtn.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
             SettingsSearchHighlightNextBtn.KeyboardAccelerators.Add(nextAccelerator);
         }
-#if DEBUG
+
         private async void DebugCustomDialogButton_Click(object sender, RoutedEventArgs e)
         {
             try
@@ -2448,5 +2448,4 @@ namespace CollapseLauncher.Pages
             }
         }
     }
-#endif
 }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -2385,12 +2385,15 @@ namespace CollapseLauncher.Pages
             catch (Exception ex)
             {
                 LogWriteLine("[DBG-DialogSpawner] Exception: " + ex, LogType.Error);
-                await new ContentDialog
-                {
-                    Title           = "Exception",
-                    Content         = ex.ToString(),
-                    CloseButtonText = "OK"
-                }.ShowAsync();
+                await SpawnDialog(
+                                  "Error",
+                                  ex.ToString(),
+                                  sender as UIElement,
+                                  Lang._Misc.Close,
+                                  null,
+                                  null,
+                                  ContentDialogButton.Close,
+                                  ContentDialogTheme.Error);
             }
         }
 
@@ -2407,16 +2410,17 @@ namespace CollapseLauncher.Pages
                 controls.Add(textBox);
             }
 
-            var dialog = new ContentDialog
-            {
-                Title             = "Enter Parameters",
-                Content           = stackPanel,
-                PrimaryButtonText = "OK",
-                CloseButtonText   = "Cancel",
-                XamlRoot          = xamlRoot
-            };
+            var dialog = await SpawnDialog(
+                                           "Enter Parameters",
+                                           stackPanel,
+                                           null,
+                                           Lang._Misc.Cancel,
+                                           Lang._Misc.Okay,
+                                           null,
+                                           ContentDialogButton.Primary,
+                                           ContentDialogTheme.Success);
 
-            if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+            if (dialog != ContentDialogResult.Primary)
                 return null;
             
             var values = new object[parameters.Length];

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -2363,7 +2363,7 @@ namespace CollapseLauncher.Pages
                 object[]? parameterValues = null;
                 if (parameters.Length > 0)
                 {
-                    parameterValues = await ShowDebugParameterInputDialog(method, this.XamlRoot);
+                    parameterValues = await ShowDebugParameterInputDialog(method);
                     if (parameterValues == null)
                     {
                         LogWriteLine("[DBG-DialogSpawner] Parameter input dialog was cancelled.", LogType.Warning);
@@ -2397,7 +2397,7 @@ namespace CollapseLauncher.Pages
             }
         }
 
-        private async Task<object[]?> ShowDebugParameterInputDialog(MethodInfo method, XamlRoot xamlRoot)
+        private async Task<object[]?> ShowDebugParameterInputDialog(MethodInfo method)
         {
             var parameters = method.GetParameters();
             var stackPanel = new StackPanel();

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -102,6 +102,9 @@ namespace CollapseLauncher.Pages
         #region Settings Page Handler
         public SettingsPage()
         {
+            // This is a waste of memory because it initalizes the list even if DEBUG is not defined.
+            _dialogMethods = new List<MethodInfo>();
+            DialogMethodNames = new List<string>();
 #if DEBUG
             _dialogMethods = typeof(SimpleDialogs)
                             .GetMethods(BindingFlags.Public | BindingFlags.Static)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -42,6 +42,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -82,14 +83,17 @@ namespace CollapseLauncher.Pages
 
         private readonly DnsSettingsContext _dnsSettingsContext;
 
-        private readonly Dictionary<string, FrameworkElement>               _settingsControls      = new();
-        private readonly Lock                                               _highlightLock         = new();
-        private readonly ObservableCollection<HighlightableControlProperty> _highlightedControls   = new([]);
+        private readonly Dictionary<string, FrameworkElement>               _settingsControls    = new();
+        private readonly Lock                                               _highlightLock       = new();
+        private readonly ObservableCollection<HighlightableControlProperty> _highlightedControls = new([]);
         private          int                                                _highlightCurrentIndex;
         private          Brush                                              _highlightBrush;
         private          Brush                                              _highlightSelectedBrush;
+        private readonly List<MethodInfo>                                   _dialogMethods;
+        private          List<string>                                       DialogMethodNames        { get; }
+        public           string                                             SelectedDialogMethodName { get; set; }
 
-#nullable enable
+    #nullable enable
         private string? _previousSearchQuery;
 #nullable restore
 
@@ -98,6 +102,18 @@ namespace CollapseLauncher.Pages
         #region Settings Page Handler
         public SettingsPage()
         {
+#if DEBUG
+            _dialogMethods = typeof(SimpleDialogs)
+                            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                            .Where(m => m.ReturnType == typeof(Task<ContentDialogResult>))
+                            .ToList();
+            
+            DialogMethodNames = _dialogMethods.Select(m => m.Name).ToList();
+            
+            if (DialogMethodNames.Count > 0)
+                SelectedDialogMethodName = DialogMethodNames[0];
+#endif
+    
             InitializeComponent();
 
             _dnsSettingsContext = new DnsSettingsContext(CustomDnsHostTextbox);
@@ -113,7 +129,9 @@ namespace CollapseLauncher.Pages
 
             string version = $" {LauncherUpdateHelper.LauncherCurrentVersionString}";
 #if DEBUG
-            version += "d";
+            version                       += "d";
+            DebugItemSeparator.Visibility =  Visibility.Visible;
+            DebugStackPanel.Visibility    =  Visibility.Visible;
 #endif
             if (IsPreview)
                 version += " Preview";
@@ -2325,5 +2343,110 @@ namespace CollapseLauncher.Pages
             SettingsSearchHighlightNextBtn.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
             SettingsSearchHighlightNextBtn.KeyboardAccelerators.Add(nextAccelerator);
         }
+#if DEBUG
+        private async void DebugCustomDialogButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var method = _dialogMethods.FirstOrDefault(m => m.Name == SelectedDialogMethodName);
+                if (method == null)
+                {
+                    LogWriteLine("[DBG-DialogSpawner] No method found.", LogType.Debug);
+                    return;
+                }
+
+                LogWriteLine($"[DBG-DialogSpawner] Invoking method: {method.Name}",              LogType.Debug);
+                LogWriteLine($"[DBG-DialogSpawner] Parameters: {method.GetParameters().Length}", LogType.Debug);
+                LogWriteLine($"[DBG-DialogSpawner] Return type: {method.ReturnType}",            LogType.Debug);
+
+                var parameters = method.GetParameters();
+                object[]? parameterValues = null;
+                if (parameters.Length > 0)
+                {
+                    parameterValues = await ShowDebugParameterInputDialog(method, this.XamlRoot);
+                    if (parameterValues == null)
+                    {
+                        LogWriteLine("[DBG-DialogSpawner] Parameter input dialog was cancelled.", LogType.Warning);
+                        return;
+                    }
+                }
+                LogWriteLine("[DBG-DialogSpawner] Invoking method with parameters: " + 
+                             (parameterValues != null ? string.Join(", ", parameterValues) : "None"), LogType.Debug);
+                var result = method.Invoke(null, parameterValues);
+                if (result is Task<ContentDialogResult> task)
+                {
+                    await task;
+                }
+                else
+                {
+                    LogWriteLine("[DBG-DialogSpawner] Method did not return a ContentDialogResult task.", LogType.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine("[DBG-DialogSpawner] Exception: " + ex, LogType.Error);
+                await new ContentDialog
+                {
+                    Title           = "Exception",
+                    Content         = ex.ToString(),
+                    CloseButtonText = "OK"
+                }.ShowAsync();
+            }
+        }
+
+        private async Task<object[]?> ShowDebugParameterInputDialog(MethodInfo method, XamlRoot xamlRoot)
+        {
+            var parameters = method.GetParameters();
+            var stackPanel = new StackPanel();
+            var controls   = new List<Control>();
+
+            foreach (var parameter in parameters)
+            {
+                var textBox = new TextBox { Header = parameter.Name, PlaceholderText = parameter.ParameterType.Name };
+                stackPanel.Children.Add(textBox);
+                controls.Add(textBox);
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title             = "Enter Parameters",
+                Content           = stackPanel,
+                PrimaryButtonText = "OK",
+                CloseButtonText   = "Cancel",
+                XamlRoot          = xamlRoot
+            };
+
+            if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+                return null;
+            
+            var values = new object[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var text = ((TextBox)controls[i]).Text;
+                values[i] = Convert.ChangeType(text, parameters[i].ParameterType);
+            }
+
+            return values;
+        }
+
+        private void DebugCustomDialogComboBox_OnQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            if (DialogMethodNames.Contains(args.QueryText))
+            {
+                SelectedDialogMethodName = args.QueryText;
+            }
+        }
+
+        private void DebugCustomDialogComboBox_OnTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+            {
+                var filtered = DialogMethodNames
+                              .Where(name => name.Contains(sender.Text, StringComparison.OrdinalIgnoreCase))
+                              .ToList();
+                sender.ItemsSource = filtered;
+            }
+        }
     }
+#endif
 }

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -470,8 +470,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "9.0.5",
-        "contentHash": "iFhbuwiertFWWVlbOtfVV2MaojUW0/eQ2AKkBcjvmWHYw2orW5OiTHPqAeB7ny5+s09EQaZaQmX4SIpGX8HUdg=="
+        "resolved": "9.0.6",
+        "contentHash": "oMOYyDCLu7sRdupDnpq1yXqUiM+K0j9ZZAVIYDoT06cXTnflNiCLTCb9A6+1yn2a3aBqmOi1xMudbF+WOPFY5Q=="
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",

--- a/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
@@ -22,7 +22,8 @@ namespace Hi3Helper
                 public string Debug_SendRemoteCrashData                   { get; set; } = LangFallback?._SettingsPage.Debug_SendRemoteCrashData;
                 public string Debug_SendRemoteCrashData_EnvVarDisablement { get; set; } = LangFallback?._SettingsPage.Debug_SendRemoteCrashData_EnvVarDisablement;
                 public string Debug_MultipleInstance                      { get; set; } = LangFallback?._SettingsPage.Debug_MultipleInstance;
-
+                public string Debug_CustomDialogBtn                            { get; set; } = LangFallback?._SettingsPage.Debug_CustomDialogBtn;
+                
                 public string ChangeRegionWarning_Toggle                { get; set; } = LangFallback?._SettingsPage.ChangeRegionWarning_Toggle;
                 public string ChangeRegionInstant_Toggle                { get; set; } = LangFallback?._SettingsPage.ChangeRegionInstant_Toggle;
                 public string ChangeRegionWarning_Warning               { get; set; } = LangFallback?._SettingsPage.ChangeRegionWarning_Warning;

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -436,6 +436,7 @@
     "Debug_SendRemoteCrashData": "Send anonymous crash reports to developers",
     "Debug_SendRemoteCrashData_EnvVarDisablement": "This setting is disabled due to 'DISABLE_SENTRY' environment variable being set to true.",
     "Debug_MultipleInstance": "Allow running multiple instances of Collapse",
+    "Debug_CustomDialogBtn": "[DBG] Spawn Custom Dialog",
 
     "ChangeRegionWarning_Toggle": "Show Region Change Warning",
     "ChangeRegionInstant_Toggle": "Instantly Change Region on Selection",


### PR DESCRIPTION
# Main Goal
Adds a debug UI element in the settings page to allow for spawning custom dialogs for testing purposes.

You can search for the dialog box that you want using the `AutoSuggestionBox` field. Please note that currently, only dialogs implemented in the `SimpleDialogs` class are supported, but we could add more classes in the future if we'd like to do that.

Some dialogs require specific parameters, those have been made to spawn a dialog box before spawning the selected dialog, so that you can manually input them and pass them as parameters.

## Demo

https://github.com/user-attachments/assets/42ee469c-38f4-4b18-a547-29c37155f597

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0