### PR TITLE
Update System.CommandLine dependency

### DIFF
--- a/CollapseLauncher/Classes/Extension/VelopackLocatorExtension.cs
+++ b/CollapseLauncher/Classes/Extension/VelopackLocatorExtension.cs
@@ -274,9 +274,22 @@ namespace CollapseLauncher.Extension
                                        </metadata>
                                        </package>
                                        """; // Adding shortcutAumid for future use, since they typo-ed the XML tag LMAO
-            string currentVersion = LauncherUpdateHelper.LauncherCurrentVersionString;
-            string xmlPath        = Path.Combine(LauncherConfig.AppExecutableDir, "sq.version");
-            string xmlContent     = string.Format(xmlTemplate, currentVersion, LauncherConfig.IsPreview ? "preview" : "stable", aumid);
+            var currentVersion = LauncherUpdateHelper.LauncherCurrentVersionString;
+            var xmlPath        = Path.Combine(LauncherConfig.AppExecutableDir, "sq.version");
+            var xmlContent = string.Format(xmlTemplate, currentVersion, LauncherConfig.IsPreview ? "preview" : "stable",
+                                           aumid);
+            
+            // Check if file exist
+            if (File.Exists(xmlPath))
+            {
+                // Check if the content is the same
+                var existingContent = File.ReadAllText(xmlPath);
+                if (existingContent.ReplaceLineEndings("\n").Equals(xmlContent.ReplaceLineEndings("\n"), StringComparison.Ordinal))
+                {
+                    Logger.LogWriteLine("Velopack metadata is already up-to-date, skipping write operation.", LogType.Default, true);
+                    return;
+                }
+            }
             File.WriteAllText(xmlPath, xmlContent.ReplaceLineEndings("\n"));
             Logger.LogWriteLine($"Velopack metadata has been successfully written!\r\n{xmlContent}", LogType.Default, true);
         }

--- a/CollapseLauncher/Classes/Extension/VelopackLocatorExtension.cs
+++ b/CollapseLauncher/Classes/Extension/VelopackLocatorExtension.cs
@@ -277,20 +277,20 @@ namespace CollapseLauncher.Extension
             var currentVersion = LauncherUpdateHelper.LauncherCurrentVersionString;
             var xmlPath        = Path.Combine(LauncherConfig.AppExecutableDir, "sq.version");
             var xmlContent = string.Format(xmlTemplate, currentVersion, LauncherConfig.IsPreview ? "preview" : "stable",
-                                           aumid);
+                                           aumid).ReplaceLineEndings("\n");
             
             // Check if file exist
             if (File.Exists(xmlPath))
             {
                 // Check if the content is the same
                 var existingContent = File.ReadAllText(xmlPath);
-                if (existingContent.ReplaceLineEndings("\n").Equals(xmlContent.ReplaceLineEndings("\n"), StringComparison.Ordinal))
+                if (existingContent.ReplaceLineEndings("\n").Equals(xmlContent, StringComparison.Ordinal))
                 {
                     Logger.LogWriteLine("Velopack metadata is already up-to-date, skipping write operation.", LogType.Default, true);
                     return;
                 }
             }
-            File.WriteAllText(xmlPath, xmlContent.ReplaceLineEndings("\n"));
+            File.WriteAllText(xmlPath, xmlContent);
             Logger.LogWriteLine($"Velopack metadata has been successfully written!\r\n{xmlContent}", LogType.Default, true);
         }
     }

--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -62,35 +62,35 @@ namespace CollapseLauncher
             {
                 case "hi3cacheupdate":
                     m_appMode = AppMode.Hi3CacheUpdater;
-                    ParseHi3CacheUpdaterArguments(args);
+                    ParseHi3CacheUpdaterArguments();
                     break;
                 case "update":
                     m_appMode = AppMode.Updater;
-                    ParseUpdaterArguments(args);
+                    ParseUpdaterArguments();
                     break;
                 case "elevateupdate":
                     m_appMode = AppMode.ElevateUpdater;
-                    ParseElevateUpdaterArguments(args);
+                    ParseElevateUpdaterArguments();
                     break;
                 case "takeownership":
                     m_appMode = AppMode.InvokerTakeOwnership;
-                    ParseTakeOwnershipArguments(args);
+                    ParseTakeOwnershipArguments();
                     break;
                 case "migrate":
                     m_appMode = AppMode.InvokerMigrate;
-                    ParseMigrateArguments(false, args);
+                    ParseMigrateArguments(false);
                     break;
                 case "migratebhi3l":
                     m_appMode = AppMode.InvokerMigrate;
-                    ParseMigrateArguments(true, args);
+                    ParseMigrateArguments(true);
                     break;
                 case "movesteam":
                     m_appMode = AppMode.InvokerMoveSteam;
-                    ParseMoveSteamArguments(args);
+                    ParseMoveSteamArguments();
                     break;
                 case "oobesetup":
                     m_appMode = AppMode.OOBEState;
-                    ParseOobeArguments(args);
+                    ParseOobeArguments();
                     break;
                 case "tray":
                     m_appMode = AppMode.StartOnTray;
@@ -100,7 +100,7 @@ namespace CollapseLauncher
                     break;
                 case "generatevelopackmetadata":
                     m_appMode = AppMode.GenerateVelopackMetadata;
-                    ParseGenerateVelopackMetadataArguments(args);
+                    ParseGenerateVelopackMetadataArguments();
                     break;
             }
 
@@ -118,28 +118,28 @@ namespace CollapseLauncher
             m_appMode = AppMode.Launcher;
         }
 
-        private static void ParseHi3CacheUpdaterArguments(params string[] _)
+        private static void ParseHi3CacheUpdaterArguments()
         {
             Command hi3CacheUpdate = new Command("hi3cacheupdate", "Update the app or change the Release Channel of the app");
             _rootCommand.Add(hi3CacheUpdate);
-            AddHi3CacheUpdaterOptions(hi3CacheUpdate);
+            AddHi3CacheUpdaterOptions();
         }
 
-        private static void ParseUpdaterArguments(params string[] _)
+        private static void ParseUpdaterArguments()
         {
             Command updater = new Command("update", "Update the app or change the Release Channel of the app");
             _rootCommand.Add(updater);
             AddUpdaterOptions(updater);
         }
 
-        private static void ParseElevateUpdaterArguments(params string[] _)
+        private static void ParseElevateUpdaterArguments()
         {
             Command elevateUpdater = new Command("elevateupdate", "Elevate updater to run as administrator");
             _rootCommand.Add(elevateUpdater);
             AddUpdaterOptions(elevateUpdater);
         }
 
-        private static void AddHi3CacheUpdaterOptions(Command _) { }
+        private static void AddHi3CacheUpdaterOptions() { }
 
         private static void AddUpdaterOptions(Command command)
         {
@@ -169,7 +169,7 @@ namespace CollapseLauncher
             });
         }
 
-        private static void ParseTakeOwnershipArguments(params string[] _)
+        private static void ParseTakeOwnershipArguments()
         {
             var inputOption = new Option<string>("--input-path")
             {
@@ -190,19 +190,19 @@ namespace CollapseLauncher
             _rootCommand.Add(command);
         }
 
-        private static void ParseMigrateArguments(bool isBhi3L = false, params string[] _)
+        private static void ParseMigrateArguments(bool isBhi3L)
         {
             var migrate = !isBhi3L ? new Command("migrate", "Migrate Game from one installation to another location") : new Command("migratebhi3l", "Migrate Game from BetterHi3Launcher to another location");
             AddMigrateOptions(isBhi3L, migrate);
             _rootCommand.Add(migrate);
         }
 
-        private static void ParseOobeArguments(params string[] _)
+        private static void ParseOobeArguments()
         {
             _rootCommand.Add(new Command("oobesetup", "Starts Collapse in OOBE mode, to simulate first-time setup"));
         }
 
-        private static void ParseGenerateVelopackMetadataArguments(params string[] _)
+        private static void ParseGenerateVelopackMetadataArguments()
         {
             _rootCommand.Add(new Command("generatevelopackmetadata", "Generate Velopack metadata to enable update management"));
         }
@@ -271,7 +271,7 @@ namespace CollapseLauncher
                 });
         }
 
-        private static void ParseMoveSteamArguments(params string[] _)
+        private static void ParseMoveSteamArguments()
         {
             var inputOption = new Option<string>("--input")
             {
@@ -300,8 +300,8 @@ namespace CollapseLauncher
                 Required    = true,
                 Description = "Location of game registry for BetterHI3Launcher keys"
             };
-            
-            var            command       = new Command("movesteam", "Migrate Game from Steam to another location");
+
+            var command = new Command("movesteam", "Migrate Game from Steam to another location");
             command.Options.Add(inputOption);
             command.Options.Add(outputOption);
             command.Options.Add(keyNameOption);
@@ -380,39 +380,39 @@ namespace CollapseLauncher
 
     public class Arguments
     {
-        public ArgumentUpdater Updater { get; set; }
-        public ArgumentReindexer Reindexer { get; set; }
+        public ArgumentUpdater   Updater       { get; set; }
+        public ArgumentReindexer Reindexer     { get; set; }
         public ArgumentReindexer TakeOwnership { get; set; }
-        public ArgumentMigrate Migrate { get; set; }
-        public ArgumentStartGame StartGame { get; set; }
+        public ArgumentMigrate   Migrate       { get; set; }
+        public ArgumentStartGame StartGame     { get; set; }
     }
 
     public class ArgumentUpdater
     {
-        public string AppPath { get; set; }
-        public AppReleaseChannel UpdateChannel { get; set; }
+        public string            AppPath       { get; init; }
+        public AppReleaseChannel UpdateChannel { get; init; }
     }
 
     public class ArgumentReindexer
     {
-        public string AppPath { get; set; }
+        public string AppPath { get; init; }
         public string Version { get; set; }
     }
 
     public class ArgumentMigrate
     {
-        public string InputPath { get; set; }
-        public string OutputPath { get; set; }
-        public string GameVer { get; set; }
-        public string RegLoc { get; set; }
-        public string KeyName { get; set; }
-        public bool IsBhi3L { get; set; }
+        public string InputPath  { get; init; }
+        public string OutputPath { get; init; }
+        public string GameVer    { get; init; }
+        public string RegLoc     { get; init; }
+        public string KeyName    { get; init; }
+        public bool   IsBhi3L    { get; init; }
     }
 
     public class ArgumentStartGame
     {
-        public string Game { get; set; }
-        public string Region { get; set; }
-        public bool Play { get; set; }
+        public string Game   { get; init; }
+        public string Region { get; init; }
+        public bool   Play   { get; set; }
     }
 }

--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -143,7 +143,7 @@ namespace CollapseLauncher
 
         private static void AddUpdaterOptions(Command command)
         {
-            var oInput = new Option<string>("--output-path")
+            var oInput = new Option<string>("--input-path")
             {
                 Description = "Output path for the output file",
                 Required    = true
@@ -159,11 +159,11 @@ namespace CollapseLauncher
             command.Options.Add(oInput);
             command.Options.Add(oChannel);
             
-            command.Action = CommandHandler.Create((string input, AppReleaseChannel channel) =>
+            command.Action = CommandHandler.Create((string inputPath, AppReleaseChannel channel) =>
             {
                 m_arguments.Updater = new ArgumentUpdater
                 {
-                    AppPath = input,
+                    AppPath = inputPath,
                     UpdateChannel = channel
                 };
             });
@@ -179,11 +179,11 @@ namespace CollapseLauncher
 
             var command = new Command("takeownership", "Take ownership of the folder");
             command.Options.Add(inputOption);
-            command.Action = CommandHandler.Create((string input) =>
+            command.Action = CommandHandler.Create((string inputPath) =>
             {
                 m_arguments.TakeOwnership = new ArgumentReindexer
                 {
-                    AppPath = input
+                    AppPath = inputPath
                 };
             });
             

--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -358,9 +358,9 @@ namespace CollapseLauncher
             var command = new Command("open", "Open the Launcher in a specific Game and Region (if specified).\n" +
                                 "Note that game/regions provided will be ignored if invalid.\n" +
                                 "Quotes are required if the game/region name has spaces.");
-            command.Add(gameOption);
-            command.Add(regionOption);
-            command.Add(startGameOption);
+            command.Options.Add(gameOption);
+            command.Options.Add(regionOption);
+            command.Options.Add(startGameOption);
             command.Action = CommandHandler.Create(
                 (string game, string region, bool play) =>
                 {

--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -111,9 +111,7 @@ namespace CollapseLauncher
             var result = _rootCommand.Parse(args);
             
             if (result.Errors.Count <= 0)
-            {
                 return;
-            }
 
             var e = new ArgumentException("Argument to run this command is invalid! See the information above for more detail.");
             Console.WriteLine(e);
@@ -151,11 +149,12 @@ namespace CollapseLauncher
                 Required    = true
             };
 
-            var oChannel = new Option<AppReleaseChannel>("--channel", "-c")
-                {
-                    Required = true,
-                    Description = "App release channel"
-                };
+            var oChannel = new Option<AppReleaseChannel>("--channel")
+            {
+                Aliases = { "-c" },
+                Required = true,
+                Description = "App release channel"
+            };
 
             command.Options.Add(oInput);
             command.Options.Add(oChannel);
@@ -320,8 +319,7 @@ namespace CollapseLauncher
                     };
                 });
             
-            var rootCommandInternal = new RootCommand();
-            rootCommandInternal.Add(command);
+            _rootCommand.Add(command);
         }
 
         private static void AddPublicCommands()

--- a/CollapseLauncher/Classes/Properties/ArgumentParser.cs
+++ b/CollapseLauncher/Classes/Properties/ArgumentParser.cs
@@ -109,7 +109,7 @@ namespace CollapseLauncher
                                       "It supports installing games, repairing game files and much more!";
             
             var result = _rootCommand.Parse(args);
-            
+            result.Invoke();
             if (result.Errors.Count <= 0)
                 return;
 

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -206,8 +206,8 @@
         <PackageReference Include="PhotoSauce.NativeCodecs.Libwebp" Version="*-*" />
         <PackageReference Include="Roman-Numerals" Version="2.0.1" />
         <PackageReference Include="SharpCompress" Version="0.40.0" Condition="$(DefineConstants.Contains('USENEWZIPDECOMPRESS'))" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
         <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.6" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.6" />

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -207,7 +207,7 @@
         <PackageReference Include="PhotoSauce.NativeCodecs.Libwebp" Version="*-*" />
         <PackageReference Include="Roman-Numerals" Version="2.0.1" />
         <PackageReference Include="SharpCompress" Version="0.40.0" Condition="$(DefineConstants.Contains('USENEWZIPDECOMPRESS'))" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta6.25358.103" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
         <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.6" />

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <!-- General Properties -->
         <OutputType>WinExe</OutputType>
@@ -92,6 +92,7 @@
         - ENABLEUSERFEEDBACK : Enable user feedback feature
 -->
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+        <OutputType>Exe</OutputType>
         <!-- !! IMPORTANT !!-->
         <!-- DO NOT FORGET TO UPDATE THE DEFINECONSTANTS IN THE PUBLISH PROFILE(S) AS WELL   -->
         <DefineConstants>DISABLE_XAML_GENERATED_MAIN;ENABLEUSERFEEDBACK;USEVELOPACK;USENEWZIPDECOMPRESS;ENABLEHTTPREPAIR;DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION;PREVIEW;DUMPGIJSON;SIMULATEGIHDR;GSPBYPASSGAMERUNNING;MHYPLUGINSUPPORT</DefineConstants>

--- a/CollapseLauncher/Program.cs
+++ b/CollapseLauncher/Program.cs
@@ -67,43 +67,12 @@ namespace CollapseLauncher
         #endif
             try
             {
-                // Extract icons from the executable file
-                string mainModulePath = AppExecutablePath;
-                var    iconCount      = PInvoke.ExtractIconEx(mainModulePath, -1, null, null, 0);
-                if (iconCount > 0)
-                {
-                    var largeIcons = new IntPtr[1];
-                    var smallIcons = new IntPtr[1];
-                    PInvoke.ExtractIconEx(mainModulePath, 0, largeIcons, smallIcons, 1);
-                    AppIconLarge = largeIcons[0];
-                    AppIconSmall = smallIcons[0];
-                }
-
-                // Start Updater Hook
-                VelopackLocatorExtension.StartUpdaterHook(AppAumid);
-
-                InitAppPreset();
-                var logPath = AppGameLogsFolder;
-                CurrentLogger = IsConsoleEnabled
-                    ? new LoggerConsole(logPath, Encoding.UTF8)
-                    : new LoggerNull(logPath, Encoding.UTF8);
-
-                if (Directory.GetCurrentDirectory() != AppExecutableDir)
-                {
-                    LogWriteLine(
-                                 $"Force changing the working directory from {Directory.GetCurrentDirectory()} to {AppExecutableDir}!",
-                                 LogType.Warning, true);
-                    Directory.SetCurrentDirectory(AppExecutableDir);
-                }
-
-                InitializeAppSettings();
-
+                // Initialize the Sentry SDK
                 SentryHelper.IsPreview = IsPreview;
             #pragma warning disable CS0618 // Type or member is obsolete
                 SentryHelper.AppBuildCommit = ThisAssembly.Git.Sha;
                 SentryHelper.AppBuildBranch = ThisAssembly.Git.Branch;
                 SentryHelper.AppBuildRepo   = ThisAssembly.Git.RepositoryUrl;
-                SentryHelper.AppCdnOption   = FallbackCDNUtil.GetPreferredCDN().URLPrefix;
             #pragma warning restore CS0618 // Type or member is obsolete
                 if (SentryHelper.IsEnabled)
                 {
@@ -120,6 +89,38 @@ namespace CollapseLauncher
                         LogWriteLine($"Failed to load Sentry SDK.\r\n{ex}", LogType.Sentry, true);
                     }
                 }
+                
+                // Extract icons from the executable file
+                string mainModulePath = AppExecutablePath;
+                var    iconCount      = PInvoke.ExtractIconEx(mainModulePath, -1, null, null, 0);
+                if (iconCount > 0)
+                {
+                    var largeIcons = new IntPtr[1];
+                    var smallIcons = new IntPtr[1];
+                    PInvoke.ExtractIconEx(mainModulePath, 0, largeIcons, smallIcons, 1);
+                    AppIconLarge = largeIcons[0];
+                    AppIconSmall = smallIcons[0];
+                }
+
+                InitAppPreset();
+                var logPath = AppGameLogsFolder;
+                CurrentLogger = IsConsoleEnabled
+                    ? new LoggerConsole(logPath, Encoding.UTF8)
+                    : new LoggerNull(logPath, Encoding.UTF8);
+
+                // Start Updater Hook
+                VelopackLocatorExtension.StartUpdaterHook(AppAumid);
+                
+                if (Directory.GetCurrentDirectory() != AppExecutableDir)
+                {
+                    LogWriteLine(
+                                 $"Force changing the working directory from {Directory.GetCurrentDirectory()} to {AppExecutableDir}!",
+                                 LogType.Warning, true);
+                    Directory.SetCurrentDirectory(AppExecutableDir);
+                }
+                
+                InitializeAppSettings();
+                SentryHelper.AppCdnOption = FallbackCDNUtil.GetPreferredCDN().URLPrefix;
 
                 LogWriteLine(string.Format("Running Collapse Launcher [{0}], [{3}], under {1}, as {2}",
                                            LauncherUpdateHelper.LauncherCurrentVersionString,

--- a/CollapseLauncher/packages.lock.json
+++ b/CollapseLauncher/packages.lock.json
@@ -217,17 +217,17 @@
       },
       "System.CommandLine": {
         "type": "Direct",
-        "requested": "[2.0.0-beta4.22272.1, )",
-        "resolved": "2.0.0-beta4.22272.1",
-        "contentHash": "1uqED/q2H0kKoLJ4+hI2iPSBSEdTuhfCYADeJrAqERmiGQ2NNacYKRNEQ+gFbU4glgVyK8rxI+ZOe1onEtr/Pg=="
+        "requested": "[2.0.0-beta5.25306.1, )",
+        "resolved": "2.0.0-beta5.25306.1",
+        "contentHash": "ce0wuowuh13Cd7GXqLCq77/YWlxQMxrVCMIO/2/QUP6CdP/JWnlYSN/N3/55wwGsUwa9CvPuT8ddjgyypUr5ag=="
       },
       "System.CommandLine.NamingConventionBinder": {
         "type": "Direct",
-        "requested": "[2.0.0-beta4.22272.1, )",
-        "resolved": "2.0.0-beta4.22272.1",
-        "contentHash": "ux2eUA/syF+JtlpMDc/Lsd6PBIBuwjH3AvHnestoh5uD0WKT5b+wkQxDWVCqp9qgVjMBTLNhX19ZYFtenunt9A==",
+        "requested": "[2.0.0-beta5.25306.1, )",
+        "resolved": "2.0.0-beta5.25306.1",
+        "contentHash": "hEz+l/35lDcDuGg6wpTQNYwAQ6D4Nw5jFzGJu7C2sNFMkKgncGppjyH4jmWrdIuSi3GXOy4Jm+t5UwJAaxJdFQ==",
         "dependencies": {
-          "System.CommandLine": "2.0.0-beta4.22272.1"
+          "System.CommandLine": "2.0.0-beta5.25306.1"
         }
       },
       "System.Security.AccessControl": {

--- a/Hi3Helper.Core/Classes/Logger/Type/LoggerConsole.cs
+++ b/Hi3Helper.Core/Classes/Logger/Type/LoggerConsole.cs
@@ -93,16 +93,23 @@ namespace Hi3Helper
 
         public static void AllocateConsole(bool isConsoleApp = false)
         {
+            var consoleWindow = PInvoke.GetConsoleWindow();
+            
             if (ConsoleHandle != IntPtr.Zero)
             {
-                IntPtr consoleWindow = PInvoke.GetConsoleWindow();
                 PInvoke.ShowWindow(consoleWindow, 5);
                 return;
             }
+            
+            if (consoleWindow != IntPtr.Zero)
+                isConsoleApp = true;
 
-            if (!isConsoleApp && !PInvoke.AllocConsole())
+            if (!isConsoleApp && !PInvoke.AttachConsole(0xFFFFFFFF))
             {
-                throw new ContextMarshalException($"Failed to allocate console with error code: {Win32Error.GetLastWin32ErrorMessage()}");
+                if (!PInvoke.AllocConsole())
+                {
+                    throw new ContextMarshalException($"Failed to attach or allocate console with error code: {Win32Error.GetLastWin32ErrorMessage()}");
+                }
             }
 
             const uint GENERIC_READ = 0x80000000;
@@ -116,12 +123,6 @@ namespace Hi3Helper
 
             Console.OutputEncoding = Encoding.UTF8;
 
-            var instanceIndicator = "";
-            var instanceCount = ProcessChecker.EnumerateInstances(ILoggerHelper.GetILogger());
-
-            if (instanceCount > 1) instanceIndicator = $" - #{instanceCount}";
-            Console.Title = $"Collapse Console{instanceIndicator}";
-
             if (PInvoke.GetConsoleMode(ConsoleHandle, out uint mode))
             {
                 const uint ENABLE_PROCESSED_OUTPUT            = 1;
@@ -133,10 +134,23 @@ namespace Hi3Helper
                     _virtualTerminal = true;
                 }
             }
+            
+            try
+            {
+                var instanceIndicator = "";
+                var instanceCount     = ProcessChecker.EnumerateInstances(ILoggerHelper.GetILogger());
 
-#if !APPLYUPDATE
-            Windowing.SetWindowIcon(PInvoke.GetConsoleWindow(), AppIconLarge, AppIconSmall);
-#endif
+                if (instanceCount > 1) instanceIndicator = $" - #{instanceCount}";
+                Console.Title = $"Collapse Console{instanceIndicator}";
+
+            #if !APPLYUPDATE
+                Windowing.SetWindowIcon(PInvoke.GetConsoleWindow(), AppIconLarge, AppIconSmall);
+            #endif
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ERROR] Failed to set console title or icon: \r\n{ex}");
+            }
         }
 #endregion
     }


### PR DESCRIPTION
# Main Goal
Update System.CommandLine to beta 5

What works:
- `open`, though it doesn't state the error or notice when the argument input is invalid.
  - Cc @gablm  
- `tray`
- `generatevelopackmetadata`

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : Yes
- Bug found caused by PR : 1
  - Suboption doesn't state the error or notice when the argument input is invalid.

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
